### PR TITLE
fix(input): handle Shift+Enter with Chinese IMEs

### DIFF
--- a/Glint/Pane/GhosttySurfaceView.swift
+++ b/Glint/Pane/GhosttySurfaceView.swift
@@ -19,6 +19,7 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
     private var surface: ghostty_surface_t?
     private var trackingArea: NSTrackingArea?
     private var markedTextValue: NSAttributedString = NSAttributedString(string: "")
+    private var keyTextAccumulator: [String]?
     private let initialCwd: String?
     /// Identifier (`"<wsuuid>:<paneSeq>"`) passed into the pty as
     /// `$GLINT_PANE_ID` so CLI-agent hooks can address us back.
@@ -968,6 +969,20 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
             NotificationCenter.default.post(
                 name: .glintPaneReturnPressed, object: nil, userInfo: ["pane": pk])
         }
+
+        if Self.isShiftReturn(event) && !hasMarkedText() {
+            // Let the input method observe the whole Shift+Return chord. Some
+            // Chinese IMEs toggle languages on a "standalone" Shift; if Return
+            // bypasses AppKit's text-input path, the IME can misclassify the
+            // chord and flip Chinese/English mode after inserting the newline.
+            keyTextAccumulator = []
+            interpretKeyEvents([event])
+            keyTextAccumulator = nil
+            let handled = sendKey(event, action: GHOSTTY_ACTION_PRESS, surface: s)
+            if !handled { interpretKeyEvents([event]) }
+            return
+        }
+
         let hasBindingMod = mods.contains(.control) || mods.contains(.command)
             || optionActsAsMeta(mods, surface: s)
         if hasBindingMod || Self.isSpecialKey(event.keyCode) {
@@ -982,6 +997,15 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
             // a white-background "marked text" until the user moves the cursor.
             interpretKeyEvents([event])
         }
+    }
+
+    private static func isShiftReturn(_ event: NSEvent) -> Bool {
+        let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        return (event.keyCode == 36 || event.keyCode == 76)
+            && mods.contains(.shift)
+            && !mods.contains(.command)
+            && !mods.contains(.option)
+            && !mods.contains(.control)
     }
 
     /// Whether an Option-modified press should be routed through ghostty
@@ -1724,6 +1748,10 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
         case let s as String: text = s
         case let s as NSAttributedString: text = s.string
         default: return
+        }
+        if keyTextAccumulator != nil {
+            keyTextAccumulator?.append(text)
+            return
         }
         guard !text.isEmpty, let s = surface else { return }
         text.withCString { ptr in

--- a/Glint/Pane/GhosttySurfaceView.swift
+++ b/Glint/Pane/GhosttySurfaceView.swift
@@ -1766,6 +1766,11 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
         markedTextValue = NSAttributedString(string: "")
     }
 
+    override func doCommand(by selector: Selector) {
+        guard keyTextAccumulator == nil else { return }
+        super.doCommand(by: selector)
+    }
+
     func setMarkedText(_ string: Any, selectedRange: NSRange, replacementRange: NSRange) {
         let text: String
         switch string {

--- a/Glint/Pane/GhosttySurfaceView.swift
+++ b/Glint/Pane/GhosttySurfaceView.swift
@@ -1032,11 +1032,16 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
     }
 
     override func flagsChanged(with event: NSEvent) {
-        // Modifier-only events — forward as a key press w/ empty text so
-        // ghostty stays in sync with mods.
+        // `flagsChanged` is emitted for both modifier press and release.
+        // Sending every edge as PRESS leaves Ghostty with phantom Shift
+        // events; with IMEs that use Shift to toggle languages this can feel
+        // like Shift+Enter fired Shift more than once.
         guard let s = surface else { return }
+        guard !hasMarkedText(),
+              let action = Self.modifierAction(for: event) else { return }
+
         var key = ghostty_input_key_s()
-        key.action = GHOSTTY_ACTION_PRESS
+        key.action = action
         key.mods = currentMods(event.modifierFlags)
         key.consumed_mods = ghostty_input_mods_e(rawValue: 0)
         key.keycode = UInt32(event.keyCode)
@@ -1044,6 +1049,51 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
         key.unshifted_codepoint = 0
         key.composing = false
         _ = ghostty_surface_key(s, key)
+    }
+
+    private static func modifierAction(for event: NSEvent) -> ghostty_input_action_e? {
+        let modifierActive: Bool
+        switch event.keyCode {
+        case 0x39:
+            modifierActive = event.modifierFlags.contains(.capsLock)
+        case 0x38, 0x3C:
+            modifierActive = event.modifierFlags.contains(.shift)
+        case 0x3B, 0x3E:
+            modifierActive = event.modifierFlags.contains(.control)
+        case 0x3A, 0x3D:
+            modifierActive = event.modifierFlags.contains(.option)
+        case 0x37, 0x36:
+            modifierActive = event.modifierFlags.contains(.command)
+        default:
+            return nil
+        }
+
+        guard modifierActive else { return GHOSTTY_ACTION_RELEASE }
+
+        let flags = event.modifierFlags.rawValue
+        let sidePressed: Bool
+        switch event.keyCode {
+        case 0x38:
+            sidePressed = flags & UInt(NX_DEVICELSHIFTKEYMASK) != 0
+        case 0x3C:
+            sidePressed = flags & UInt(NX_DEVICERSHIFTKEYMASK) != 0
+        case 0x3B:
+            sidePressed = flags & UInt(NX_DEVICELCTLKEYMASK) != 0
+        case 0x3E:
+            sidePressed = flags & UInt(NX_DEVICERCTLKEYMASK) != 0
+        case 0x3A:
+            sidePressed = flags & UInt(NX_DEVICELALTKEYMASK) != 0
+        case 0x3D:
+            sidePressed = flags & UInt(NX_DEVICERALTKEYMASK) != 0
+        case 0x37:
+            sidePressed = flags & UInt(NX_DEVICELCMDKEYMASK) != 0
+        case 0x36:
+            sidePressed = flags & UInt(NX_DEVICERCMDKEYMASK) != 0
+        default:
+            sidePressed = true
+        }
+
+        return sidePressed ? GHOSTTY_ACTION_PRESS : GHOSTTY_ACTION_RELEASE
     }
 
     @discardableResult


### PR DESCRIPTION
## Summary

Closes #1.

This fixes `Shift+Enter` with Chinese IMEs that use `Shift` to toggle Chinese/English mode.

- forward real modifier press/release edges from `flagsChanged(with:)` instead of sending every edge as `PRESS`
- let AppKit/IME observe the full plain `Shift+Return` / `Shift+KeypadEnter` chord before forwarding it to Ghostty
- suppress text/command output from that temporary IME observation path so newline is sent once and no AppKit beep is emitted

## Why

`flagsChanged(with:)` is emitted for both modifier press and release. Sending release as `PRESS` can leave Ghostty with a stale Shift state.

Separately, Glint routes Return/Enter as a special key directly to Ghostty. For IMEs that treat standalone Shift as a language toggle, that can make `Shift+Enter` look like a standalone Shift followed by terminal input.

## Validation

```bash
git submodule update --init --recursive
scripts/setup-ghosttykit.sh
xcodebuild -project Glint.xcodeproj -scheme Glint -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/glint-shift-enter-ime-v3 build\n```\n\nResult: `** BUILD SUCCEEDED **`\n\nManual QA passed locally:\n\n- Chinese IME with Shift language toggle enabled\n- `Shift+Enter` inserts one newline\n- no Chinese/English mode toggle\n- no AppKit beep after newline\n- plain `Shift` still toggles the IME normally\n