### PR TITLE
fix(ghostty): honor byte length when writing clipboard

### DIFF
--- a/Glint/Ghostty/GhosttyManager.swift
+++ b/Glint/Ghostty/GhosttyManager.swift
@@ -201,7 +201,13 @@ final class GhosttyManager {
         guard let contentPtr, count > 0 else { return }
         let content = contentPtr.pointee
         guard let cstr = content.data else { return }
-        let s = String(cString: cstr)
+        // Honor `count`, not a NUL terminator: ghostty hands us a byte buffer
+        // + length (not guaranteed NUL-terminated). String(cString:) would
+        // truncate at an embedded NUL, and a reused buffer could leak a prior
+        // clipboard's tail. Mirrors the OPEN_URL handler below.
+        let s = cstr.withMemoryRebound(to: UInt8.self, capacity: Int(count)) { bytes in
+            String(decoding: UnsafeBufferPointer(start: bytes, count: Int(count)), as: UTF8.self)
+        }
         DispatchQueue.main.async {
             NSPasteboard.general.clearContents()
             NSPasteboard.general.setString(s, forType: .string)


### PR DESCRIPTION
## 问题
`GhosttyManager.writeClipboard`（`Glint/Ghostty/GhosttyManager.swift`）原本用 `String(cString:)` 解码剪贴板——遇到第一个 NUL 字节就停，完全忽略 ghostty 传入的 `count`（字节长度）。后果：
- 粘贴内容里若含 NUL，会在 NUL 处被**静默截断**；
- 若 ghostty 复用缓冲且未重新补 NUL 终止符，**上一次剪贴板的尾巴**可能泄露进粘贴板。

同文件的 `OPEN_URL` 处理器已用正确写法（按 `count` 解码），这两处不一致。

## 修复前如何重现
日常复制粘贴基本遇不到（普通文本不含 NUL），属防御性正确性修复。要触发得通过 OSC 52 把含 `0x00` 字节的内容写进剪贴板：

```bash
# 在 Glint 终端里跑：用 OSC 52 把 "before" + NUL + "after" 写进剪贴板
python3 -c "import base64;p=base64.b64encode(b'before'+bytes([0])+b'after').decode();print(chr(27)+']52;c;'+p+chr(7),end='')"
# 修复前：剪贴板被截断成 "before"（用 pbpaste 看长度即可验证）
```

（能否触发还取决于 ghostty 的 OSC 52 写入策略。）

## 修复
改用 `String(decoding: UnsafeBufferPointer(start:count:), as: UTF8.self)` 按 `count` 解码，与 `OPEN_URL` 处理器一致。

## 验证
Debug / arm64 编译通过；4 个修复聚合后 `BUILD SUCCEEDED`。

## 潜在影响
极小。仅当剪贴板内容含 NUL 时行为变化（之前截断、现在保留完整），是期望方向。唯一不确定性是 ghostty `count` 是否含末尾 NUL——与 `OPEN_URL` 的 `len` 同源（不含）；即便含了，多出的一个 NUL 进粘贴板对 GUI 粘贴也基本无害。对不含 NUL 的普通文本零变化。