### PR TITLE
fix(persistence): tolerate a single bad pane; never overwrite an unmovable file

### DIFF
--- a/Glint/Workspace/Persistence.swift
+++ b/Glint/Workspace/Persistence.swift
@@ -49,29 +49,57 @@ enum Persistence {
         SupportDir.url?.appendingPathComponent(fileName, isDirectory: false)
     }
 
+    /// Path of a corrupt state.json that we could NOT move aside (disk full,
+    /// permissions). save() refuses to write over it so the only copy of the
+    /// user's data is never clobbered. Session-scoped: cleared on next launch.
+    private static var corruptUnmovablePath: String?
+
     /// Returns nil both for "no saved state" (fresh install) and "state was
     /// unreadable" — but the two paths differ in side effects: an unreadable
     /// file is moved aside (never deleted or overwritten) so a decode bug or
-    /// half-written file can't silently destroy the user's workspaces. The
-    /// caller falls back to `PersistedState.fresh` and the very next autosave
-    /// would otherwise clobber the original.
+    /// half-written file can't silently destroy the user's workspaces. Before
+    /// quarantining we try to surgically strip a single bad pane entry so it
+    /// costs only that pane, not every workspace.
     static func load() -> PersistedState? {
         guard let url = fileURL else { return nil }
         guard let data = try? Data(contentsOf: url) else { return nil }
         do {
             return try JSONDecoder().decode(PersistedState.self, from: data)
         } catch {
+            // A single undecodable pane entry would otherwise quarantine the
+            // whole file and lose every workspace. PaneID isn't a String/Int
+            // key, so [PaneID: Pane] serializes as a flat alternating
+            // [key, value, ...] array; stripBadPanes drops just the bad pair.
+            if let repaired = Self.stripBadPanes(from: data),
+               let state = try? JSONDecoder().decode(PersistedState.self, from: repaired) {
+                NSLog("[glint] decoded \(fileName) after stripping undecodable pane(s); persisting the repaired copy")
+                try? repaired.write(to: url, options: [.atomic])
+                return state
+            }
+
             let stamp = Int(Date().timeIntervalSince1970)
             let backup = url.deletingLastPathComponent()
                 .appendingPathComponent("\(fileName).corrupt-\(stamp)")
-            try? FileManager.default.moveItem(at: url, to: backup)
-            NSLog("[glint] failed to decode \(fileName): \(error); moved it aside to \(backup.lastPathComponent) and starting fresh")
+            do {
+                try FileManager.default.moveItem(at: url, to: backup)
+                NSLog("[glint] failed to decode \(fileName): \(error); moved it aside to \(backup.lastPathComponent) and starting fresh")
+            } catch {
+                // Couldn't move it aside either — remember the path so save()
+                // won't overwrite the only copy. The original stays put for
+                // the user to recover manually; we start fresh in memory.
+                corruptUnmovablePath = url.path
+                NSLog("[glint] \(fileName) couldn't be moved aside to \(backup.lastPathComponent); refusing to overwrite — original kept at \(url.path), starting fresh")
+            }
             return nil
         }
     }
 
     static func save(_ state: PersistedState) {
         guard let url = fileURL else { return }
+        if corruptUnmovablePath == url.path {
+            NSLog("[glint] skipping save: \(fileName) is the corrupt file we couldn't move aside; not overwriting the user's data")
+            return
+        }
         let enc = JSONEncoder()
         enc.outputFormatting = [.prettyPrinted, .sortedKeys]
         do {
@@ -82,5 +110,38 @@ enum Persistence {
             // at least leave a trail in the console.
             NSLog("[glint] failed to save \(fileName): \(error)")
         }
+    }
+
+    /// Walk each workspace's `panes` — `[PaneID: Pane]` serializes as a flat
+    /// alternating [key, value, key, value, ...] array because PaneID isn't a
+    /// String/Int key — and drop any pair whose value half won't decode as a
+    /// `Pane`. Returns re-serialized JSON if a bad pane was removed, nil if
+    /// nothing changed or the structure is unrecognizable (so the caller only
+    /// retries when there's something to retry with). Lets one bad pane cost
+    /// only that pane instead of the whole file.
+    private static func stripBadPanes(from data: Data) -> Data? {
+        guard var root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+              var workspaces = root["workspaces"] as? [[String: Any]] else { return nil }
+        let pdecoder = JSONDecoder()
+        var changed = false
+        for i in workspaces.indices {
+            guard let panes = workspaces[i]["panes"] as? [Any] else { continue }
+            var kept: [Any] = []
+            var j = 0
+            while j + 1 < panes.count {
+                let value = panes[j + 1]
+                let blob = (try? JSONSerialization.data(withJSONObject: value)) ?? Data()
+                if (try? pdecoder.decode(Pane.self, from: blob)) != nil {
+                    kept.append(panes[j]); kept.append(value)
+                } else {
+                    changed = true
+                }
+                j += 2
+            }
+            if kept.count != panes.count { workspaces[i]["panes"] = kept }
+        }
+        guard changed else { return nil }
+        root["workspaces"] = workspaces
+        return try? JSONSerialization.data(withJSONObject: root)
     }
 }


### PR DESCRIPTION
## 问题
`state.json` 加载有两条丢数据路径：

1. **单个坏 pane 拖垮全部**：`[PaneID: Pane]` 用抛错的 Dictionary 解码，一个 pane 条目损坏 → 整个 `Workspace` 解码失败 → 经 `PersistedState` 把文件判 corrupt 移走，**所有工作区**丢失。
2. **corrupt 文件移不走时被覆盖**：若把损坏文件 move 到 `.corrupt-<时间戳>` 本身失败（磁盘满 / 权限），`try?` 吞掉错误，`load()` 返回 nil，下次自动保存就**覆盖了唯一的那份原始数据**——违背注释里"绝不覆盖"的承诺。

## 修复前如何重现（问题 1）

```bash
# 1. 正常用 Glint：建几个工作区、各开 pane，退出（确保 state.json 已保存）
# 2. 备份后，把某个 pane 的 value 弄坏（删掉 id 字段，使其无法解码为 Pane）
cp "$HOME/Library/Application Support/Glint/state.json" /tmp/state.bak.json
python3 - <<'PY'
import json, os
p = os.path.expanduser('~/Library/Application Support/Glint/state.json')
d = json.load(open(p))
panes = d['workspaces'][0]['panes']   # 扁平 [key,value,key,value,...]
panes[3] = {"broken": True}           # 把第 2 个 pane value 改坏
json.dump(d, open(p, 'w'))
PY
# 3. 重启 Glint
#    修复前：state.json 被改名为 .corrupt-<时间戳>，全部工作区消失（回到初始状态）
#    修复后：仅那个 pane 被剔除，其余工作区 / pane 全部保留
```

问题 2（move 失败）属磁盘满 / 权限的边缘场景，较难日常复现；修复让 `save()` 在该 session 内跳过覆盖，原始文件原地保留。

## 修复
1. 放弃前先逐对清洗 panes 数组（`PaneID` 非 String/Int 键，dict 序列化为扁平 `[key,value,...]` 交替数组），剔除 value 无法解码的对再重试。逐对解码也避开了 Foundation「unkeyed decode 失败时 currentIndex 不前进」会死循环的坑。
2. 记住移不走的 corrupt 文件路径，`save()` 本 session 内拒绝覆盖。

## 验证
Debug / arm64 编译通过。strip 算法骨架另用 Python 在合成数据上验证（3 对、中间坏 → 剩 2 对；奇数落单 key 不崩）。

## 潜在影响
- **正常使用零影响**：`stripBadPanes` 只在 decode 失败后才跑，健康文件不经过它。
- **剔除 pane 后的悬空引用**：若被剔除的 pane 仍被某 tab 的 split tree（`SplitNode.leaf`）引用，会出现指向不存在 pane 的悬空 leaf——`WorkspaceStore.surfaceView` 会为该 key 补造空 surface 容错；最坏情况是那个 tab 出现一个空 pane。相比"丢掉全部工作区"，这是可接受的降级。
- **state.json 格式抖动**：清洗后写回用的是 `JSONSerialization` 默认格式（非 pretty/sorted），下次自动保存又恢复 pretty。一次性格式变化，JSON 解析不依赖格式，无害。
- **corrupt 文件移不走时本 session 不保存**：有意的——宁可丢本次 session 的改动，也不覆盖用户唯一一份原始数据。代价是用户该 session 的新建/改动不持久化（仅 NSLog 记录），需手动从原文件恢复。