### PR TITLE
fix(tabs): compact labels with full path help

### DIFF
--- a/Glint/Chrome/ContentView.swift
+++ b/Glint/Chrome/ContentView.swift
@@ -509,13 +509,16 @@ private struct TabChip: View {
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isButton)
         .accessibilityLabel(Text(verbatim: ws.tabDisplayName(tab)))
-        .onTapGesture {
+        .onTapGesture(count: 2) {
+            if !isEditing { startEditing() }
+        }
+        .onTapGesture(count: 1) {
             // Single-tap selects the tab. During edit the tap is the user
             // clicking into the field — don't steal the focus to selectTab.
             if !isEditing { store.selectTab(tab.id) }
         }
         .onHover { hovering = $0 && !isEditing }
-        .help(ws.tabDisplayName(tab))
+        .help(ws.tabHelpText(tab))
         .contextMenu {
             Button("Rename") { startEditing() }
         }

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -316,13 +316,34 @@ extension Workspace {
         return Self.shortLabel(forCwd: cwd) ?? name
     }
 
-    /// Label for a tab chip: the user's name if set, otherwise a short cwd
-    /// label from the tab's focused pane, otherwise a generic fallback.
+    /// Label for a tab chip: the user's name if set, otherwise the focused
+    /// pane's folder name, otherwise a generic fallback.
     func tabDisplayName(_ tab: WorkspaceTab) -> String {
         if let n = tab.name, !n.isEmpty { return n }
-        let cwd = panes[tab.focusedPane]?.workingDirectory
+        return Self.shortTabLabel(forCwd: tabCwd(tab)) ?? String(localized: "Terminal")
+    }
+
+    /// Tooltip for a tab chip. The visible label stays compact, while hover
+    /// still exposes the full working directory when Glint knows it.
+    func tabHelpText(_ tab: WorkspaceTab) -> String {
+        let display = tabDisplayName(tab)
+        guard let cwd = tabCwd(tab), !cwd.isEmpty, cwd != display else { return display }
+        return "\(display)\n\(cwd)"
+    }
+
+    private func tabCwd(_ tab: WorkspaceTab) -> String? {
+        panes[tab.focusedPane]?.workingDirectory
             ?? tab.root.leaves.compactMap { panes[$0]?.workingDirectory }.first
-        return Self.shortLabel(forCwd: cwd) ?? String(localized: "Terminal")
+    }
+
+    private static func shortTabLabel(forCwd path: String?) -> String? {
+        guard var path, !path.isEmpty else { return nil }
+        while path.count > 1, path.hasSuffix("/") { path.removeLast() }
+        let home = NSHomeDirectory()
+        if path == home { return "~" }
+        if path == "/" { return "/" }
+        let label = URL(fileURLWithPath: path).lastPathComponent
+        return label.isEmpty ? nil : label
     }
 
     private static func shortLabel(forCwd path: String?) -> String? {


### PR DESCRIPTION
## 中文说明

这次改动让 tab 标题更紧凑：未手动命名时只显示当前目录的最后一级，完整路径保留在 hover tooltip 里，减少长路径把 tab bar 挤爆的问题。

- unnamed tab 的 visible label 改为 cwd 的最后一级目录
- home/root 分别显示为 `~` / `/`
- hover tooltip 显示 compact label + full cwd
- 双击 tab chip 可直接 rename，保留右键 Rename 入口

Fixes #9

## English summary

This PR keeps tab chips compact by showing only the focused pane's folder name for unnamed tabs, while preserving the full working directory in the hover help text. It also adds double-click rename on tab chips.

## Validation

- Built locally:
  `xcodebuild -project Glint.xcodeproj -scheme Glint -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/glint-pr-tab-title-ux PRODUCT_NAME=GlintPRTabTitle PRODUCT_BUNDLE_IDENTIFIER=app.glint.Glint.pr.tabTitle build`
- Result: `** BUILD SUCCEEDED **`
- Checked: `git diff --check`
- Manual validation: verified in the combined local integration build `/tmp/glint-upstream-polish-local-test/Build/Products/Debug/GlintUpstreamPolishLocal.app`
