### PR TITLE
fix(ui): apply accent to terminal cursor and selection

### DIFF
--- a/Glint/Chrome/CommandPalette.swift
+++ b/Glint/Chrome/CommandPalette.swift
@@ -157,6 +157,7 @@ struct CommandPalette: View {
 
     private func allItems() -> [PaletteItem] {
         var items: [PaletteItem] = []
+        let actionTint = store.accent
 
         // Workspace jumpers — current workspace first and badged, so an
         // accidental ⏎ on an empty query is a harmless no-op (it just
@@ -181,6 +182,7 @@ struct CommandPalette: View {
             subtitle: "Create a fresh workspace",
             symbol: "plus.square",
             shortcut: "",
+            tint: actionTint,
             action: { store.addWorkspace() }
         ))
 
@@ -189,6 +191,7 @@ struct CommandPalette: View {
             subtitle: "Open a tab in this workspace",
             symbol: "plus.rectangle.on.rectangle",
             shortcut: "⌘T",
+            tint: actionTint,
             action: { store.newTab() }
         ))
         // Naming note: the store's `.horizontal` means an HSplit — panes
@@ -200,6 +203,7 @@ struct CommandPalette: View {
             subtitle: "Open a new pane on the right",
             symbol: "rectangle.split.2x1",
             shortcut: "⌘D",
+            tint: actionTint,
             action: { store.splitFocused(.horizontal) }
         ))
         items.append(.action(
@@ -207,6 +211,7 @@ struct CommandPalette: View {
             subtitle: "Stack a new pane below",
             symbol: "rectangle.split.1x2",
             shortcut: "⌘⇧D",
+            tint: actionTint,
             action: { store.splitFocused(.vertical) }
         ))
         items.append(.action(
@@ -214,6 +219,7 @@ struct CommandPalette: View {
             subtitle: "Close the focused pane",
             symbol: "xmark.square",
             shortcut: "⌘W",
+            tint: actionTint,
             action: { store.closeFocused() }
         ))
         items.append(.action(
@@ -221,6 +227,7 @@ struct CommandPalette: View {
             subtitle: "Cycle pane focus within this workspace",
             symbol: "arrow.triangle.2.circlepath",
             shortcut: "⌘]",
+            tint: actionTint,
             action: { store.focusNext() }
         ))
         items.append(.action(
@@ -228,6 +235,7 @@ struct CommandPalette: View {
             subtitle: "Show or hide the workspace sidebar",
             symbol: "sidebar.left",
             shortcut: "⌘/",
+            tint: actionTint,
             action: { store.sidebarCollapsed.toggle() }
         ))
 
@@ -433,9 +441,10 @@ private struct PaletteItem: Identifiable {
     }
 
     static func action(title: String, subtitle: String, symbol: String,
-                       shortcut: String, action: @escaping () -> Void) -> PaletteItem {
+                       shortcut: String, tint: Color,
+                       action: @escaping () -> Void) -> PaletteItem {
         PaletteItem(title: title, subtitle: subtitle,
-                    icon: .symbol(symbol, Theme.accentBright),
+                    icon: .symbol(symbol, tint),
                     trailing: shortcut.isEmpty ? .kind("ACTION") : .kbd(shortcut),
                     userContent: false,
                     action: action)

--- a/Glint/Chrome/SettingsView.swift
+++ b/Glint/Chrome/SettingsView.swift
@@ -181,21 +181,10 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .about:      return "info.circle"
         }
     }
-    /// Accent for the icon chip when this row is selected. Cycles through
-    /// the system palette so each category reads as its own destination.
-    var tint: Color {
-        switch self {
-        case .general:    return Theme.accentBright
-        case .appearance: return Color(red: 1.0, green: 0.55, blue: 0.55)
-        case .terminal:   return Color(red: 0.40, green: 0.86, blue: 0.55)
-        case .agents:     return Color(red: 0.72, green: 0.68, blue: 1.0)
-        case .shortcuts:  return Color(red: 0.43, green: 0.72, blue: 0.86)
-        case .about:      return Theme.text3
-        }
-    }
 }
 
 private struct SettingsCategoryRow: View {
+    @EnvironmentObject var store: WorkspaceStore
     let category: SettingsCategory
     let isSelected: Bool
     let onSelect: () -> Void
@@ -206,10 +195,10 @@ private struct SettingsCategoryRow: View {
             HStack(spacing: 10) {
                 ZStack {
                     RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .fill(isSelected ? category.tint.opacity(0.22) : Color.white.opacity(0.05))
+                        .fill(isSelected ? store.accent.opacity(0.22) : Color.white.opacity(0.05))
                     Image(systemName: category.icon)
                         .font(.system(size: 12, weight: .medium))
-                        .foregroundStyle(isSelected ? category.tint : Theme.text3)
+                        .foregroundStyle(isSelected ? store.accent : Theme.text3)
                 }
                 .frame(width: 22, height: 22)
 

--- a/Glint/Chrome/SidebarView.swift
+++ b/Glint/Chrome/SidebarView.swift
@@ -201,11 +201,11 @@ struct SidebarView: View {
             HStack(spacing: 10) {
                 Image(systemName: "plus")
                     .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(Theme.accentBright)
+                    .foregroundStyle(store.accent)
                     .frame(width: 28, height: 28)
                     .background(
                         RoundedRectangle(cornerRadius: 7, style: .continuous)
-                            .fill(Theme.accent.opacity(newWorkspaceHovered ? 0.30 : 0.18))
+                            .fill(store.accent.opacity(newWorkspaceHovered ? 0.30 : 0.18))
                     )
                 Text("New Workspace")
                     .font(.system(size: 12.5, weight: .medium))
@@ -789,7 +789,7 @@ private struct WorkspaceCard: View {
                         ? Color(red: 0.32, green: 0.38, blue: 1.0).opacity(0.5)
                         : isOpenCode
                             ? Color(red: 0.95, green: 0.94, blue: 0.90).opacity(0.32)
-                            : Theme.accent.opacity(0.5))
+                            : store.accent.opacity(0.5))
                 : .clear,
             radius: 8
         )
@@ -932,7 +932,7 @@ private struct WorkspaceCard: View {
             // accent tab pill. Idle rows are bare (no fill, no border) so
             // the list reads as rows on one shared surface, not a stack of
             // boxes.
-            if active { return Theme.accent.opacity(0.16) }
+            if active { return store.accent.opacity(0.16) }
             if isHovered { return Color.white.opacity(0.04) }
             return .clear
         }()
@@ -976,7 +976,7 @@ private struct WorkspaceCard: View {
     private func permissionPulseOverlay(status: PaneAgentStatus?) -> some View {
         if status == .needsPermission {
             BreathingBorder(
-                color: NSColor(Theme.accentBright),
+                color: NSColor(store.accent),
                 cornerRadius: 9,
                 lineWidth: 1.4,
                 // Reduce Motion: hold the border at full strength instead
@@ -993,7 +993,7 @@ private struct WorkspaceCard: View {
     private func workingBeaconOverlay(status: PaneAgentStatus?) -> some View {
         if let status, isWorking(status) {
             EdgeBeacon(
-                color: NSColor(Theme.accentBright),
+                color: NSColor(store.accent),
                 fast: status == .compacting,
                 animates: !reduceMotion
             )

--- a/Glint/Ghostty/GhosttyManager.swift
+++ b/Glint/Ghostty/GhosttyManager.swift
@@ -110,6 +110,7 @@ final class GhosttyManager {
         }()
         let cursorStyle = defaults.string(forKey: "glint.terminalCursorStyle") ?? "block"
         let cursorBlink = (defaults.object(forKey: "glint.terminalCursorBlink") as? Bool) ?? true
+        let accentHex = Self.accentHex(defaults.string(forKey: "glint.accentName"))
         let scrollback: Int = {
             let v = defaults.integer(forKey: "glint.terminalScrollback")
             return v == 0 ? 10_000 : v
@@ -123,10 +124,10 @@ final class GhosttyManager {
         let overrides = """
         background = 0B0A14
         foreground = ECEDF2
-        cursor-color = 5E5CE6
+        cursor-color = \(accentHex)
         cursor-style = \(cursorStyle)
         cursor-style-blink = \(cursorBlink)
-        selection-background = 5E5CE6
+        selection-background = \(accentHex)
         selection-foreground = ECEDF2
         font-family = \(family)
         font-family = Menlo
@@ -143,6 +144,16 @@ final class GhosttyManager {
             source.withCString { src in
                 ghostty_config_load_string(cfg, ovr, UInt(strlen(ovr)), src)
             }
+        }
+    }
+
+    private static func accentHex(_ name: String?) -> String {
+        switch name {
+        case "cyan":   return "64D2FF"
+        case "pink":   return "FF6482"
+        case "orange": return "FF9F0A"
+        case "green":  return "30D158"
+        default:       return "8C8CFF"
         }
     }
 

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -468,12 +468,15 @@ final class WorkspaceStore: ObservableObject {
         didSet { UserDefaults.standard.set(glassEffect, forKey: "glint.glassEffect") }
     }
 
-    /// UI accent color. Drives focus/selection highlights across the chrome
-    /// (command palette selection bar, workspace switcher checkmark, Install
-    /// buttons in Settings). Values: "indigo" | "cyan" | "pink" | "orange"
-    /// | "green". Default "indigo". Persists across launches.
+    /// UI accent color. Drives focus/selection highlights across the chrome,
+    /// plus the terminal cursor and selection highlight. Values: "indigo" |
+    /// "cyan" | "pink" | "orange" | "green". Default "indigo". Persists
+    /// across launches.
     @Published var accentName: String = UserDefaults.standard.string(forKey: "glint.accentName") ?? "indigo" {
-        didSet { UserDefaults.standard.set(accentName, forKey: "glint.accentName") }
+        didSet {
+            UserDefaults.standard.set(accentName, forKey: "glint.accentName")
+            GhosttyManager.shared.reloadConfig()
+        }
     }
 
     var accent: Color {


### PR DESCRIPTION
## 中文说明

这次改动让 Settings 里的 accent color 真正影响终端里的 cursor 和 selection，而不只是右侧 chrome/按钮高亮。

- 统一使用当前 accent 驱动 Command Palette、Sidebar、Settings 等 chrome highlight
- Ghostty config 生成时同步写入 cursor color 和 selection color
- 切换 accent 后立即 reload Ghostty config，让现有 terminal surface 生效
- 移除 Settings 内重复的 accent color 映射，避免两套颜色漂移

Fixes #6

## English summary

This PR applies the selected accent color to the embedded terminal cursor and selection highlight, and reloads Ghostty config when the accent setting changes.

## Validation

- Built locally:
  `xcodebuild -project Glint.xcodeproj -scheme Glint -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/glint-pr-accent-terminal-cursor PRODUCT_NAME=GlintPRAccent PRODUCT_BUNDLE_IDENTIFIER=app.glint.Glint.pr.accent build`
- Result: `** BUILD SUCCEEDED **`
- Checked: `git diff --check`
- Manual validation: verified in the combined local integration build `/tmp/glint-upstream-polish-local-test/Build/Products/Debug/GlintUpstreamPolishLocal.app`
