### PR TITLE
fix(pane): don't flip agent state on Esc/Return consumed by an IME

### DIFF
--- a/Glint/Pane/GhosttySurfaceView.swift
+++ b/Glint/Pane/GhosttySurfaceView.swift
@@ -971,14 +971,20 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
         // pane's agent state back to idle. If the agent wasn't actually
         // interrupted, its next hook event restores the busy status. The
         // event still flows through to ghostty below.
+        // Skip while an IME composition is active: plain Esc / Return then
+        // cancel or confirm the candidate, not the agent — posting would
+        // optimistically flip agent state for a key the agent never received.
+        // Same guard the ⌘K and Shift+Return paths already use.
         if event.keyCode == 53,
            mods.intersection([.command, .option, .control, .shift]).isEmpty,
+           !hasMarkedText(),
            let pk = paneKey {
             NotificationCenter.default.post(
                 name: .glintPaneEscPressed, object: nil, userInfo: ["pane": pk])
         }
         if (event.keyCode == 36 || event.keyCode == 76),
            mods.intersection([.command, .option, .control, .shift]).isEmpty,
+           !hasMarkedText(),
            let pk = paneKey {
             NotificationCenter.default.post(
                 name: .glintPaneReturnPressed, object: nil, userInfo: ["pane": pk])


### PR DESCRIPTION
## 问题
`GhosttySurfaceView` 的 `.glintPaneEscPressed` / `.glintPaneReturnPressed` 乐观通知，在**每一次**普通 Esc / Return 时就发出，且早于 marked-text（IME 组合）检查。后果：用中日韩输入法时——
- Esc 本是**取消候选词**，却把 pane 的 agent 状态翻成了 idle；
- Return 本是**确认候选词**，却清掉了 pane 的「需权限」提示。

这两个键根本没送达 agent。同方法里的 ⌘K（clear）和 Shift+Return 已有 `!hasMarkedText()` 守卫，这两处漏了。

## 修复前如何重现
1. 在 Glint 里跑一个 agent（claude / codex），让它进入「思考中」或「需权限」状态（pane 有对应指示）。
2. 切到中文输入法（如拼音），敲几个字让候选词浮出（IME 组合态，有 marked text）。
3. 不要提交候选词，直接按 Esc：
   - 修复前：pane 的 agent 状态被翻成 idle（Esc 只该取消候选词）。
   - 修复后：候选词被取消，agent 状态不变。
   （Return 同理：组合态按 Return 确认候选词，修复前会误触发 `.glintPaneReturnPressed`。）

## 修复
给两个通知的发送条件加 `!hasMarkedText()`，与 ⌘K / Shift+Return 一致。

## 验证
Debug / arm64 编译通过。

## 潜在影响
低，仅影响 IME 组合态。非输入法用户 `hasMarkedText()` 恒为 false，行为零变化；输入法用户组合候选词时按 Esc/Return，agent 状态保持不变（之前会被误翻），正是期望方向。前提是 `hasMarkedText()`（标准 `NSTextInputClient`）可靠——它在同方法的 ⌘K、Shift+Return 路径已稳定使用。