### PR TITLE
feat(agent): badge dock for background attention

### DIFF
--- a/Glint/Chrome/SettingsView.swift
+++ b/Glint/Chrome/SettingsView.swift
@@ -805,7 +805,13 @@ private struct AgentsPane: View {
         }
 
         SettingsCard("Notifications",
-                     footer: "Chimes only fire for background workspaces — the one you're looking at stays quiet.") {
+                     footer: "Dock badges and chimes only update for background workspaces — the one you're looking at stays quiet.") {
+            SettingsRow("Show Dock badge for agent attention",
+                        subtitle: "Count background panes that need approval, just finished, or failed.") {
+                Toggle("", isOn: $store.dockBadgeOnAgentAttention)
+                    .toggleStyle(.switch).labelsHidden()
+            }
+            SettingsDivider()
             SettingsRow("Sound on permission request",
                         subtitle: "Play a chime when an agent is waiting for your approval in a background workspace.") {
                 HStack(spacing: 10) {

--- a/Glint/Resources/Localizable.xcstrings
+++ b/Glint/Resources/Localizable.xcstrings
@@ -453,6 +453,28 @@
         }
       }
     },
+    "Count background panes that need approval, just finished, or failed." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "统计需要批准、刚完成或失败的后台面板。"
+          }
+        }
+      }
+    },
+    "Dock badges and chimes only update for background workspaces — the one you're looking at stays quiet." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dock 角标和提示音只在后台工作区更新,你正在查看的工作区保持安静。"
+          }
+        }
+      }
+    },
     "Claude Code" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -2017,6 +2039,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "上下文溢出时,在工作区卡片上显示压缩状态。"
+          }
+        }
+      }
+    },
+    "Show Dock badge for agent attention" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agent 需要关注时显示 Dock 角标"
           }
         }
       }

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -611,6 +611,17 @@ final class WorkspaceStore: ObservableObject {
         didSet { UserDefaults.standard.set(soundOnError, forKey: "glint.soundOnError") }
     }
 
+    /// Show a Dock badge count for background agent states that need a look.
+    /// Unlike notification banners this stays quiet and carries no prompt or
+    /// transcript text. Defaults to on because it is non-interruptive.
+    @Published var dockBadgeOnAgentAttention: Bool = (UserDefaults.standard.object(forKey: "glint.dockBadgeOnAgentAttention") as? Bool) ?? true {
+        didSet {
+            UserDefaults.standard.set(dockBadgeOnAgentAttention, forKey: "glint.dockBadgeOnAgentAttention")
+            if !dockBadgeOnAgentAttention { dockBadgePaneStatuses.removeAll() }
+            updateDockBadge()
+        }
+    }
+
     /// NSSound names for the three audio cues, persisted; the defaults are
     /// the original hardcoded chimes.
     @Published var soundPermissionName: String = UserDefaults.standard.string(forKey: "glint.soundPermissionName") ?? "Funk" {
@@ -804,6 +815,7 @@ final class WorkspaceStore: ObservableObject {
     /// Persistent NSView per global pane identity. Surfaces are keyed by
     /// (workspaceID, paneID) so switching workspaces doesn't destroy them.
     private var surfaceViews: [WorkspacePaneKey: GhosttySurfaceView] = [:]
+    private var dockBadgePaneStatuses: [WorkspacePaneKey: PaneAgentStatus] = [:]
 
     private var saveCancellable: AnyCancellable?
     private var cwdTimer: Timer?
@@ -885,6 +897,7 @@ final class WorkspaceStore: ObservableObject {
         ) { [weak self] _ in
             MainActor.assumeIsolated {
                 guard let self else { return }
+                self.clearDockBadge()
                 self.captureCwdsFromLiveSurfaces()
                 self.flushScrollback()
                 self.persist()
@@ -928,6 +941,7 @@ final class WorkspaceStore: ObservableObject {
         self.codexHooksInstalled = CodexHookInstaller.isInstalled()
         self.opencodeHooksInstalled = OpenCodeHookInstaller.isInstalled()
         self.shellKeybindsInstalled = ShellKeybindInstaller.isInstalled()
+        updateDockBadge()
         observerTokens.append(NotificationCenter.default.addObserver(
             forName: .glintAgentEvent,
             object: nil,
@@ -1233,6 +1247,7 @@ final class WorkspaceStore: ObservableObject {
                 break
             }
         }
+        syncDockBadge(for: key, oldStatus: oldStatus, newStatus: state.status, userIsWatching: userIsWatching)
     }
 
     /// User pressed plain Esc in a pane whose agent is mid-turn. Neither
@@ -1251,6 +1266,7 @@ final class WorkspaceStore: ObservableObject {
             state.status = .idle
             state.updatedAt = Date()
             paneAgentState[key] = state
+            clearDockBadge(for: key)
         case .idle, .justCompleted, .failed:
             // justCompleted/failed are unread badges — only viewing the
             // workspace clears them, not a stray Esc.
@@ -1274,6 +1290,7 @@ final class WorkspaceStore: ObservableObject {
         state.updatedAt = now
         state.turnStartedAt = now
         paneAgentState[key] = state
+        clearDockBadge(for: key)
     }
 
     /// Clear any `.justCompleted` / `.failed` panes back to `.idle` — but
@@ -1285,12 +1302,70 @@ final class WorkspaceStore: ObservableObject {
         guard let ws = workspaces.first(where: { $0.id == workspaceID }),
               let tab = ws.selectedTab else { return }
         let visible = Set(tab.root.leaves)
+        for key in Array(dockBadgePaneStatuses.keys)
+        where key.workspace == workspaceID && visible.contains(key.pane) {
+            clearDockBadge(for: key)
+        }
         for (key, state) in paneAgentState
         where key.workspace == workspaceID && visible.contains(key.pane)
             && (state.status == .justCompleted || state.status == .failed) {
             paneAgentState[key]?.status = .idle
             paneAgentState[key]?.updatedAt = Date()
         }
+    }
+
+    private static func isDockBadgeStatus(_ status: PaneAgentStatus) -> Bool {
+        switch status {
+        case .needsPermission, .justCompleted, .failed:
+            return true
+        case .idle, .thinking, .tool, .compacting:
+            return false
+        }
+    }
+
+    private func syncDockBadge(for key: WorkspacePaneKey,
+                               oldStatus: PaneAgentStatus,
+                               newStatus: PaneAgentStatus,
+                               userIsWatching: Bool) {
+        if userIsWatching {
+            clearDockBadge(for: key)
+            return
+        }
+        guard dockBadgeOnAgentAttention else { return }
+        if oldStatus != newStatus, Self.isDockBadgeStatus(newStatus) {
+            dockBadgePaneStatuses[key] = newStatus
+        } else if !Self.isDockBadgeStatus(newStatus) {
+            dockBadgePaneStatuses.removeValue(forKey: key)
+        }
+        updateDockBadge()
+    }
+
+    private func clearDockBadge(for key: WorkspacePaneKey) {
+        guard dockBadgePaneStatuses.removeValue(forKey: key) != nil else { return }
+        updateDockBadge()
+    }
+
+    private func clearDockBadges(for keys: [WorkspacePaneKey]) {
+        var changed = false
+        for key in keys where dockBadgePaneStatuses.removeValue(forKey: key) != nil {
+            changed = true
+        }
+        if changed { updateDockBadge() }
+    }
+
+    private func clearDockBadge() {
+        guard !dockBadgePaneStatuses.isEmpty || NSApp.dockTile.badgeLabel != nil else { return }
+        dockBadgePaneStatuses.removeAll()
+        updateDockBadge()
+    }
+
+    private func updateDockBadge() {
+        guard dockBadgeOnAgentAttention else {
+            NSApp.dockTile.badgeLabel = nil
+            return
+        }
+        let count = dockBadgePaneStatuses.count
+        NSApp.dockTile.badgeLabel = count == 0 ? nil : "\(count)"
     }
 
     /// True when `key`'s pane is on screen right now: its workspace is the
@@ -1487,6 +1562,7 @@ final class WorkspaceStore: ObservableObject {
         // ghost entries forever.
         paneAgentState.removeValue(forKey: key)
         paneProcesses.removeValue(forKey: key)
+        clearDockBadge(for: key)
         workspaces[i].tabs[t].focusedPane = survivor
             ?? workspaces[i].tabs[t].root.leaves.first
             ?? PaneID(value: 0)
@@ -1674,6 +1750,7 @@ final class WorkspaceStore: ObservableObject {
                 id: ScrollbackArchive.fileID(forPaneKey: "\(wsID.uuidString):\(pane.value)"))
             paneAgentState.removeValue(forKey: key)
             paneProcesses.removeValue(forKey: key)
+            clearDockBadge(for: key)
         }
         workspaces[i].tabs.remove(at: t)
         if wasSelected {
@@ -1768,6 +1845,7 @@ final class WorkspaceStore: ObservableObject {
         // Drop every surface tied to this workspace (their ghostty surfaces
         // get freed in GhosttySurfaceView.deinit when the dict releases them).
         surfaceViews = surfaceViews.filter { $0.key.workspace != id }
+        clearDockBadges(for: workspaces[idx].panes.keys.map { WorkspacePaneKey(workspace: id, pane: $0) })
         // And their scrollback snapshots.
         for paneID in workspaces[idx].panes.keys {
             ScrollbackArchive.delete(
@@ -1812,6 +1890,7 @@ final class WorkspaceStore: ObservableObject {
         // hold onto GPU/IOSurface memory. The Pane / SplitNode / scrollback
         // archive stay on disk so unarchive can rehydrate them.
         surfaceViews = surfaceViews.filter { $0.key.workspace != id }
+        clearDockBadges(for: workspaces[idx].panes.keys.map { WorkspacePaneKey(workspace: id, pane: $0) })
         paneAgentState = paneAgentState.filter { $0.key.workspace != id }
         paneProcesses = paneProcesses.filter { $0.key.workspace != id }
 


### PR DESCRIPTION
## 中文说明

这次给后台 agent 注意事项增加一个轻量的 Dock 角标提醒：当后台 pane 需要批准、刚完成或失败时，Dock 图标显示 pending count。

它和 system notification 不一样：

- 不弹 banner，不打断当前工作；
- 不显示 prompt / transcript / command output，privacy 风险更低；
- 同一个 pane 去重计数，避免重复 spam；
- 用户切回对应 workspace/tab/pane 后自动清理；
- pane/tab/workspace 删除、Esc interrupt、permission Return、app 退出都会清理；
- Settings > Notifications 增加开关，默认开启。

Fixes #23

## English summary

This PR adds a quiet Dock badge count for background agent panes that need attention.

The badge tracks these statuses:

- `needsPermission`
- `justCompleted`
- `failed`

It only counts background panes, clears when the user views the relevant pane/session, and cleans up on pane/tab/workspace lifecycle changes or app termination. The badge only shows a count and does not expose any prompt, transcript, or command output.

## Validation

- `git diff --check upstream/main...HEAD`
- `python3 -m json.tool Glint/Resources/Localizable.xcstrings >/dev/null`
- Built locally:
  `xcodebuild -project Glint.xcodeproj -scheme Glint -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/glint-pr-dock-badge build`
- Result: `** BUILD SUCCEEDED **`
- Local review-hub post-review: 3/3 reviewers complete, all APPROVE, no blockers (`qwen3.7-max`, `mimo-v2.5`, `MiniMax-M3`).
