### PR TITLE
fix(shortcuts): free command k for terminal clear

### DIFF
--- a/Glint/App/GlintApp.swift
+++ b/Glint/App/GlintApp.swift
@@ -104,7 +104,7 @@ struct GlintApp: App {
                 Button("Command Palette") {
                     workspaceStore.commandPaletteOpen.toggle()
                 }
-                .keyboardShortcut("k", modifiers: .command)
+                .keyboardShortcut("p", modifiers: [.command, .shift])
                 Button("Find in Sidebar") {
                     workspaceStore.focusSidebarSearch()
                 }

--- a/Glint/Chrome/CommandPalette.swift
+++ b/Glint/Chrome/CommandPalette.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// Centered modal overlay summoned by ⌘K or the toolbar's ⌘ button.
+/// Centered modal overlay summoned by ⌘⇧P or the toolbar's ⌘ button.
 /// Type to fuzzy-filter; ↑↓ to move selection; ⏎ to execute; ⎋ to close.
 struct CommandPalette: View {
     @EnvironmentObject var store: WorkspaceStore

--- a/Glint/Chrome/ContentView.swift
+++ b/Glint/Chrome/ContentView.swift
@@ -140,7 +140,7 @@ struct ToolbarHeader: View {
             TabBar()
                 .padding(.horizontal, 12)
             HStack(spacing: 4) {
-                ToolbarIconButton(symbol: "command", help: "Command Palette (⌘K)") {
+                ToolbarIconButton(symbol: "command", help: "Command Palette (⌘⇧P)") {
                     store.commandPaletteOpen = true
                 }
                 ToolbarIconButton(symbol: "gearshape", help: "Settings (⌘,)") {

--- a/Glint/Chrome/SettingsView.swift
+++ b/Glint/Chrome/SettingsView.swift
@@ -335,7 +335,7 @@ struct SettingsDivider: View {
     }
 }
 
-/// Compact key-cap pill, e.g. `⌘K`, used in the shortcuts list and footers.
+/// Compact key-cap pill, e.g. `⌘⇧P`, used in the shortcuts list and footers.
 struct KeyCap: View {
     let label: String
     var body: some View {
@@ -1168,7 +1168,7 @@ private struct ShortcutsPane: View {
         SettingsCard("Window") {
             shortcutRow("Toggle Sidebar", keys: ["⌘", "/"])
             SettingsDivider()
-            shortcutRow("Command Palette", keys: ["⌘", "K"])
+            shortcutRow("Command Palette", keys: ["⌘", "⇧", "P"])
             SettingsDivider()
             shortcutRow("Find in Sidebar", keys: ["⌥", "⌘", "F"])
             SettingsDivider()

--- a/Glint/Chrome/SidebarView.swift
+++ b/Glint/Chrome/SidebarView.swift
@@ -261,7 +261,7 @@ struct SidebarView: View {
                 .fill(Color.white.opacity(searchFocused ? 0.08 : 0.04))
         )
         // Make the entire pill hit-testable so clicking anywhere (the
-        // magnifying glass, the empty padding, the trailing ⌘K tag) hands
+        // magnifying glass, the empty padding, the trailing key hint) hands
         // focus to the TextField. Without contentShape SwiftUI only routes
         // hits that land directly on the TextField's text baseline.
         .contentShape(Rectangle())

--- a/Glint/Pane/GhosttySurfaceView.swift
+++ b/Glint/Pane/GhosttySurfaceView.swift
@@ -953,6 +953,15 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
             }
             return
         }
+        // ⌘K is terminal muscle memory for clearing the screen/scrollback.
+        // Keep it out of app-level shortcuts so it always targets the
+        // focused terminal surface.
+        if mods.contains(.command),
+           !mods.contains(.shift), !mods.contains(.option), !mods.contains(.control),
+           event.keyCode == 40 {
+            triggerBindingAction(s, "clear_screen")
+            return
+        }
         // Plain Esc: neither claude nor codex emit any hook when the user
         // interrupts a turn (Stop explicitly skips interrupts), so the
         // sidebar would show "thinking" forever. The wrapper does see the
@@ -1515,11 +1524,9 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
         m.addItem(withTitle: String(localized: "Select All"),
                   action: #selector(menuSelectAll(_:)),
                   keyEquivalent: "a").target = self
-        // No key equivalent: ⌘K is bound to the command palette app-wide,
-        // so advertising it here would lie about what the shortcut does.
         m.addItem(withTitle: String(localized: "Clear"),
                   action: #selector(menuClear(_:)),
-                  keyEquivalent: "").target = self
+                  keyEquivalent: "k").target = self
         return m
     }
 

--- a/Glint/Resources/Localizable.xcstrings
+++ b/Glint/Resources/Localizable.xcstrings
@@ -563,13 +563,13 @@
         }
       }
     },
-    "Command Palette (⌘K)" : {
+    "Command Palette (⌘⇧P)" : {
       "extractionState" : "stale",
       "localizations" : {
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "命令面板 (⌘K)"
+            "value" : "命令面板 (⌘⇧P)"
           }
         }
       }

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -361,7 +361,7 @@ final class WorkspaceStore: ObservableObject {
     @Published var paneAgentState: [WorkspacePaneKey: PaneAgentState] = [:]
 
     /// Drives the command-palette overlay. Toggled by the toolbar's ⌘
-    /// button and the ⌘K global shortcut.
+    /// button and the ⌘⇧P global shortcut.
     @Published var commandPaletteOpen: Bool = false
 
     /// Drives the Settings sheet attached to the main window. We host


### PR DESCRIPTION
## 中文说明

这次改动把 Command Palette 从 `⌘K` 挪到 `⌘⇧P`，让终端里常用的 `⌘K` 可以正常执行 clear screen / clear scrollback。

- 菜单、toolbar tooltip、Settings shortcuts 和 Command Palette 注释统一改成 `⌘⇧P`
- 终端 surface 捕获 `⌘K` 后直接触发 Ghostty `clear_screen`
- 右键菜单里的 `Clear` 重新显示 `⌘K`
- 同步更新本地化字符串，避免 UI hint 继续误导用户

Fixes #7

## English summary

This PR moves the app-level Command Palette shortcut from `⌘K` to `⌘⇧P`, so `⌘K` can be used by the focused terminal surface for clear screen / clear scrollback.

## Validation

- Built locally:
  `xcodebuild -project Glint.xcodeproj -scheme Glint -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/glint-pr-command-k-clear PRODUCT_NAME=GlintPRCommandK PRODUCT_BUNDLE_IDENTIFIER=app.glint.Glint.pr.commandK build`
- Result: `** BUILD SUCCEEDED **`
- Checked: `git diff --check`
- Checked: `Glint/Resources/Localizable.xcstrings` parses as JSON
