### PR TITLE
fix(pane): use UTF-8 length when injecting control-channel text

### DIFF
--- a/Glint/Pane/GhosttySurfaceView.swift
+++ b/Glint/Pane/GhosttySurfaceView.swift
@@ -1604,8 +1604,13 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
     /// thread only (ghostty surface APIs are not thread-safe).
     func injectText(_ text: String) {
         guard let s = surface, !text.isEmpty else { return }
+        // UTF-8 length, not strlen: a control-socket payload can carry an
+        // embedded NUL (a literal NUL byte), and strlen would truncate the paste at
+        // it. withCString's buffer is exactly utf8.count bytes + a NUL, so
+        // passing utf8.count never overreads. Mirrors injectKey's char branch.
+        let n = text.utf8.count
         text.withCString { ptr in
-            ghostty_surface_text(s, ptr, UInt(strlen(ptr)))
+            ghostty_surface_text(s, ptr, UInt(n))
         }
     }
 


### PR DESCRIPTION
## 问题
`GhosttySurfaceView.injectText`（v0.1.22 新增的外部控制桥注入路径）把 `strlen(ptr)` 传给 `ghostty_surface_text`。外部控制通道发来的 text 可能含 NUL 字节，`strlen` 遇 NUL 即停，注入内容被**静默截断**。

## 修复前如何重现
需先在「设置 → 终端 → External control」开启外部控制（默认关）：

```bash
# 先列出 pane，拿到某个 pane key（形如 <uuid>:<seq>）
echo '{"cmd":"list"}' | /usr/bin/nc -U ~/.glint/run/control.sock

# 向该 pane 注入含 NUL 的文本（用 chr(0) 构造，避免 shell 转义）
python3 -c "import json,sys;P='粘贴上面拿到的pane key';T=open('$HOME/.glint/run/control.token').read().strip();m=json.dumps({'cmd':'send-text','pane':P,'text':'before'+chr(0)+'after','enter':False,'token':T});sys.stdout.write(m+chr(10))" | /usr/bin/nc -U ~/.glint/run/control.sock
# 修复前：终端只收到 "before"；修复后：完整的 "before" + NUL + "after"
```

## 修复
改用 `text.utf8.count`。`withCString` 的缓冲正好是该字节数 + 一个 NUL，不会越界读。与同文件 `injectKey` 的 char 分支一致。

## 验证
Debug / arm64 编译通过。

## 潜在影响
低。对不含 NUL 的 text 行为完全不变（`utf8.count` 与 `strlen` 在无 NUL 时相等）；只在 text 含 NUL 时从"截断"变为"完整注入"（期望方向）。这是 opt-in 的外部控制功能，影响面仅限开启它的用户。前提是 `ghostty_surface_text` 按 len 读取——它是 ghostty 的 paste 通道，符合预期。