### PR TITLE
feat(settings): inherit Ghostty terminal appearance

### DIFF
--- a/Glint/App/AppDelegate.swift
+++ b/Glint/App/AppDelegate.swift
@@ -97,6 +97,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         window.titlebarSeparatorStyle = .none
         // Sidebar inset to nothing — we draw chrome ourselves
         window.toolbar = nil
+        GhosttyManager.shared.applyWindowEffects()
 
         // Intercept the close button so closing the (only) window — which
         // terminates the app — gets the same "work is still running"

--- a/Glint/Chrome/ContentView.swift
+++ b/Glint/Chrome/ContentView.swift
@@ -9,19 +9,19 @@ struct ContentView: View {
     /// On macOS 26+ the islands use real Liquid Glass; pre-26 they use the
     /// in-house `GlassCapsuleFallback`. Glass off → stacked band layout.
     private var floatingHeader: Bool { store.glassEffect }
+    private var terminalBacking: Color {
+        store.terminalUseGhosttyConfig ? .clear : Theme.bgPane
+    }
 
     var body: some View {
         HStack(spacing: 0) {
             if !store.sidebarCollapsed {
-                // Exactly the pane area's color: ghostty paints an opaque
-                // `background = 0B0A14` (= Theme.bgPane), so a flat fill
-                // makes the two surfaces read as one, split only by the
-                // hairline. (A Tahoe floating glass sidebar was tried and
-                // rejected: with nothing but flat near-black behind it,
-                // glass has nothing to refract and reads as a gray slab.)
+                // Match the pane backing. When Ghostty config owns terminal
+                // transparency this stays clear so background-opacity can show
+                // the desktop/window blur behind the surface.
                 SidebarView()
                     .frame(width: 244)
-                    .background(Theme.bgPane)
+                    .background(terminalBacking)
                     .overlay(alignment: .trailing) {
                         Rectangle().fill(Color.white.opacity(0.045)).frame(width: 1)
                     }
@@ -39,9 +39,9 @@ struct ContentView: View {
                     // islands by the padded shell launcher (see
                     // GhosttyManager.paddedShellLauncherPath), not by
                     // insetting the layout.
-                    .background(Theme.bgPane)
+                    .background(terminalBacking)
             }
-            .background(Theme.bgPane)
+            .background(terminalBacking)
             // Floating mode: the terminal owns the full height and the
             // toolbar's glass islands ride on top of it. The strip itself
             // is an invisible window-drag handle (see ToolbarHeader).
@@ -52,7 +52,7 @@ struct ContentView: View {
             }
         }
         .ignoresSafeArea()
-        .background(Theme.bgWindow)
+        .background(store.terminalUseGhosttyConfig ? Color.clear : Theme.bgWindow)
         .animation(.easeOut(duration: 0.18), value: store.sidebarCollapsed)
         .overlay {
             if store.commandPaletteOpen {

--- a/Glint/Chrome/ContentView.swift
+++ b/Glint/Chrome/ContentView.swift
@@ -9,19 +9,15 @@ struct ContentView: View {
     /// On macOS 26+ the islands use real Liquid Glass; pre-26 they use the
     /// in-house `GlassCapsuleFallback`. Glass off → stacked band layout.
     private var floatingHeader: Bool { store.glassEffect }
-    private var terminalBacking: Color {
-        store.terminalUseGhosttyConfig ? .clear : Theme.bgPane
-    }
 
     var body: some View {
         HStack(spacing: 0) {
             if !store.sidebarCollapsed {
-                // Match the pane backing. When Ghostty config owns terminal
-                // transparency this stays clear so background-opacity can show
-                // the desktop/window blur behind the surface.
+                // Sidebar is Glint chrome, but its base fill should follow
+                // the terminal background when Ghostty owns appearance.
                 SidebarView()
                     .frame(width: 244)
-                    .background(terminalBacking)
+                    .background(store.terminalChromeBacking)
                     .overlay(alignment: .trailing) {
                         Rectangle().fill(Color.white.opacity(0.045)).frame(width: 1)
                     }
@@ -39,9 +35,9 @@ struct ContentView: View {
                     // islands by the padded shell launcher (see
                     // GhosttyManager.paddedShellLauncherPath), not by
                     // insetting the layout.
-                    .background(terminalBacking)
+                    .background(store.terminalPaneBacking)
             }
-            .background(terminalBacking)
+            .background(store.terminalPaneBacking)
             // Floating mode: the terminal owns the full height and the
             // toolbar's glass islands ride on top of it. The strip itself
             // is an invisible window-drag handle (see ToolbarHeader).
@@ -52,7 +48,7 @@ struct ContentView: View {
             }
         }
         .ignoresSafeArea()
-        .background(store.terminalUseGhosttyConfig ? Color.clear : Theme.bgWindow)
+        .background(store.terminalWindowBacking)
         .animation(.easeOut(duration: 0.18), value: store.sidebarCollapsed)
         .overlay {
             if store.commandPaletteOpen {

--- a/Glint/Chrome/SettingsView.swift
+++ b/Glint/Chrome/SettingsView.swift
@@ -463,8 +463,25 @@ private struct UpdatesCard: View {
 private struct AppearancePane: View {
     @EnvironmentObject var store: WorkspaceStore
 
+    private var terminalThemeSource: Binding<String> {
+        Binding(get: {
+            store.terminalUseGhosttyConfig ? "ghostty" : "glint"
+        }, set: { value in
+            store.terminalUseGhosttyConfig = (value == "ghostty")
+        })
+    }
+
+    private var ghosttyTransparency: Binding<Bool> {
+        Binding(get: {
+            store.terminalUseGhosttyConfig && store.terminalUseGhosttyTransparency
+        }, set: { value in
+            store.terminalUseGhosttyTransparency = value
+        })
+    }
+
     var body: some View {
-        SettingsCard("Theme") {
+        SettingsCard("Theme",
+                     footer: "Terminal theme source controls whether Glint uses its built-in terminal styling or Ghostty's resolved colors, font, cursor, and scrollback. Transparency stays opt-in.") {
             SettingsRow("Color scheme",
                         subtitle: "Glint is dark-mode only for now.") {
                 StatusPill(label: "Dark", tone: .neutral)
@@ -489,6 +506,34 @@ private struct AppearancePane: View {
                             .onTapGesture { store.accentName = opt.rawValue }
                     }
                 }
+            }
+            SettingsDivider()
+            SettingsRow("Terminal theme source",
+                        subtitle: store.terminalUseGhosttyConfig
+                        ? "Terminal colors, font, cursor, and scrollback come from Ghostty."
+                        : "Use Glint's built-in terminal theme controls.") {
+                GlintDropdown(selection: terminalThemeSource, items: [
+                    (value: "glint", label: "Glint"),
+                    (value: "ghostty", label: "Ghostty config"),
+                ], listWidth: 170)
+            }
+            SettingsDivider()
+            SettingsRow("Use Ghostty transparency",
+                        subtitle: store.terminalUseGhosttyConfig
+                        ? "Apply background-opacity and background-blur while keeping Glint chrome on the same Ghostty background."
+                        : "Requires Ghostty config as the terminal theme source.") {
+                Toggle("", isOn: ghosttyTransparency)
+                    .toggleStyle(.switch).labelsHidden()
+                    .disabled(!store.terminalUseGhosttyConfig)
+            }
+            SettingsDivider()
+            SettingsRow("Reload Ghostty config",
+                        subtitle: "Re-read Ghostty config files from disk after editing them.") {
+                Button("Reload") {
+                    store.reloadTerminalConfig()
+                }
+                    .controlSize(.small)
+                    .tint(store.accent)
             }
         }
 
@@ -550,26 +595,6 @@ private struct TerminalPane: View {
     private let scrollbackChoices: [Int] = [1_000, 5_000, 10_000, 50_000, 100_000]
 
     var body: some View {
-        SettingsCard("Ghostty config",
-                     footer: "When enabled, Glint uses your Ghostty config for terminal colors, font, cursor, scrollback, transparency, and blur. Glint still keeps layout settings required by its floating chrome.") {
-            SettingsRow("Use Ghostty config",
-                        subtitle: store.terminalUseGhosttyConfig
-                        ? "Terminal appearance is loaded from Ghostty's config files."
-                        : "Use Glint's terminal appearance controls below.") {
-                Toggle("", isOn: $store.terminalUseGhosttyConfig)
-                    .toggleStyle(.switch).labelsHidden()
-            }
-            SettingsDivider()
-            SettingsRow("Reload Ghostty config",
-                        subtitle: "Re-read Ghostty config files from disk after editing them.") {
-                Button("Reload") {
-                    store.reloadTerminalConfig()
-                }
-                    .controlSize(.small)
-                    .tint(store.accent)
-            }
-        }
-
         SettingsCard("Font") {
             SettingsRow("Family", subtitle: "Used for all panes. Falls back to Menlo if missing.") {
                 GlintDropdown(selection: $store.terminalFontFamily,

--- a/Glint/Chrome/SettingsView.swift
+++ b/Glint/Chrome/SettingsView.swift
@@ -550,6 +550,26 @@ private struct TerminalPane: View {
     private let scrollbackChoices: [Int] = [1_000, 5_000, 10_000, 50_000, 100_000]
 
     var body: some View {
+        SettingsCard("Ghostty config",
+                     footer: "When enabled, Glint uses your Ghostty config for terminal colors, font, cursor, scrollback, transparency, and blur. Glint still keeps layout settings required by its floating chrome.") {
+            SettingsRow("Use Ghostty config",
+                        subtitle: store.terminalUseGhosttyConfig
+                        ? "Terminal appearance is loaded from Ghostty's config files."
+                        : "Use Glint's terminal appearance controls below.") {
+                Toggle("", isOn: $store.terminalUseGhosttyConfig)
+                    .toggleStyle(.switch).labelsHidden()
+            }
+            SettingsDivider()
+            SettingsRow("Reload Ghostty config",
+                        subtitle: "Re-read Ghostty config files from disk after editing them.") {
+                Button("Reload") {
+                    store.reloadTerminalConfig()
+                }
+                    .controlSize(.small)
+                    .tint(store.accent)
+            }
+        }
+
         SettingsCard("Font") {
             SettingsRow("Family", subtitle: "Used for all panes. Falls back to Menlo if missing.") {
                 GlintDropdown(selection: $store.terminalFontFamily,
@@ -568,6 +588,8 @@ private struct TerminalPane: View {
                 }
             }
         }
+        .disabled(store.terminalUseGhosttyConfig)
+        .opacity(store.terminalUseGhosttyConfig ? 0.55 : 1)
 
         SettingsCard("Cursor") {
             SettingsRow("Style", subtitle: nil) {
@@ -583,6 +605,8 @@ private struct TerminalPane: View {
                     .toggleStyle(.switch).labelsHidden()
             }
         }
+        .disabled(store.terminalUseGhosttyConfig)
+        .opacity(store.terminalUseGhosttyConfig ? 0.55 : 1)
 
         SettingsCard("Buffer", footer: "Scrollback is kept per-pane. Increasing this raises memory usage.") {
             SettingsRow("Scrollback", subtitle: "Lines retained per pane.") {
@@ -591,6 +615,8 @@ private struct TerminalPane: View {
                               listWidth: 150)
             }
         }
+        .disabled(store.terminalUseGhosttyConfig)
+        .opacity(store.terminalUseGhosttyConfig ? 0.55 : 1)
 
         SettingsCard("Paste") {
             SettingsRow("Warn before pasting multi-line text",

--- a/Glint/Ghostty/GhosttyManager.swift
+++ b/Glint/Ghostty/GhosttyManager.swift
@@ -83,6 +83,15 @@ final class GhosttyManager {
         ghostty_app_set_color_scheme(app, scheme)
     }
 
+    func applyWindowEffects() {
+        guard let app else { return }
+        guard usesGhosttyAppearanceConfig else { return }
+        guard currentBackgroundOpacity < 1 else { return }
+        for window in NSApp.windows {
+            ghostty_set_window_background_blur(app, Unmanaged.passUnretained(window).toOpaque())
+        }
+    }
+
     private func tickSoon() {
         DispatchQueue.main.async { [weak self] in
             guard let app = self?.app else { return }
@@ -98,9 +107,8 @@ final class GhosttyManager {
     // MARK: clipboard / close stubs
 
     /// Inline overrides so ghostty's surface matches our chrome. User-tweakable
-    /// fields (font family/size, cursor style/blink, scrollback) are read out
-    /// of `UserDefaults` so we don't need a Combine subscription on the store
-    /// inside this lower layer.
+    /// fields are read out of `UserDefaults` so we don't need a Combine
+    /// subscription on the store inside this lower layer.
     private func applyGlintTheme(_ cfg: ghostty_config_t) {
         let defaults = UserDefaults.standard
         let family = defaults.string(forKey: "glint.terminalFontFamily") ?? "SF Mono"
@@ -116,29 +124,39 @@ final class GhosttyManager {
             return v == 0 ? 10_000 : v
         }()
 
+        var lines: [String] = []
+        if !usesGhosttyAppearanceConfig {
+            lines.append(contentsOf: [
+                "background = 0B0A14",
+                "foreground = ECEDF2",
+                "cursor-color = \(accentHex)",
+                "cursor-style = \(cursorStyle)",
+                "cursor-style-blink = \(cursorBlink)",
+                "selection-background = \(accentHex)",
+                "selection-foreground = ECEDF2",
+                "font-family = \(family)",
+                "font-family = Menlo",
+                "font-size = \(size)",
+                "scrollback-limit = \(scrollback)",
+            ])
+        }
+
+        // Keep embedding/layout settings under Glint's control. They prevent
+        // the floating chrome and embedded macOS shell from fighting the
+        // user's Ghostty appearance config.
         // Note: the per-surface `viewport-top-offset` reserves an inset above
         // the grid that the renderer paints scrollback rows up into (instead
         // of the dead-padding behavior of `window-padding-y`). It's set in
         // GhosttySurfaceView.createSurface, not here, because only the
         // top-aligned pane needs the inset; split children don't.
-        let overrides = """
-        background = 0B0A14
-        foreground = ECEDF2
-        cursor-color = \(accentHex)
-        cursor-style = \(cursorStyle)
-        cursor-style-blink = \(cursorBlink)
-        selection-background = \(accentHex)
-        selection-foreground = ECEDF2
-        font-family = \(family)
-        font-family = Menlo
-        font-size = \(size)
-        scrollback-limit = \(scrollback)
-        window-padding-x = 14
-        window-padding-y = 12
-        window-padding-balance = true
-        adjust-cell-height = 10%
-        macos-titlebar-style = hidden
-        """
+        lines.append(contentsOf: [
+            "window-padding-x = 14",
+            "window-padding-y = 12",
+            "window-padding-balance = true",
+            "adjust-cell-height = 10%",
+            "macos-titlebar-style = hidden",
+        ])
+        let overrides = lines.joined(separator: "\n")
         let source = "glint-inline"
         overrides.withCString { ovr in
             source.withCString { src in
@@ -195,6 +213,21 @@ final class GhosttyManager {
         // extra config objects accumulated over a session are bounded by how
         // often a user changes settings (~tens of bytes per knob).
         self.config = newCfg
+        DispatchQueue.main.async { [weak self] in
+            self?.applyWindowEffects()
+        }
+    }
+
+    var usesGhosttyAppearanceConfig: Bool {
+        (UserDefaults.standard.object(forKey: "glint.terminalUseGhosttyConfig") as? Bool) ?? false
+    }
+
+    var currentBackgroundOpacity: Double {
+        guard usesGhosttyAppearanceConfig, let config else { return 1 }
+        var value: Double = 1
+        let key = "background-opacity"
+        _ = key.withCString { ghostty_config_get(config, &value, $0, UInt(strlen($0))) }
+        return min(max(value, 0), 1)
     }
 
     private static let writeClipboard: ghostty_runtime_write_clipboard_cb = { _, _, contentPtr, count, _ in

--- a/Glint/Ghostty/GhosttyManager.swift
+++ b/Glint/Ghostty/GhosttyManager.swift
@@ -13,6 +13,7 @@ import GhosttyKit
 ///   keyDown dispatch.
 final class GhosttyManager {
     static let shared = GhosttyManager()
+    static let glintPaneBackground = NSColor(red: 0.043, green: 0.039, blue: 0.078, alpha: 1.0)
 
     private(set) var app: ghostty_app_t?
     private var config: ghostty_config_t?
@@ -85,7 +86,7 @@ final class GhosttyManager {
 
     func applyWindowEffects() {
         guard let app else { return }
-        guard usesGhosttyAppearanceConfig else { return }
+        guard usesGhosttyTransparency else { return }
         guard currentBackgroundOpacity < 1 else { return }
         for window in NSApp.windows {
             ghostty_set_window_background_blur(app, Unmanaged.passUnretained(window).toOpaque())
@@ -138,6 +139,11 @@ final class GhosttyManager {
                 "font-family = Menlo",
                 "font-size = \(size)",
                 "scrollback-limit = \(scrollback)",
+            ])
+        } else if !usesGhosttyTransparency {
+            lines.append(contentsOf: [
+                "background-opacity = 1",
+                "background-blur = false",
             ])
         }
 
@@ -222,25 +228,56 @@ final class GhosttyManager {
         (UserDefaults.standard.object(forKey: "glint.terminalUseGhosttyConfig") as? Bool) ?? false
     }
 
+    var usesGhosttyTransparency: Bool {
+        guard usesGhosttyAppearanceConfig else { return false }
+        return (UserDefaults.standard.object(forKey: "glint.terminalUseGhosttyTransparency") as? Bool) ?? false
+    }
+
     var currentBackgroundOpacity: Double {
-        guard usesGhosttyAppearanceConfig, let config else { return 1 }
+        guard usesGhosttyTransparency, let config else { return 1 }
         var value: Double = 1
         let key = "background-opacity"
         _ = key.withCString { ghostty_config_get(config, &value, $0, UInt(strlen($0))) }
         return min(max(value, 0), 1)
     }
 
-    private static let writeClipboard: ghostty_runtime_write_clipboard_cb = { _, _, contentPtr, count, _ in
-        guard let contentPtr, count > 0 else { return }
-        let content = contentPtr.pointee
-        guard let cstr = content.data else { return }
-        // Honor `count`, not a NUL terminator: ghostty hands us a byte buffer
-        // + length (not guaranteed NUL-terminated). String(cString:) would
-        // truncate at an embedded NUL, and a reused buffer could leak a prior
-        // clipboard's tail. Mirrors the OPEN_URL handler below.
-        let s = cstr.withMemoryRebound(to: UInt8.self, capacity: Int(count)) { bytes in
-            String(decoding: UnsafeBufferPointer(start: bytes, count: Int(count)), as: UTF8.self)
+    var currentBackgroundColor: NSColor {
+        guard usesGhosttyAppearanceConfig, let config else {
+            return Self.glintPaneBackground
         }
+
+        var value = ghostty_config_color_s(r: 0, g: 0, b: 0)
+        let key = "background"
+        let ok = key.withCString { ghostty_config_get(config, &value, $0, UInt(strlen($0))) }
+        guard ok else { return Self.glintPaneBackground }
+        return NSColor(
+            srgbRed: CGFloat(value.r) / 255.0,
+            green: CGFloat(value.g) / 255.0,
+            blue: CGFloat(value.b) / 255.0,
+            alpha: 1.0
+        )
+    }
+
+    private static let writeClipboard: ghostty_runtime_write_clipboard_cb = { _, _, contentPtr, contentCount, _ in
+        guard let contentPtr, contentCount > 0 else { return }
+
+        // `contentCount` is the number of clipboard content entries, not the
+        // byte length of `data`. Prefer text/plain and fall back to the first
+        // usable string payload, matching Ghostty's own macOS app semantics.
+        var fallback: String?
+        var plainText: String?
+        for i in 0..<Int(contentCount) {
+            let item = contentPtr[i]
+            guard let mimePtr = item.mime,
+                  let dataPtr = item.data else { continue }
+            let data = String(cString: dataPtr)
+            if fallback == nil { fallback = data }
+            if String(cString: mimePtr) == "text/plain" {
+                plainText = data
+                break
+            }
+        }
+        guard let s = plainText ?? fallback else { return }
         DispatchQueue.main.async {
             NSPasteboard.general.clearContents()
             NSPasteboard.general.setString(s, forType: .string)

--- a/Glint/Pane/GhosttySurfaceView.swift
+++ b/Glint/Pane/GhosttySurfaceView.swift
@@ -81,7 +81,7 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
     override var acceptsFirstResponder: Bool { true }
     override var canBecomeKeyView: Bool { true }
     override var isFlipped: Bool { false }
-    override var isOpaque: Bool { false }
+    override var isOpaque: Bool { !GhosttyManager.shared.usesGhosttyAppearanceConfig }
     override var wantsUpdateLayer: Bool { true }
     /// NSView's default in borderless windows is YES — that lets the terminal
     /// area drag the whole window. Force NO so clicks here only go to ghostty.
@@ -110,12 +110,9 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
         self.initialInput = initialInput
         super.init(frame: frame)
         wantsLayer = true
-        layer?.isOpaque = false
         // Placeholder until ghostty installs its IOSurfaceLayer — matches the
         // terminal background so new panes don't flash white pre-first-frame.
-        layer?.backgroundColor = GhosttyManager.shared.usesGhosttyAppearanceConfig
-            ? NSColor.clear.cgColor
-            : NSColor(red: 0.043, green: 0.039, blue: 0.078, alpha: 1.0).cgColor
+        refreshAppearanceBacking()
         // Accept file drops from Finder; on drop we paste the shell-quoted
         // path so users can `cd <drop>` without typing it.
         registerForDraggedTypes([.fileURL])
@@ -138,6 +135,14 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
     /// build with `GLINT_LOG_VISIBLE=1` to see attach / forced-redraw events.
     private let logVisible = ProcessInfo.processInfo.environment["GLINT_LOG_VISIBLE"] != nil
     var debugKey: String { paneKey ?? "?" }
+
+    func refreshAppearanceBacking() {
+        let usesGhosttyAppearanceConfig = GhosttyManager.shared.usesGhosttyAppearanceConfig
+        layer?.isOpaque = !usesGhosttyAppearanceConfig
+        layer?.backgroundColor = usesGhosttyAppearanceConfig
+            ? NSColor.clear.cgColor
+            : NSColor(red: 0.043, green: 0.039, blue: 0.078, alpha: 1.0).cgColor
+    }
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
@@ -340,7 +345,7 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
             return
         }
         self.surface = s
-        layer?.isOpaque = false
+        refreshAppearanceBacking()
         removeSurfaceCreationError()
 
         // Terminal history restore: echo last session's saved colored

--- a/Glint/Pane/GhosttySurfaceView.swift
+++ b/Glint/Pane/GhosttySurfaceView.swift
@@ -81,6 +81,7 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
     override var acceptsFirstResponder: Bool { true }
     override var canBecomeKeyView: Bool { true }
     override var isFlipped: Bool { false }
+    override var isOpaque: Bool { false }
     override var wantsUpdateLayer: Bool { true }
     /// NSView's default in borderless windows is YES — that lets the terminal
     /// area drag the whole window. Force NO so clicks here only go to ghostty.
@@ -109,9 +110,12 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
         self.initialInput = initialInput
         super.init(frame: frame)
         wantsLayer = true
+        layer?.isOpaque = false
         // Placeholder until ghostty installs its IOSurfaceLayer — matches the
         // terminal background so new panes don't flash white pre-first-frame.
-        layer?.backgroundColor = NSColor(red: 0.043, green: 0.039, blue: 0.078, alpha: 1.0).cgColor
+        layer?.backgroundColor = GhosttyManager.shared.usesGhosttyAppearanceConfig
+            ? NSColor.clear.cgColor
+            : NSColor(red: 0.043, green: 0.039, blue: 0.078, alpha: 1.0).cgColor
         // Accept file drops from Finder; on drop we paste the shell-quoted
         // path so users can `cd <drop>` without typing it.
         registerForDraggedTypes([.fileURL])
@@ -336,6 +340,7 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
             return
         }
         self.surface = s
+        layer?.isOpaque = false
         removeSurfaceCreationError()
 
         // Terminal history restore: echo last session's saved colored

--- a/Glint/Pane/GhosttySurfaceView.swift
+++ b/Glint/Pane/GhosttySurfaceView.swift
@@ -81,7 +81,7 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
     override var acceptsFirstResponder: Bool { true }
     override var canBecomeKeyView: Bool { true }
     override var isFlipped: Bool { false }
-    override var isOpaque: Bool { !GhosttyManager.shared.usesGhosttyAppearanceConfig }
+    override var isOpaque: Bool { !GhosttyManager.shared.usesGhosttyTransparency }
     override var wantsUpdateLayer: Bool { true }
     /// NSView's default in borderless windows is YES — that lets the terminal
     /// area drag the whole window. Force NO so clicks here only go to ghostty.
@@ -137,11 +137,11 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
     var debugKey: String { paneKey ?? "?" }
 
     func refreshAppearanceBacking() {
-        let usesGhosttyAppearanceConfig = GhosttyManager.shared.usesGhosttyAppearanceConfig
-        layer?.isOpaque = !usesGhosttyAppearanceConfig
-        layer?.backgroundColor = usesGhosttyAppearanceConfig
+        let usesGhosttyTransparency = GhosttyManager.shared.usesGhosttyTransparency
+        layer?.isOpaque = !usesGhosttyTransparency
+        layer?.backgroundColor = usesGhosttyTransparency
             ? NSColor.clear.cgColor
-            : NSColor(red: 0.043, green: 0.039, blue: 0.078, alpha: 1.0).cgColor
+            : GhosttyManager.shared.currentBackgroundColor.cgColor
     }
 
     override func viewDidMoveToWindow() {

--- a/Glint/Pane/PaneSurfaceRepresentable.swift
+++ b/Glint/Pane/PaneSurfaceRepresentable.swift
@@ -6,6 +6,7 @@ import AppKit
 /// the surface itself outlives that and just re-parents.
 struct PaneSurfaceRepresentable: NSViewRepresentable {
     let surfaceView: GhosttySurfaceView
+    let usesGhosttyConfig: Bool
     /// Plain value, not a Binding: focus only flows store → AppKit here.
     /// The reverse direction (clicks) goes through store.focus(_:), so a
     /// writable binding would just be a lie about the data flow.
@@ -14,13 +15,15 @@ struct PaneSurfaceRepresentable: NSViewRepresentable {
     func makeNSView(context: Context) -> NoDragContainerView {
         let container = NoDragContainerView()
         container.wantsLayer = true
-        container.layer?.isOpaque = false
-        container.layer?.backgroundColor = NSColor.clear.cgColor
+        Self.updateContainerBacking(container, usesGhosttyConfig: usesGhosttyConfig)
+        surfaceView.refreshAppearanceBacking()
         attach(surfaceView, to: container)
         return container
     }
 
     func updateNSView(_ nsView: NoDragContainerView, context: Context) {
+        Self.updateContainerBacking(nsView, usesGhosttyConfig: usesGhosttyConfig)
+        surfaceView.refreshAppearanceBacking()
         if surfaceView.superview !== nsView {
             attach(surfaceView, to: nsView)
         }
@@ -66,7 +69,6 @@ struct PaneSurfaceRepresentable: NSViewRepresentable {
         /// the pair (container, surface) is what's being verified).
         weak var expectedSurface: GhosttySurfaceView?
 
-        override var isOpaque: Bool { false }
         override var mouseDownCanMoveWindow: Bool { false }
 
         override func setFrameOrigin(_ newOrigin: NSPoint) {
@@ -109,6 +111,13 @@ struct PaneSurfaceRepresentable: NSViewRepresentable {
                   container.expectedSurface === surface else { return }
             Self.pin(surface, in: container)
         }
+    }
+
+    private static func updateContainerBacking(_ container: NoDragContainerView, usesGhosttyConfig: Bool) {
+        container.layer?.isOpaque = !usesGhosttyConfig
+        container.layer?.backgroundColor = usesGhosttyConfig
+            ? NSColor.clear.cgColor
+            : NSColor(red: 0.043, green: 0.039, blue: 0.078, alpha: 1.0).cgColor
     }
 
     private static func pin(_ surface: GhosttySurfaceView, in container: NSView) {

--- a/Glint/Pane/PaneSurfaceRepresentable.swift
+++ b/Glint/Pane/PaneSurfaceRepresentable.swift
@@ -6,7 +6,7 @@ import AppKit
 /// the surface itself outlives that and just re-parents.
 struct PaneSurfaceRepresentable: NSViewRepresentable {
     let surfaceView: GhosttySurfaceView
-    let usesGhosttyConfig: Bool
+    let usesTransparentBacking: Bool
     /// Plain value, not a Binding: focus only flows store → AppKit here.
     /// The reverse direction (clicks) goes through store.focus(_:), so a
     /// writable binding would just be a lie about the data flow.
@@ -15,14 +15,14 @@ struct PaneSurfaceRepresentable: NSViewRepresentable {
     func makeNSView(context: Context) -> NoDragContainerView {
         let container = NoDragContainerView()
         container.wantsLayer = true
-        Self.updateContainerBacking(container, usesGhosttyConfig: usesGhosttyConfig)
+        Self.updateContainerBacking(container, usesTransparentBacking: usesTransparentBacking)
         surfaceView.refreshAppearanceBacking()
         attach(surfaceView, to: container)
         return container
     }
 
     func updateNSView(_ nsView: NoDragContainerView, context: Context) {
-        Self.updateContainerBacking(nsView, usesGhosttyConfig: usesGhosttyConfig)
+        Self.updateContainerBacking(nsView, usesTransparentBacking: usesTransparentBacking)
         surfaceView.refreshAppearanceBacking()
         if surfaceView.superview !== nsView {
             attach(surfaceView, to: nsView)
@@ -113,11 +113,11 @@ struct PaneSurfaceRepresentable: NSViewRepresentable {
         }
     }
 
-    private static func updateContainerBacking(_ container: NoDragContainerView, usesGhosttyConfig: Bool) {
-        container.layer?.isOpaque = !usesGhosttyConfig
-        container.layer?.backgroundColor = usesGhosttyConfig
+    private static func updateContainerBacking(_ container: NoDragContainerView, usesTransparentBacking: Bool) {
+        container.layer?.isOpaque = !usesTransparentBacking
+        container.layer?.backgroundColor = usesTransparentBacking
             ? NSColor.clear.cgColor
-            : NSColor(red: 0.043, green: 0.039, blue: 0.078, alpha: 1.0).cgColor
+            : GhosttyManager.shared.currentBackgroundColor.cgColor
     }
 
     private static func pin(_ surface: GhosttySurfaceView, in container: NSView) {

--- a/Glint/Pane/PaneSurfaceRepresentable.swift
+++ b/Glint/Pane/PaneSurfaceRepresentable.swift
@@ -14,6 +14,8 @@ struct PaneSurfaceRepresentable: NSViewRepresentable {
     func makeNSView(context: Context) -> NoDragContainerView {
         let container = NoDragContainerView()
         container.wantsLayer = true
+        container.layer?.isOpaque = false
+        container.layer?.backgroundColor = NSColor.clear.cgColor
         attach(surfaceView, to: container)
         return container
     }
@@ -64,6 +66,7 @@ struct PaneSurfaceRepresentable: NSViewRepresentable {
         /// the pair (container, surface) is what's being verified).
         weak var expectedSurface: GhosttySurfaceView?
 
+        override var isOpaque: Bool { false }
         override var mouseDownCanMoveWindow: Bool { false }
 
         override func setFrameOrigin(_ newOrigin: NSPoint) {

--- a/Glint/Pane/PaneView.swift
+++ b/Glint/Pane/PaneView.swift
@@ -7,6 +7,9 @@ struct PaneView: View {
     /// (stale evaluation of the outgoing tree during a workspace switch).
     let workspaceID: UUID?
     let paneID: PaneID
+    private var terminalBacking: Color {
+        store.terminalUseGhosttyConfig ? .clear : Theme.bgPane
+    }
 
     var body: some View {
         // Resolve a surface only for a (workspace, pane) pair that exists in
@@ -21,7 +24,7 @@ struct PaneView: View {
                      focusedPane: ws.selectedTab?.focusedPane ?? paneID,
                      cwd: pane.workingDirectory)
         } else {
-            Theme.bgPane
+            terminalBacking
         }
     }
 
@@ -33,13 +36,13 @@ struct PaneView: View {
         }
         let isFocused = focusedPane == paneID
         return ZStack {
-            Theme.bgPane
+            terminalBacking
             PaneSurfaceRepresentable(
                 surfaceView: store.surfaceView(workspaceID: workspaceID, paneID: paneID, cwd: cwd),
                 focused: isFocused
             )
             if !isFocused {
-                Theme.bgPane.opacity(0.45)
+                Color.black.opacity(store.terminalUseGhosttyConfig ? 0.18 : 0.45)
                     .allowsHitTesting(false)
             }
         }

--- a/Glint/Pane/PaneView.swift
+++ b/Glint/Pane/PaneView.swift
@@ -7,8 +7,11 @@ struct PaneView: View {
     /// (stale evaluation of the outgoing tree during a workspace switch).
     let workspaceID: UUID?
     let paneID: PaneID
+    private var terminalUsesTransparency: Bool {
+        store.terminalUseGhosttyConfig && store.terminalUseGhosttyTransparency
+    }
     private var terminalBacking: Color {
-        store.terminalUseGhosttyConfig ? .clear : Theme.bgPane
+        store.terminalPaneBacking
     }
 
     var body: some View {
@@ -39,11 +42,11 @@ struct PaneView: View {
             terminalBacking
             PaneSurfaceRepresentable(
                 surfaceView: store.surfaceView(workspaceID: workspaceID, paneID: paneID, cwd: cwd),
-                usesGhosttyConfig: store.terminalUseGhosttyConfig,
+                usesTransparentBacking: terminalUsesTransparency,
                 focused: isFocused
             )
             if !isFocused {
-                (store.terminalUseGhosttyConfig ? Color.black.opacity(0.18) : Theme.bgPane.opacity(0.45))
+                (terminalUsesTransparency ? Color.black.opacity(0.18) : Theme.bgPane.opacity(0.45))
                     .allowsHitTesting(false)
             }
         }

--- a/Glint/Pane/PaneView.swift
+++ b/Glint/Pane/PaneView.swift
@@ -39,10 +39,11 @@ struct PaneView: View {
             terminalBacking
             PaneSurfaceRepresentable(
                 surfaceView: store.surfaceView(workspaceID: workspaceID, paneID: paneID, cwd: cwd),
+                usesGhosttyConfig: store.terminalUseGhosttyConfig,
                 focused: isFocused
             )
             if !isFocused {
-                Color.black.opacity(store.terminalUseGhosttyConfig ? 0.18 : 0.45)
+                (store.terminalUseGhosttyConfig ? Color.black.opacity(0.18) : Theme.bgPane.opacity(0.45))
                     .allowsHitTesting(false)
             }
         }

--- a/Glint/Resources/Localizable.xcstrings
+++ b/Glint/Resources/Localizable.xcstrings
@@ -2574,13 +2574,13 @@
         }
       }
     },
-    "When enabled, Glint uses your Ghostty config for terminal colors, font, cursor, scrollback, transparency, and blur. Glint still keeps layout settings required by its floating chrome." : {
+    "When enabled, Glint uses your Ghostty config for terminal colors, font, cursor, and scrollback. Transparency stays off unless enabled separately, so Glint chrome remains stable." : {
       "extractionState" : "manual",
       "localizations" : {
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "开启后，Glint 会使用你的 Ghostty 配置来设置终端颜色、字体、光标、滚动记录、透明度和模糊。Glint 仍会保留浮动窗口栏所需的布局设置。"
+            "value" : "开启后，Glint 会使用你的 Ghostty 配置来设置终端颜色、字体、光标和滚动记录。透明度需要单独开启，所以 Glint 窗口栏保持稳定。"
           }
         }
       }
@@ -2614,6 +2614,105 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用下方的 Glint 终端外观控制项。"
+          }
+        }
+      }
+    },
+    "Terminal theme source controls whether Glint uses its built-in terminal styling or Ghostty's resolved colors, font, cursor, and scrollback. Transparency stays opt-in." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "终端主题来源决定 Glint 使用内置终端样式，还是使用 Ghostty 解析后的颜色、字体、光标和滚动记录。透明度保持单独开启。"
+          }
+        }
+      }
+    },
+    "Terminal theme source" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "终端主题来源"
+          }
+        }
+      }
+    },
+    "Terminal colors, font, cursor, and scrollback come from Ghostty." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "终端颜色、字体、光标和滚动记录来自 Ghostty。"
+          }
+        }
+      }
+    },
+    "Use Glint's built-in terminal theme controls." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用 Glint 内置终端主题控制项。"
+          }
+        }
+      }
+    },
+    "Use Ghostty transparency" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用 Ghostty 透明度"
+          }
+        }
+      }
+    },
+    "Honor background-opacity and background-blur for the terminal pane only." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "只在终端面板里遵循 background-opacity 和 background-blur。"
+          }
+        }
+      }
+    },
+    "Apply background-opacity and background-blur while keeping Glint chrome on the same Ghostty background." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "应用 background-opacity 和 background-blur，同时让 Glint 窗口栏保持同一个 Ghostty 背景。"
+          }
+        }
+      }
+    },
+    "Requires Use Ghostty config." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要先开启使用 Ghostty 配置。"
+          }
+        }
+      }
+    },
+    "Requires Ghostty config as the terminal theme source." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要先把终端主题来源设为 Ghostty 配置。"
           }
         }
       }

--- a/Glint/Resources/Localizable.xcstrings
+++ b/Glint/Resources/Localizable.xcstrings
@@ -2563,6 +2563,94 @@
         }
       }
     },
+    "Ghostty config" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ghostty 配置"
+          }
+        }
+      }
+    },
+    "When enabled, Glint uses your Ghostty config for terminal colors, font, cursor, scrollback, transparency, and blur. Glint still keeps layout settings required by its floating chrome." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "开启后，Glint 会使用你的 Ghostty 配置来设置终端颜色、字体、光标、滚动记录、透明度和模糊。Glint 仍会保留浮动窗口栏所需的布局设置。"
+          }
+        }
+      }
+    },
+    "Use Ghostty config" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用 Ghostty 配置"
+          }
+        }
+      }
+    },
+    "Terminal appearance is loaded from Ghostty's config files." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "终端外观已从 Ghostty 配置文件加载。"
+          }
+        }
+      }
+    },
+    "Use Glint's terminal appearance controls below." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用下方的 Glint 终端外观控制项。"
+          }
+        }
+      }
+    },
+    "Reload Ghostty config" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新加载 Ghostty 配置"
+          }
+        }
+      }
+    },
+    "Re-read Ghostty config files from disk after editing them." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "编辑后从磁盘重新读取 Ghostty 配置文件。"
+          }
+        }
+      }
+    },
+    "Reload" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新加载"
+          }
+        }
+      }
+    },
     "WORKSPACES" : {
       "localizations" : {
         "zh-Hans" : {

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -421,6 +421,12 @@ final class WorkspaceStore: ObservableObject {
             GhosttyManager.shared.reloadConfig()
         }
     }
+    @Published var terminalUseGhosttyTransparency: Bool = (UserDefaults.standard.object(forKey: "glint.terminalUseGhosttyTransparency") as? Bool) ?? false {
+        didSet {
+            UserDefaults.standard.set(terminalUseGhosttyTransparency, forKey: "glint.terminalUseGhosttyTransparency")
+            GhosttyManager.shared.reloadConfig()
+        }
+    }
     @Published var terminalFontFamily: String = UserDefaults.standard.string(forKey: "glint.terminalFontFamily") ?? "SF Mono" {
         didSet {
             UserDefaults.standard.set(terminalFontFamily, forKey: "glint.terminalFontFamily")
@@ -507,9 +513,23 @@ final class WorkspaceStore: ObservableObject {
     }
 
     var accent: Color { Theme.accent(named: accentName) }
+    var terminalChromeBacking: Color {
+        let color = Color(nsColor: GhosttyManager.shared.currentBackgroundColor)
+        guard terminalUseGhosttyConfig && terminalUseGhosttyTransparency else {
+            return color
+        }
+        return color.opacity(GhosttyManager.shared.currentBackgroundOpacity)
+    }
+    var terminalPaneBacking: Color {
+        terminalUseGhosttyConfig && terminalUseGhosttyTransparency ? .clear : terminalChromeBacking
+    }
+    var terminalWindowBacking: Color {
+        terminalUseGhosttyConfig && terminalUseGhosttyTransparency ? .clear : terminalChromeBacking
+    }
 
     func reloadTerminalConfig() {
         GhosttyManager.shared.reloadConfig()
+        objectWillChange.send()
     }
 
     /// Dock icon the user picked. `.default` keeps the bundle's `.icon`

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -415,6 +415,12 @@ final class WorkspaceStore: ObservableObject {
     /// Terminal appearance settings. Each is persisted to UserDefaults and
     /// fed into ghostty via `GhosttyManager.reloadConfig()` whenever it
     /// changes. The `didSet` hooks both persist and trigger live reload.
+    @Published var terminalUseGhosttyConfig: Bool = (UserDefaults.standard.object(forKey: "glint.terminalUseGhosttyConfig") as? Bool) ?? false {
+        didSet {
+            UserDefaults.standard.set(terminalUseGhosttyConfig, forKey: "glint.terminalUseGhosttyConfig")
+            GhosttyManager.shared.reloadConfig()
+        }
+    }
     @Published var terminalFontFamily: String = UserDefaults.standard.string(forKey: "glint.terminalFontFamily") ?? "SF Mono" {
         didSet {
             UserDefaults.standard.set(terminalFontFamily, forKey: "glint.terminalFontFamily")
@@ -490,9 +496,9 @@ final class WorkspaceStore: ObservableObject {
     }
 
     /// UI accent color. Drives focus/selection highlights across the chrome,
-    /// plus the terminal cursor and selection highlight. Values: "indigo" |
-    /// "cyan" | "pink" | "orange" | "green". Default "indigo". Persists
-    /// across launches.
+    /// plus the terminal cursor and selection highlight when Glint owns the
+    /// terminal appearance. Values: "indigo" | "cyan" | "pink" | "orange" |
+    /// "green". Default "indigo". Persists across launches.
     @Published var accentName: String = UserDefaults.standard.string(forKey: "glint.accentName") ?? "indigo" {
         didSet {
             UserDefaults.standard.set(accentName, forKey: "glint.accentName")
@@ -501,6 +507,10 @@ final class WorkspaceStore: ObservableObject {
     }
 
     var accent: Color { Theme.accent(named: accentName) }
+
+    func reloadTerminalConfig() {
+        GhosttyManager.shared.reloadConfig()
+    }
 
     /// Dock icon the user picked. `.default` keeps the bundle's `.icon`
     /// asset (Liquid Glass on macOS 26); every other case overrides the


### PR DESCRIPTION
Closes #17

## Summary

- add an opt-in `Appearance > Theme > Terminal theme source` control with `Glint` and `Ghostty config` choices
- inherit Ghostty terminal colors, background, font, cursor, and scrollback only when `Ghostty config` is selected
- keep Ghostty transparency as a separate opt-in switch so the default and non-transparent paths stay opaque/stable
- align Glint chrome/sidebar backing with Ghostty's resolved `background` so the terminal pane and sidebar do not visually split
- fix the Ghostty clipboard callback so copied text is not truncated when Ghostty provides multiple clipboard content entries

## Final behavior

- Default: Glint keeps its current built-in terminal appearance and opaque rendering path.
- `Terminal theme source = Ghostty config`, `Use Ghostty transparency = off`: Glint uses Ghostty's resolved font/colors/background/cursor/scrollback, but forces `background-opacity = 1` and `background-blur = false`; sidebar/chrome use the same Ghostty background color.
- `Terminal theme source = Ghostty config`, `Use Ghostty transparency = on`: Ghostty owns `background-opacity` / `background-blur`; Glint pane/window backing clears where needed and chrome uses the same Ghostty background + opacity.
- Glint still owns embedded layout overrides required by the floating chrome, including padding/titlebar behavior.

## Verification

- `git diff --check`
- `python3 -m json.tool Glint/Resources/Localizable.xcstrings`
- `xcodebuild -project Glint.xcodeproj -scheme Glint -configuration Debug -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`
- local dogfood validation: transparency now matches the intended Ghostty behavior, sidebar and terminal backgrounds are visually unified, and copy/paste copies full text again

## Notes

This keeps the upstream constraint that existing/default behavior should not change, while still allowing Ghostty users to reuse their terminal appearance config when they explicitly opt in.
