### PR TITLE
feat(agent): add managed agent sessions

### DIFF
--- a/Glint.xcodeproj/project.pbxproj
+++ b/Glint.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		5157C5439862F21202BCC44D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E67CF5D8552AE1F51386161 /* AppDelegate.swift */; };
 		692D1A7D490E07D796535EAA /* UpdaterController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4408F9761E584DE2AB6630E2 /* UpdaterController.swift */; };
 		6D74FE6545631EB8193C82E1 /* PaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FC2FBC9E8729A5ECBF857C /* PaneView.swift */; };
+		75DB92EB1F7C0E3818771313 /* AgentSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFA3E9C631330FEB4BA5FEB /* AgentSessionManager.swift */; };
+		7957C8179895EB72E2AB1124 /* AgentSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09CA545DE3F810BD83602569 /* AgentSession.swift */; };
 		7D07A40DF6411A613624827A /* PaneSurfaceRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16137B405E48DBE262A15B6D /* PaneSurfaceRepresentable.swift */; };
 		7FC12666816053BEB64079CB /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 050E267AE14712D4D6633B4F /* Theme.swift */; };
 		942ED7C1C1A2E823BA52F67A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3023490E670A10EC38870B12 /* Assets.xcassets */; };
@@ -25,6 +27,7 @@
 		B70CAFEBB2416E25B0FFED97 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = C48F9D3C512A0ABE8369D0F4 /* Sparkle */; };
 		C0E8D97C08BA3F0FA33F31E7 /* CommandPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 235E2D958A2244483CAA0812 /* CommandPalette.swift */; };
 		C48BD1224EA2C6D3C87B9120 /* AgentPaneSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829D894CF747D6BC08667239 /* AgentPaneSummary.swift */; };
+		C86EC59161FEF5192CC3FB11 /* NewAgentSessionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA3B5F9220B358747385698 /* NewAgentSessionView.swift */; };
 		CD30F5E1B78B3C46C9990FD6 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C269A6E9AE87961C3356DC /* SidebarView.swift */; };
 		CD7908F096580864CB2992ED /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BE4DBC7E2579823474466E9 /* ContentView.swift */; };
 		CEA0A8FF66046FEFA80FAC0C /* GlintApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CB74659D174004C620D538A /* GlintApp.swift */; };
@@ -40,6 +43,7 @@
 		050E267AE14712D4D6633B4F /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		05F2CA2243872C8111048EF2 /* AgentBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBridge.swift; sourceTree = "<group>"; };
 		08FC2FBC9E8729A5ECBF857C /* PaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneView.swift; sourceTree = "<group>"; };
+		09CA545DE3F810BD83602569 /* AgentSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSession.swift; sourceTree = "<group>"; };
 		16137B405E48DBE262A15B6D /* PaneSurfaceRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneSurfaceRepresentable.swift; sourceTree = "<group>"; };
 		1E646AABA8ADCE8A2A5C6F55 /* PaneTreeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneTreeView.swift; sourceTree = "<group>"; };
 		21868C7211897C87A6CAD7C3 /* ControlBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlBridge.swift; sourceTree = "<group>"; };
@@ -54,6 +58,7 @@
 		4BE4DBC7E2579823474466E9 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		5A8933F67B4B6EEA3FD4E603 /* WorkspaceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceStore.swift; sourceTree = "<group>"; };
 		6D3B64992BBD5A190DFE36D2 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		7BFA3E9C631330FEB4BA5FEB /* AgentSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSessionManager.swift; sourceTree = "<group>"; };
 		7CB74659D174004C620D538A /* GlintApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlintApp.swift; sourceTree = "<group>"; };
 		81DADCF27E710CC77846E961 /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GhosttyKit.xcframework; path = Vendor/GhosttyKit.xcframework; sourceTree = "<group>"; };
 		829D894CF747D6BC08667239 /* AgentPaneSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentPaneSummary.swift; sourceTree = "<group>"; };
@@ -61,6 +66,7 @@
 		8EDE0D7C434B8E9C76C4A297 /* Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Persistence.swift; sourceTree = "<group>"; };
 		9E67CF5D8552AE1F51386161 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A8C269A6E9AE87961C3356DC /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
+		AEA3B5F9220B358747385698 /* NewAgentSessionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewAgentSessionView.swift; sourceTree = "<group>"; };
 		C0656F7C1D48AE0429C1888B /* VisualEffectBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualEffectBackground.swift; sourceTree = "<group>"; };
 		E298AD81B1615CBBFD69F48A /* GhosttySurfaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttySurfaceView.swift; sourceTree = "<group>"; };
 		F5A69ACF962AEDE189F98649 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -109,6 +115,7 @@
 			children = (
 				235E2D958A2244483CAA0812 /* CommandPalette.swift */,
 				4BE4DBC7E2579823474466E9 /* ContentView.swift */,
+				AEA3B5F9220B358747385698 /* NewAgentSessionView.swift */,
 				6D3B64992BBD5A190DFE36D2 /* SettingsView.swift */,
 				A8C269A6E9AE87961C3356DC /* SidebarView.swift */,
 				050E267AE14712D4D6633B4F /* Theme.swift */,
@@ -131,6 +138,8 @@
 				05F2CA2243872C8111048EF2 /* AgentBridge.swift */,
 				265A192AC9BD06DB09346E90 /* AgentHookInstaller.swift */,
 				829D894CF747D6BC08667239 /* AgentPaneSummary.swift */,
+				09CA545DE3F810BD83602569 /* AgentSession.swift */,
+				7BFA3E9C631330FEB4BA5FEB /* AgentSessionManager.swift */,
 				21868C7211897C87A6CAD7C3 /* ControlBridge.swift */,
 				41DDB9C7B5A277B7924270A3 /* PaneAgentState.swift */,
 				F8A1F24DAA7220AD4EE961E2 /* UsageStore.swift */,
@@ -278,6 +287,8 @@
 				E464D0233508CD31C1235054 /* AgentBridge.swift in Sources */,
 				3932A4CFEFF6FB81AE283645 /* AgentHookInstaller.swift in Sources */,
 				C48BD1224EA2C6D3C87B9120 /* AgentPaneSummary.swift in Sources */,
+				7957C8179895EB72E2AB1124 /* AgentSession.swift in Sources */,
+				75DB92EB1F7C0E3818771313 /* AgentSessionManager.swift in Sources */,
 				5157C5439862F21202BCC44D /* AppDelegate.swift in Sources */,
 				C0E8D97C08BA3F0FA33F31E7 /* CommandPalette.swift in Sources */,
 				CD7908F096580864CB2992ED /* ContentView.swift in Sources */,
@@ -285,6 +296,7 @@
 				3CB9F41E3B1CB4A8790D9159 /* GhosttyManager.swift in Sources */,
 				1115F230E14FBE3C1FC754A2 /* GhosttySurfaceView.swift in Sources */,
 				CEA0A8FF66046FEFA80FAC0C /* GlintApp.swift in Sources */,
+				C86EC59161FEF5192CC3FB11 /* NewAgentSessionView.swift in Sources */,
 				21C03B3AE912F4D30FA6F92C /* PaneAgentState.swift in Sources */,
 				7D07A40DF6411A613624827A /* PaneSurfaceRepresentable.swift in Sources */,
 				49DF8EE59313B7CFE29DA303 /* PaneTreeView.swift in Sources */,

--- a/Glint/Agent/AgentBridge.swift
+++ b/Glint/Agent/AgentBridge.swift
@@ -144,7 +144,8 @@ final class AgentBridge {
     }
 
     private struct HookEnvelope: Decodable {
-        let pane: String
+        let session: String?
+        let pane: String?
         let hook: String
         let agent: String?
     }
@@ -155,10 +156,9 @@ final class AgentBridge {
             return
         }
         DispatchQueue.main.async {
-            var userInfo: [String: Any] = [
-                "pane": env.pane,
-                "hook": env.hook,
-            ]
+            var userInfo: [String: Any] = ["hook": env.hook]
+            if let session = env.session, !session.isEmpty { userInfo["session"] = session }
+            if let pane = env.pane, !pane.isEmpty { userInfo["pane"] = pane }
             if let agent = env.agent, !agent.isEmpty {
                 userInfo["agent"] = agent
             }

--- a/Glint/Agent/AgentSession.swift
+++ b/Glint/Agent/AgentSession.swift
@@ -1,0 +1,281 @@
+import Foundation
+
+enum AgentKind: String, Codable, CaseIterable, Identifiable, Hashable {
+    case claude, codex, opencode, terminal
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .claude: return "Claude Code"
+        case .codex: return "Codex CLI"
+        case .opencode: return "OpenCode"
+        case .terminal: return "Terminal only"
+        }
+    }
+
+    var defaultCommand: String {
+        switch self {
+        case .claude: return "claude"
+        case .codex: return "codex"
+        case .opencode: return "opencode"
+        case .terminal: return ""
+        }
+    }
+}
+
+enum HostTarget: Codable, Hashable, Identifiable {
+    case local
+    case ssh(alias: String)
+
+    var id: String {
+        switch self { case .local: return "local"; case .ssh(let alias): return "ssh:\(alias)" }
+    }
+    var label: String {
+        switch self { case .local: return "This Mac"; case .ssh(let alias): return alias }
+    }
+
+    private enum CodingKeys: String, CodingKey { case kind, alias, profileID }
+    private enum Kind: String, Codable { case local, ssh }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        switch try c.decode(Kind.self, forKey: .kind) {
+        case .local: self = .local
+        case .ssh:
+            // `profileID` reads the first implementation's persisted shape.
+            let value = try c.decodeIfPresent(String.self, forKey: .alias)
+                ?? c.decode(String.self, forKey: .profileID)
+            self = .ssh(alias: value)
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .local: try c.encode(Kind.local, forKey: .kind)
+        case .ssh(let alias):
+            try c.encode(Kind.ssh, forKey: .kind)
+            try c.encode(alias, forKey: .alias)
+        }
+    }
+}
+
+enum AgentHookMode: String, Codable, CaseIterable, Hashable {
+    case glintOverlay
+    case disabled
+}
+
+struct AgentProfile: Identifiable, Codable, Hashable {
+    var id: String
+    var label: String
+    var agent: AgentKind
+    var hostScope: String?
+    var command: String
+    var configDir: String?
+    var settingsFile: String?
+    var envFile: String?
+    var args: [String]
+    var hookMode: AgentHookMode
+
+    static func defaultProfile(for agent: AgentKind) -> AgentProfile {
+        AgentProfile(
+            id: "default-\(agent.rawValue)",
+            label: agent.displayName,
+            agent: agent,
+            hostScope: nil,
+            command: agent.defaultCommand,
+            configDir: agent == .codex ? "~/.codex" : nil,
+            settingsFile: agent == .claude ? "~/.claude/settings.json" : nil,
+            envFile: nil,
+            args: [],
+            hookMode: agent == .terminal || agent == .opencode ? .disabled : .glintOverlay
+        )
+    }
+}
+
+extension AgentProfile {
+    var displayLabel: String {
+        guard let hostScope else { return label }
+        return "\(label) @ \(hostScope)"
+    }
+
+    var deviceLabel: String {
+        hostScope ?? String(localized: "This Mac")
+    }
+
+    var summaryLine: String {
+        var parts = [agent.displayName, deviceLabel]
+        if !command.isEmpty { parts.append(command) }
+        if let configDir, !configDir.isEmpty { parts.append(configDir) }
+        return parts.joined(separator: " · ")
+    }
+}
+
+enum AgentTransportState: String, Codable {
+    case local, connected, detached, reconnecting, unreachable
+}
+
+struct AgentSession: Identifiable, Codable, Hashable {
+    let id: String
+    var agent: AgentKind
+    var host: HostTarget
+    var profile: AgentProfile
+    var workingDirectory: String
+    var tmuxSessionName: String
+    var lastAttachedPane: String?
+    var needsHookTrust: Bool
+
+    var profileID: String { profile.id }
+
+    static func create(agent: AgentKind, host: HostTarget, profile: AgentProfile,
+                       workingDirectory: String, pane: String? = nil) -> AgentSession {
+        let token = UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased().prefix(8)
+        let id = "glint-\(token)"
+        let hostPart = slug(host.label)
+        let profilePart = slug(profile.id)
+        return AgentSession(
+            id: id,
+            agent: agent,
+            host: host,
+            profile: profile,
+            workingDirectory: workingDirectory,
+            tmuxSessionName: "glint-\(hostPart)-\(profilePart)-\(token)",
+            lastAttachedPane: pane,
+            needsHookTrust: agent == .codex && profile.hookMode == .glintOverlay
+        )
+    }
+
+    private static func slug(_ value: String) -> String {
+        let allowed = CharacterSet.alphanumerics
+        let mapped = value.lowercased().unicodeScalars.map { allowed.contains($0) ? Character(String($0)) : "-" }
+        let joined = String(mapped).split(separator: "-").filter { !$0.isEmpty }.joined(separator: "-")
+        return joined.isEmpty ? "session" : joined
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, agent, host, profile, workingDirectory, tmuxSessionName, lastAttachedPane, needsHookTrust
+    }
+
+    init(id: String, agent: AgentKind, host: HostTarget, profile: AgentProfile,
+         workingDirectory: String, tmuxSessionName: String, lastAttachedPane: String?,
+         needsHookTrust: Bool) {
+        self.id = id; self.agent = agent; self.host = host; self.profile = profile
+        self.workingDirectory = workingDirectory; self.tmuxSessionName = tmuxSessionName
+        self.lastAttachedPane = lastAttachedPane; self.needsHookTrust = needsHookTrust
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        agent = try c.decodeIfPresent(AgentKind.self, forKey: .agent) ?? .terminal
+        host = try c.decode(HostTarget.self, forKey: .host)
+        profile = try c.decodeIfPresent(AgentProfile.self, forKey: .profile)
+            ?? .defaultProfile(for: agent)
+        workingDirectory = try c.decode(String.self, forKey: .workingDirectory)
+        tmuxSessionName = try c.decode(String.self, forKey: .tmuxSessionName)
+        lastAttachedPane = try c.decodeIfPresent(String.self, forKey: .lastAttachedPane)
+        needsHookTrust = try c.decodeIfPresent(Bool.self, forKey: .needsHookTrust)
+            ?? (agent == .codex && profile.hookMode == .glintOverlay)
+    }
+}
+
+enum AgentProfileStore {
+    private static let key = "glint.agentProfiles.v1"
+
+    static var profiles: [AgentProfile] {
+        get {
+            guard let data = UserDefaults.standard.data(forKey: key),
+                  let custom = try? JSONDecoder().decode([AgentProfile].self, from: data) else {
+                return AgentKind.allCases.map(AgentProfile.defaultProfile)
+            }
+            return normalizedProfiles(custom)
+        }
+        set { UserDefaults.standard.set(try? JSONEncoder().encode(newValue), forKey: key) }
+    }
+
+    static func scopedDefaultID(for agent: AgentKind, hostScope: String) -> String {
+        "default-\(agent.rawValue)-\(slug(hostScope))"
+    }
+
+    static func save(_ profile: AgentProfile) {
+        let profile = normalizedProfile(profile)
+        var all = profiles
+        if let i = all.firstIndex(where: { $0.id == profile.id }) { all[i] = profile }
+        else { all.append(profile) }
+        profiles = all
+    }
+
+    static func delete(_ profile: AgentProfile) {
+        guard !isBuiltInDefault(profile) else { return }
+        profiles = profiles.filter { $0.id != profile.id }
+    }
+
+    static func isBuiltInDefault(_ profile: AgentProfile) -> Bool {
+        profile.hostScope == nil && profile.id == "default-\(profile.agent.rawValue)"
+    }
+
+    static func newProfileID(for agent: AgentKind) -> String {
+        "\(agent.rawValue)-\(UUID().uuidString.lowercased())"
+    }
+
+    private static func normalizedProfiles(_ profiles: [AgentProfile]) -> [AgentProfile] {
+        var result: [AgentProfile] = []
+        var seen = Set<String>()
+        for raw in profiles {
+            var profile = normalizedProfile(raw)
+            let baseID = profile.id
+            var candidate = baseID
+            var suffix = 2
+            while seen.contains(candidate) {
+                candidate = "\(baseID)-\(suffix)"
+                suffix += 1
+            }
+            profile.id = candidate
+            seen.insert(candidate)
+            result.append(profile)
+        }
+
+        for kind in AgentKind.allCases {
+            let defaultProfile = AgentProfile.defaultProfile(for: kind)
+            if !result.contains(where: { $0.id == defaultProfile.id && $0.hostScope == nil }) {
+                result.append(defaultProfile)
+            }
+        }
+        return result
+    }
+
+    private static func normalizedProfile(_ profile: AgentProfile) -> AgentProfile {
+        var profile = profile
+        if let hostScope = profile.hostScope,
+           profile.id == "default-\(profile.agent.rawValue)" {
+            profile.id = scopedDefaultID(for: profile.agent, hostScope: hostScope)
+        }
+        return profile
+    }
+
+    private static func slug(_ value: String) -> String {
+        let allowed = CharacterSet.alphanumerics
+        let mapped = value.lowercased().unicodeScalars.map {
+            allowed.contains($0) ? Character(String($0)) : "-"
+        }
+        let joined = String(mapped).split(separator: "-").filter { !$0.isEmpty }.joined(separator: "-")
+        return joined.isEmpty ? "host" : joined
+    }
+}
+
+enum SSHConfigHosts {
+    static func aliases() -> [String] {
+        let url = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".ssh/config")
+        guard let text = try? String(contentsOf: url, encoding: .utf8) else { return [] }
+        var result = Set<String>()
+        for raw in text.split(whereSeparator: \.isNewline) {
+            let line = raw.trimmingCharacters(in: .whitespaces)
+            guard line.lowercased().hasPrefix("host ") else { continue }
+            for alias in line.dropFirst(5).split(whereSeparator: \.isWhitespace) {
+                let value = String(alias)
+                if !value.contains("*") && !value.contains("?") { result.insert(value) }
+            }
+        }
+        return result.sorted()
+    }
+}

--- a/Glint/Agent/AgentSessionManager.swift
+++ b/Glint/Agent/AgentSessionManager.swift
@@ -1,0 +1,446 @@
+import Foundation
+
+struct AgentCapabilities {
+    var supportsHooks: Bool
+    var supportsTemporarySettings: Bool
+    var supportsOneRunConfigOverrides: Bool
+    var supportsConfigDir: Bool
+    var supportsResume: Bool
+}
+
+protocol AgentAdapter {
+    var id: AgentKind { get }
+    var displayName: String { get }
+    var capabilities: AgentCapabilities { get }
+    func writeRuntime(session: AgentSession, directory: URL, runtimePath: String) throws
+}
+
+private struct ClaudeAdapter: AgentAdapter {
+    let id = AgentKind.claude
+    let displayName = "Claude Code"
+    let capabilities = AgentCapabilities(supportsHooks: true, supportsTemporarySettings: true,
+                                         supportsOneRunConfigOverrides: false,
+                                         supportsConfigDir: true, supportsResume: true)
+
+    func writeRuntime(session: AgentSession, directory: URL, runtimePath: String) throws {
+        let fm = FileManager.default
+        // Keep the command definition identical across sessions so Codex-like
+        // trust hashes and Claude overlays do not depend on a random ID.
+        let reporter = "\"$GLINT_SESSION_DIR/hooks/glint-report.sh\""
+        let events = ["SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse",
+                      "PermissionRequest", "PreCompact", "Stop", "StopFailure"]
+        var glintHooks: [String: Any] = [:]
+        if session.profile.hookMode == .glintOverlay {
+            for event in events {
+                glintHooks[event] = [["matcher": "", "hooks": [[
+                    "type": "command", "command": "\(reporter) \(event) claude", "timeout": 1,
+                ]]]]
+            }
+        }
+        let overlay: [String: Any] = ["hooks": glintHooks]
+        try jsonData(overlay).write(to: directory.appendingPathComponent("claude-settings.json"), options: .atomic)
+
+        var merged: [String: Any] = [:]
+        if case .local = session.host,
+           let path = session.profile.settingsFile.map(expandHome),
+           let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+           let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            merged = object
+        }
+        var hooks = (merged["hooks"] as? [String: Any]) ?? [:]
+        for (event, value) in glintHooks {
+            let existing = (hooks[event] as? [Any]) ?? []
+            hooks[event] = existing + ((value as? [Any]) ?? [])
+        }
+        if !hooks.isEmpty { merged["hooks"] = hooks }
+        try jsonData(merged).write(to: directory.appendingPathComponent("merged-claude-settings.json"), options: .atomic)
+        try fm.setAttributes([.posixPermissions: 0o600],
+                             ofItemAtPath: directory.appendingPathComponent("merged-claude-settings.json").path)
+
+        let real = session.profile.command.isEmpty ? "claude" : session.profile.command
+        let configExport = session.profile.configDir.map {
+            "export CLAUDE_CONFIG_DIR=\(profilePathExpression($0, host: session.host))\n"
+        } ?? ""
+        let args = session.profile.args.map(shellQuote).joined(separator: " ")
+        let wrapper = """
+        #!/bin/sh
+        \(configExport)REAL=\(shellQuote(real))
+        case "$REAL" in */*) ;; *)
+          PATH=$(printf '%s' "$PATH" | awk -v RS=: -v ORS=: -v d="$GLINT_SESSION_DIR/bin" '$0 != d')
+          REAL=$(command -v "$REAL" 2>/dev/null)
+        esac
+        [ -n "$REAL" ] || { echo 'Glint: Claude Code is not installed.' >&2; exit 127; }
+        exec "$REAL" --settings "$GLINT_SESSION_DIR/merged-claude-settings.json" \(args) "$@"
+        """
+        try write(wrapper, to: directory.appendingPathComponent("bin/claude"), mode: 0o700)
+    }
+}
+
+private struct CodexAdapter: AgentAdapter {
+    let id = AgentKind.codex
+    let displayName = "Codex CLI"
+    let capabilities = AgentCapabilities(supportsHooks: true, supportsTemporarySettings: false,
+                                         supportsOneRunConfigOverrides: true,
+                                         supportsConfigDir: true, supportsResume: true)
+
+    func writeRuntime(session: AgentSession, directory: URL, runtimePath: String) throws {
+        let real = session.profile.command.isEmpty ? "codex" : session.profile.command
+        let configExport = session.profile.configDir.map {
+            "export CODEX_HOME=\(profilePathExpression($0, host: session.host))\n"
+        } ?? ""
+        let args = session.profile.args.map(shellQuote).joined(separator: " ")
+        let events = ["SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse",
+                      "PermissionRequest", "PreCompact", "Stop", "StopFailure"]
+        let overrides = events.map { event in
+            let value = "hooks.\(event)=[{hooks=[{type=\"command\",command=\"\\\"$GLINT_SESSION_DIR/hooks/glint-report.sh\\\" \(event) codex\",timeout=1}]}]"
+            return "  -c \(shellQuote(value)) \\\n"
+        }.joined()
+        let probe = "hooks.Stop=[{hooks=[{type=\"command\",command=\"/bin/true\",timeout=1}]}]"
+        let hookLaunch: String
+        if session.profile.hookMode == .glintOverlay {
+            hookLaunch = """
+            if "$REAL" --strict-config -c \(shellQuote(probe)) --version >/dev/null 2>&1; then
+              exec "$REAL" \\
+            \(overrides)    \(args) "$@"
+            fi
+            """
+        } else {
+            hookLaunch = ""
+        }
+        let wrapper = """
+        #!/bin/sh
+        \(configExport)REAL=\(shellQuote(real))
+        case "$REAL" in */*) ;; *)
+          PATH=$(printf '%s' "$PATH" | awk -v RS=: -v ORS=: -v d="$GLINT_SESSION_DIR/bin" '$0 != d')
+          REAL=$(command -v "$REAL" 2>/dev/null)
+        esac
+        [ -n "$REAL" ] || { echo 'Glint: Codex is not installed.' >&2; exit 127; }
+        \(hookLaunch)
+        exec "$REAL" \(args) "$@"
+        """
+        try write(wrapper, to: directory.appendingPathComponent("bin/codex"), mode: 0o700)
+    }
+}
+
+private struct PassthroughAdapter: AgentAdapter {
+    let id: AgentKind
+    var displayName: String { id.displayName }
+    var capabilities: AgentCapabilities {
+        AgentCapabilities(supportsHooks: false, supportsTemporarySettings: false,
+                          supportsOneRunConfigOverrides: false,
+                          supportsConfigDir: false, supportsResume: false)
+    }
+    func writeRuntime(session: AgentSession, directory: URL, runtimePath: String) throws {
+        guard id != .terminal else { return }
+        let real = session.profile.command.isEmpty ? id.defaultCommand : session.profile.command
+        let args = session.profile.args.map(shellQuote).joined(separator: " ")
+        let wrapper = """
+        #!/bin/sh
+        REAL=\(shellQuote(real))
+        case "$REAL" in */*) ;; *)
+          PATH=$(printf '%s' "$PATH" | awk -v RS=: -v ORS=: -v d="$GLINT_SESSION_DIR/bin" '$0 != d')
+          REAL=$(command -v "$REAL" 2>/dev/null)
+        esac
+        [ -n "$REAL" ] || { echo 'Glint: \(id.displayName) is not installed.' >&2; exit 127; }
+        exec "$REAL" \(args) "$@"
+        """
+        try write(wrapper, to: directory.appendingPathComponent("bin/\(id.rawValue)"), mode: 0o700)
+    }
+}
+
+enum AgentSessionManagerError: Error {
+    case tmuxNotFound
+    case commandFailed(executable: String, status: Int32)
+}
+
+/// Compiles an AgentSession into a disposable tmux/SSH runtime. It never edits
+/// the selected agent profile or global configuration.
+final class AgentSessionManager {
+    static let shared = AgentSessionManager()
+    private let fm = FileManager.default
+    private init() {}
+
+    func prepare(_ session: AgentSession, paneKey: String, bridgeSocket: String) throws -> ManagedSessionLaunch {
+        switch session.host {
+        case .local: return try prepareLocal(session, paneKey: paneKey, bridgeSocket: bridgeSocket)
+        case .ssh(let alias):
+            return try prepareRemote(session, sshTarget: alias, paneKey: paneKey, bridgeSocket: bridgeSocket)
+        }
+    }
+
+    func kill(_ session: AgentSession) throws {
+        switch session.host {
+        case .local:
+            let tmux = try resolveLocalTmux()
+            _ = try runAndWait(tmux, ["kill-session", "-t", session.tmuxSessionName])
+            try? fm.removeItem(at: sessionDirectory(session.id))
+        case .ssh(let alias):
+            let dir = "~/.cache/glint/sessions/\(session.id)"
+            let remote = """
+            TMUX_BIN=$(command -v tmux 2>/dev/null || true)
+            if [ -z "$TMUX_BIN" ]; then
+              for candidate in /opt/homebrew/bin/tmux /usr/local/bin/tmux /usr/bin/tmux; do
+                [ -x "$candidate" ] && TMUX_BIN="$candidate" && break
+              done
+            fi
+            [ -n "$TMUX_BIN" ] || exit 127
+            "$TMUX_BIN" kill-session -t \(shellQuote(session.tmuxSessionName)) >/dev/null 2>&1 || true
+            rm -rf -- "$HOME/\(dir.dropFirst(2))"
+            """
+            let status = try runAndWait("/usr/bin/ssh", [alias, remote])
+            guard status == 0 else {
+                throw AgentSessionManagerError.commandFailed(executable: "ssh", status: status)
+            }
+            try? fm.removeItem(at: sessionDirectory(session.id))
+        }
+    }
+
+    private func prepareLocal(_ session: AgentSession, paneKey: String,
+                              bridgeSocket: String) throws -> ManagedSessionLaunch {
+        let dir = sessionDirectory(session.id)
+        try writeRuntimeFiles(session: session, at: dir, runtimePath: dir.path,
+                              paneKey: paneKey, socketPath: dir.appendingPathComponent("agent.sock").path)
+        let socket = dir.appendingPathComponent("agent.sock")
+        try? fm.removeItem(at: socket)
+        try fm.createSymbolicLink(at: socket, withDestinationURL: URL(fileURLWithPath: bridgeSocket))
+        let env = runtimeEnvironment(session: session, directory: dir.path,
+                                     socket: socket.path, paneKey: paneKey)
+        return ManagedSessionLaunch(environment: env,
+                                    initialInput: "exec \(shellQuote(dir.appendingPathComponent("bootstrap-and-attach.sh").path))\n")
+    }
+
+    private func prepareRemote(_ session: AgentSession, sshTarget: String, paneKey: String,
+                               bridgeSocket: String) throws -> ManagedSessionLaunch {
+        let staging = sessionDirectory(session.id)
+        let remoteDir = "~/.cache/glint/sessions/\(session.id)"
+        try writeRuntimeFiles(session: session, at: staging, runtimePath: remoteDir,
+                              paneKey: paneKey, socketPath: "\(remoteDir)/agent.sock")
+
+        let files: [(relative: String, mode: Int)] = [
+            ("env", 0o600),
+            ("hooks/glint-report.sh", 0o700),
+            ("bin/claude", 0o700),
+            ("bin/codex", 0o700),
+            ("bin/opencode", 0o700),
+            ("claude-settings.json", 0o600),
+            ("merged-claude-settings.json", 0o600),
+            ("merge-claude-settings.py", 0o700),
+            ("bootstrap-and-attach.sh", 0o700),
+        ]
+        var setup = "set -e; D=\"$HOME/.cache/glint/sessions/\(session.id)\"; mkdir -p \"$D/hooks\" \"$D/bin\"; chmod 700 \"$D\" \"$D/hooks\" \"$D/bin\"; "
+        for file in files {
+            let relative = file.relative
+            let url = staging.appendingPathComponent(relative)
+            guard let data = try? Data(contentsOf: url) else { continue }
+            setup += "printf %s \(shellQuote(data.base64EncodedString())) | base64 -d > \"$D/\(relative)\"; chmod \(String(file.mode, radix: 8)) \"$D/\(relative)\"; "
+        }
+        setup += "exec \"$D/bootstrap-and-attach.sh\""
+
+        let prepareForwardSocket = "mkdir -p \"$HOME/.cache/glint/sessions/\(session.id)\"; rm -f -- \"$HOME/.cache/glint/sessions/\(session.id)/agent.sock\""
+        let target = shellQuote(sshTarget)
+        let homeProbe = shellQuote("printf '\\n%s\\n' \"$HOME\"")
+        let remoteForward = "\"$GLINT_REMOTE_HOME/.cache/glint/sessions/\(session.id)/agent.sock:\(shellDoubleQuoteContent(bridgeSocket))\""
+        let ssh = """
+        #!/bin/sh
+        set -e
+        remote_home_output=$(ssh \(target) \(homeProbe)) || exit $?
+        GLINT_REMOTE_HOME=$(printf '%s\\n' "$remote_home_output" | awk 'NF { last=$0 } END { print last }')
+        [ -n "$GLINT_REMOTE_HOME" ] || { printf 'Glint: unable to resolve remote home.\\n' >&2; exit 1; }
+        ssh \(target) \(shellQuote(prepareForwardSocket))
+        exec ssh -tt -o ExitOnForwardFailure=yes -o StreamLocalBindUnlink=yes -R \(remoteForward) \(target) sh -lc \(shellQuote(setup))
+        """
+        let launcher = staging.appendingPathComponent("launch-remote.sh")
+        try write(ssh, to: launcher, mode: 0o700)
+        return ManagedSessionLaunch(environment: [:],
+                                    initialInput: "exec \(shellQuote(launcher.path))\n")
+    }
+
+    private func writeRuntimeFiles(session: AgentSession, at dir: URL, runtimePath: String,
+                                   paneKey: String, socketPath: String) throws {
+        try fm.createDirectory(at: dir.appendingPathComponent("hooks"), withIntermediateDirectories: true,
+                               attributes: [.posixPermissions: 0o700])
+        try fm.createDirectory(at: dir.appendingPathComponent("bin"), withIntermediateDirectories: true,
+                               attributes: [.posixPermissions: 0o700])
+
+        let reporter = """
+        #!/bin/sh
+        set +e
+        HOOK_NAME="$1"; AGENT_NAME="$2"
+        cat >/dev/null 2>/dev/null || true
+        [ -n "$GLINT_SESSION_ID" ] && [ -n "$GLINT_AGENT_SOCK" ] && [ -S "$GLINT_AGENT_SOCK" ] || exit 0
+        [ -x /usr/bin/nc ] || exit 0
+        printf '{"session":"%s","pane":"%s","hook":"%s","agent":"%s"}\\n' "$GLINT_SESSION_ID" "$GLINT_PANE_ID" "$HOOK_NAME" "$AGENT_NAME" \\
+          | /usr/bin/nc -U -w 1 "$GLINT_AGENT_SOCK" >/dev/null 2>&1 || true
+        exit 0
+        """
+        try write(reporter, to: dir.appendingPathComponent("hooks/glint-report.sh"), mode: 0o700)
+        try adapter(for: session.agent).writeRuntime(session: session, directory: dir, runtimePath: runtimePath)
+
+        // Ensure all expected remote upload paths exist even when an adapter
+        // does not use them.
+        for name in ["claude", "codex", "opencode"] {
+            let url = dir.appendingPathComponent("bin/\(name)")
+            if !fm.fileExists(atPath: url.path) {
+                try write("#!/bin/sh\nexit 127\n", to: url, mode: 0o700)
+            }
+        }
+        for name in ["claude-settings.json", "merged-claude-settings.json"] {
+            let url = dir.appendingPathComponent(name)
+            if !fm.fileExists(atPath: url.path) { try write("{}\n", to: url, mode: 0o600) }
+        }
+
+        let env = runtimeEnvironment(session: session, directory: runtimePath,
+                                     socket: socketPath, paneKey: paneKey)
+        let envBody = env.map { "export \($0.key)=\(shellQuote($0.value))" }.sorted().joined(separator: "\n")
+        try write(envBody + "\n", to: dir.appendingPathComponent("env"), mode: 0o600)
+        let hooksEnabled = !env["GLINT_AGENT_SOCK", default: ""].isEmpty
+        let bootstrapAgentSock = hooksEnabled ? "\"$GLINT_SESSION_DIR/agent.sock\"" : "''"
+
+        let mergeScript = Self.mergeClaudeSettingsScript
+        try write(mergeScript, to: dir.appendingPathComponent("merge-claude-settings.py"), mode: 0o700)
+        let sourceSettings = session.profile.settingsFile ?? ""
+        let envSource = session.profile.envFile.map {
+            let p = shellPathExpression($0)
+            return "[ -f \(p) ] && . \(p)\n"
+        } ?? ""
+        let launch: String = session.agent == .terminal
+            ? "exec \"${SHELL:-/bin/sh}\" -l"
+            : "exec \"$GLINT_SESSION_DIR/bin/\(session.agent.rawValue)\""
+        let isRemote: Bool = { if case .ssh = session.host { return true }; return false }()
+        let mergeRemote = isRemote && session.agent == .claude && !sourceSettings.isEmpty
+            ? "python3 \"$GLINT_SESSION_DIR/merge-claude-settings.py\" \(shellPathExpression(sourceSettings)) \"$GLINT_SESSION_DIR/claude-settings.json\" \"$GLINT_SESSION_DIR/merged-claude-settings.json\" >/dev/null 2>&1 || true\n"
+            : ""
+        let bootstrap = """
+        #!/bin/sh
+        set -e
+        GLINT_SESSION_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+        export GLINT_SESSION_DIR
+        export GLINT_SESSION_ID=\(shellQuote(session.id))
+        export GLINT_AGENT_SOCK=\(bootstrapAgentSock)
+        export GLINT_PANE_ID=\(shellQuote(paneKey))
+        export PATH="$GLINT_SESSION_DIR/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+        TMUX_BIN=$(command -v tmux 2>/dev/null || true)
+        if [ -z "$TMUX_BIN" ]; then
+          for candidate in /opt/homebrew/bin/tmux /usr/local/bin/tmux /usr/bin/tmux; do
+            [ -x "$candidate" ] && TMUX_BIN="$candidate" && break
+          done
+        fi
+        if [ -z "$TMUX_BIN" ]; then
+          printf 'Glint: tmux is required on this device but was not found.\\n' >&2
+          printf 'Install it on the selected device, for example: brew install tmux\\n' >&2
+          exit 127
+        fi
+        \(envSource)\(mergeRemote)exec "$TMUX_BIN" new-session -A \
+          -e GLINT_SESSION_ID="$GLINT_SESSION_ID" \
+          -e GLINT_SESSION_DIR="$GLINT_SESSION_DIR" \
+          -e GLINT_AGENT_SOCK="$GLINT_AGENT_SOCK" \
+          -e GLINT_PANE_ID="$GLINT_PANE_ID" \
+          -e PATH="$PATH" \
+          -s \(shellQuote(session.tmuxSessionName)) -c \(shellPathExpression(session.workingDirectory)) \(shellQuote(launch))
+        """
+        try write(bootstrap, to: dir.appendingPathComponent("bootstrap-and-attach.sh"), mode: 0o700)
+    }
+
+    private func runtimeEnvironment(session: AgentSession, directory: String,
+                                    socket: String, paneKey: String) -> [String: String] {
+        let basePath = ProcessInfo.processInfo.environment["PATH"] ?? "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+        let hooksEnabled = (session.agent == .claude || session.agent == .codex)
+            && session.profile.hookMode == .glintOverlay
+        return ["GLINT_SESSION_ID": session.id, "GLINT_SESSION_DIR": directory,
+                "GLINT_AGENT_SOCK": hooksEnabled ? socket : "", "GLINT_PANE_ID": paneKey,
+                "PATH": "\(directory)/bin:\(basePath)"]
+    }
+
+    private func adapter(for kind: AgentKind) -> any AgentAdapter {
+        switch kind {
+        case .claude: return ClaudeAdapter()
+        case .codex: return CodexAdapter()
+        case .opencode: return PassthroughAdapter(id: .opencode)
+        case .terminal: return PassthroughAdapter(id: .terminal)
+        }
+    }
+
+    private func sessionDirectory(_ id: String) -> URL {
+        fm.homeDirectoryForCurrentUser.appendingPathComponent(".cache/glint/sessions/\(id)", isDirectory: true)
+    }
+    private func resolveLocalTmux() throws -> String {
+        let searchPath = ProcessInfo.processInfo.environment["PATH"] ?? ""
+        if let tmux = findExecutable("tmux", in: searchPath) { return tmux }
+        for candidate in ["/opt/homebrew/bin/tmux", "/usr/local/bin/tmux", "/usr/bin/tmux"] {
+            if fm.isExecutableFile(atPath: candidate) { return candidate }
+        }
+        throw AgentSessionManagerError.tmuxNotFound
+    }
+
+    private func findExecutable(_ name: String, in path: String) -> String? {
+        for directory in path.split(separator: ":") {
+            let candidate = "\(directory)/\(name)"
+            if fm.isExecutableFile(atPath: candidate) { return candidate }
+        }
+        return nil
+    }
+
+    private func runAndWait(_ executable: String, _ arguments: [String]) throws -> Int32 {
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: executable)
+        p.arguments = arguments
+        p.standardOutput = FileHandle.nullDevice
+        p.standardError = FileHandle.nullDevice
+        try p.run()
+        p.waitUntilExit()
+        return p.terminationStatus
+    }
+
+    private static let mergeClaudeSettingsScript = """
+    #!/usr/bin/env python3
+    import json, os, sys
+    source, overlay, output = sys.argv[1:4]
+    source = os.path.expanduser(source)
+    try:
+        with open(source) as f: base = json.load(f)
+    except Exception: base = {}
+    try:
+        with open(overlay) as f: extra = json.load(f)
+    except Exception: extra = {}
+    hooks = base.setdefault("hooks", {})
+    for event, groups in extra.get("hooks", {}).items(): hooks[event] = hooks.get(event, []) + groups
+    with open(output, "w") as f: json.dump(base, f, indent=2)
+    """
+}
+
+struct ManagedSessionLaunch { let environment: [String: String]; let initialInput: String }
+
+private func expandHome(_ path: String) -> String {
+    guard path == "~" || path.hasPrefix("~/") else { return path }
+    return FileManager.default.homeDirectoryForCurrentUser.path + path.dropFirst()
+}
+private func jsonData(_ object: Any) throws -> Data {
+    try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes])
+}
+private func write(_ text: String, to url: URL, mode: Int) throws {
+    try text.write(to: url, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: mode], ofItemAtPath: url.path)
+}
+private func shellQuote(_ value: String) -> String {
+    "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+}
+private func shellDoubleQuoteContent(_ value: String) -> String {
+    value
+        .replacingOccurrences(of: "\\", with: "\\\\")
+        .replacingOccurrences(of: "\"", with: "\\\"")
+        .replacingOccurrences(of: "$", with: "\\$")
+        .replacingOccurrences(of: "`", with: "\\`")
+}
+private func shellPathExpression(_ value: String) -> String {
+    if value == "~" { return "\"$HOME\"" }
+    if value.hasPrefix("~/") {
+        return "\"$HOME/\(shellDoubleQuoteContent(String(value.dropFirst(2))))\""
+    }
+    return shellQuote(value)
+}
+private func profilePathExpression(_ value: String, host: HostTarget) -> String {
+    switch host {
+    case .local: return shellQuote(expandHome(value))
+    case .ssh: return shellPathExpression(value)
+    }
+}

--- a/Glint/Agent/AgentSessionManager.swift
+++ b/Glint/Agent/AgentSessionManager.swift
@@ -243,7 +243,7 @@ final class AgentSessionManager {
         let ssh = """
         #!/bin/sh
         set -e
-        remote_home_output=$(ssh \(target) \(homeProbe)) || exit $?
+        remote_home_output=`ssh \(target) \(homeProbe)` || exit $?
         GLINT_REMOTE_HOME=$(printf '%s\\n' "$remote_home_output" | awk 'NF { last=$0 } END { print last }')
         [ -n "$GLINT_REMOTE_HOME" ] || { printf 'Glint: unable to resolve remote home.\\n' >&2; exit 1; }
         ssh \(target) \(shellQuote(prepareForwardSocket))

--- a/Glint/App/GlintApp.swift
+++ b/Glint/App/GlintApp.swift
@@ -58,7 +58,9 @@ struct GlintApp: App {
             // events reach ghostty; workspace switching uses the tab-like
             // ⌘⇧[ / ⌘⇧] plus ⌘1…⌘9 direct jumps instead.
             CommandGroup(replacing: .newItem) {
-                Button("New Workspace") { workspaceStore.addWorkspace() }
+                Button("New Agent Session") { workspaceStore.newAgentSessionOpen = true }
+                    .keyboardShortcut("n", modifiers: [.command, .shift])
+                Button("New Workspace") { workspaceStore.newWorkspaceSessionOpen = true }
                     .keyboardShortcut("n", modifiers: .command)
                 Button("Next Workspace") { workspaceStore.selectNextWorkspace() }
                     .keyboardShortcut("]", modifiers: [.command, .shift])

--- a/Glint/Chrome/CommandPalette.swift
+++ b/Glint/Chrome/CommandPalette.swift
@@ -166,11 +166,9 @@ struct CommandPalette: View {
         let ordered = store.workspaces.filter { $0.id == currentID }
             + store.workspaces.filter { $0.id != currentID }
         for ws in ordered {
-            let n = ws.panes.count
-            let unit = String(localized: n == 1 ? "pane" : "panes")
             items.append(.workspace(
                 title: ws.displayName,
-                subtitle: "\(n) \(unit)",
+                subtitle: ws.detailLine,
                 accent: ws.accent,
                 isCurrent: ws.id == currentID,
                 action: { store.selectWorkspace(ws.id) }
@@ -178,12 +176,21 @@ struct CommandPalette: View {
         }
 
         items.append(.action(
+            title: "New Agent Session",
+            subtitle: "Launch in the current workspace",
+            symbol: "sparkles.rectangle.stack",
+            shortcut: "",
+            tint: actionTint,
+            action: { store.newAgentSessionOpen = true }
+        ))
+
+        items.append(.action(
             title: "New Workspace",
-            subtitle: "Create a fresh workspace",
+            subtitle: "Choose agent, device, and profile",
             symbol: "plus.square",
             shortcut: "",
             tint: actionTint,
-            action: { store.addWorkspace() }
+            action: { store.newWorkspaceSessionOpen = true }
         ))
 
         items.append(.action(

--- a/Glint/Chrome/ContentView.swift
+++ b/Glint/Chrome/ContentView.swift
@@ -77,6 +77,12 @@ struct ContentView: View {
             GlintSettingsView()
                 .environmentObject(store)
         }
+        .sheet(isPresented: $store.newAgentSessionOpen) {
+            NewAgentSessionView().environmentObject(store)
+        }
+        .sheet(isPresented: $store.newWorkspaceSessionOpen) {
+            NewAgentSessionView(destination: .newWorkspace).environmentObject(store)
+        }
     }
 }
 
@@ -140,6 +146,10 @@ struct ToolbarHeader: View {
             TabBar()
                 .padding(.horizontal, 12)
             HStack(spacing: 4) {
+                ToolbarIconButton(symbol: "sparkles.rectangle.stack",
+                                  help: "New Agent Session in Current Workspace") {
+                    store.newAgentSessionOpen = true
+                }
                 ToolbarIconButton(symbol: "command", help: "Command Palette (⌘⇧P)") {
                     store.commandPaletteOpen = true
                 }
@@ -1357,7 +1367,7 @@ private struct WorkspaceSwitcherPopover: View {
 
     private var newWorkspaceRow: some View {
         Button {
-            store.addWorkspace()
+            store.newWorkspaceSessionOpen = true
             dismiss()
         } label: {
             HStack(spacing: 10) {
@@ -1477,13 +1487,7 @@ private struct WorkspaceSwitcherRow: View {
             case .idle:            break
             }
         }
-        let n = ws.panes.count
-        let unit = String(localized: n == 1 ? "pane" : "panes")
-        let tabN = ws.tabs.count
-        if tabN > 1 {
-            return "\(tabN) \(String(localized: "tabs")) · \(n) \(unit)"
-        }
-        return "\(n) \(unit)"
+        return ws.detailLine
     }
 
     private func secondaryColor(_ s: PaneAgentStatus) -> Color? {

--- a/Glint/Chrome/NewAgentSessionView.swift
+++ b/Glint/Chrome/NewAgentSessionView.swift
@@ -1,0 +1,541 @@
+import SwiftUI
+import AppKit
+
+enum NewAgentSessionDestination {
+    case currentWorkspaceTab
+    case newWorkspace
+
+    var title: String {
+        switch self {
+        case .currentWorkspaceTab: return "New Agent Session"
+        case .newWorkspace: return "New Workspace"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .currentWorkspaceTab:
+            return "Launch a profile in a persistent tmux session."
+        case .newWorkspace:
+            return "Choose the first session for a new workspace."
+        }
+    }
+
+    var createTitle: String {
+        switch self {
+        case .currentWorkspaceTab: return "Create Session"
+        case .newWorkspace: return "Create Workspace"
+        }
+    }
+}
+
+struct NewAgentSessionView: View {
+    @EnvironmentObject private var store: WorkspaceStore
+    @Environment(\.dismiss) private var dismiss
+
+    let destination: NewAgentSessionDestination
+
+    @State private var selectedProfileID = ""
+    @State private var workingDirectory = FileManager.default.homeDirectoryForCurrentUser.path
+    @State private var quickProfileOpen = false
+
+    private var hosts: [HostTarget] { [.local] + SSHConfigHosts.aliases().map { .ssh(alias: $0) } }
+    private var profiles: [AgentProfile] { AgentProfileStore.profiles.sorted(by: profileSort) }
+    private var selectedProfile: AgentProfile? {
+        profiles.first { $0.id == selectedProfileID } ?? profiles.first
+    }
+
+    init(destination: NewAgentSessionDestination = .currentWorkspaceTab) {
+        self.destination = destination
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(destination.title).font(.system(size: 22, weight: .semibold))
+                    Text(destination.subtitle)
+                        .font(.system(size: 12)).foregroundStyle(Theme.text3)
+                }
+                Spacer()
+                Button { dismiss() } label: { Image(systemName: "xmark") }
+                    .buttonStyle(.plain)
+            }
+            .padding(24)
+
+            Divider().overlay(Color.white.opacity(0.08))
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    formRow("Launch profile", detail: "Agent, device, command, and config live in profiles.") {
+                        HStack(spacing: 8) {
+                            Picker("", selection: $selectedProfileID) {
+                                ForEach(profiles) { profile in
+                                    Text(profile.displayLabel).tag(profile.id)
+                                }
+                            }
+                            .labelsHidden()
+                            .frame(width: 270)
+
+                            Button("New Profile") {
+                                quickProfileOpen = true
+                            }
+                            .controlSize(.small)
+                        }
+                    }
+
+                    if let selectedProfile {
+                        profileSummary(selectedProfile)
+                    }
+
+                    Divider().overlay(Color.white.opacity(0.06))
+
+                    formRow("Working directory", detail: "Separate from the profile/config folder.") {
+                        HStack(spacing: 8) {
+                            TextField("~/projects/foo", text: $workingDirectory)
+                                .textFieldStyle(.roundedBorder).frame(width: 270)
+                            if selectedHost == .local {
+                                Button("Choose…", action: chooseDirectory).controlSize(.small)
+                            }
+                        }
+                    }
+                }
+                .padding(24)
+            }
+
+            Divider().overlay(Color.white.opacity(0.08))
+            HStack {
+                if selectedProfile?.agent == .codex && selectedProfile?.hookMode == .glintOverlay {
+                    Label("First launch may require /hooks trust", systemImage: "checkmark.shield")
+                        .font(.system(size: 11)).foregroundStyle(Theme.text3)
+                }
+                Spacer()
+                Button("Cancel") { dismiss() }.keyboardShortcut(.cancelAction)
+                Button(destination.createTitle, action: create)
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(!canCreate)
+                    .tint(store.accent)
+            }
+            .padding(18)
+        }
+        .frame(width: 680, height: 430)
+        .background(Theme.bgWindow)
+        .preferredColorScheme(.dark)
+        .onAppear { ensureSelectedProfile() }
+        .onChange(of: selectedProfileID) { _, _ in
+            if selectedHost != .local, workingDirectory.hasPrefix("/") {
+                workingDirectory = "~/"
+            }
+        }
+        .sheet(isPresented: $quickProfileOpen) {
+            AgentProfileEditorView(
+                initialProfile: selectedProfile ?? .defaultProfile(for: .codex),
+                editingID: nil,
+                saveTitle: "Create Profile"
+            ) { profile in
+                AgentProfileStore.save(profile)
+                selectedProfileID = profile.id
+            }
+            .environmentObject(store)
+        }
+    }
+
+    private var canCreate: Bool {
+        guard let profile = selectedProfile else { return false }
+        return !workingDirectory.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && (profile.agent == .terminal || !profile.command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    @ViewBuilder private func formRow<Content: View>(_ title: String, detail: String,
+                                                      @ViewBuilder content: () -> Content) -> some View {
+        HStack(alignment: .top, spacing: 24) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title).font(.system(size: 13, weight: .medium)).foregroundStyle(Theme.text1)
+                Text(detail).font(.system(size: 11)).foregroundStyle(Theme.text4)
+            }
+            .frame(width: 245, alignment: .leading)
+            Spacer()
+            content()
+        }
+    }
+
+    private func fieldRow(_ title: String, text: Binding<String>, placeholder: String) -> some View {
+        formRow(title, detail: profileFieldHelp(title)) {
+            TextField(placeholder, text: text).textFieldStyle(.roundedBorder).frame(width: 300)
+        }
+    }
+
+    @ViewBuilder private func profileSummary(_ profile: AgentProfile) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Label(profile.agent.displayName, systemImage: profileIcon(profile.agent))
+                Text(profile.deviceLabel)
+                if profile.hookMode == .glintOverlay {
+                    Text("hooks")
+                }
+            }
+            .font(.system(size: 11, weight: .medium))
+            .foregroundStyle(Theme.text3)
+
+            Text(profile.summaryLine)
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundStyle(Theme.text4)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.white.opacity(0.035))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .strokeBorder(Color.white.opacity(0.05), lineWidth: 0.5)
+                )
+        )
+    }
+
+    private func profileFieldHelp(_ field: String) -> String {
+        switch field {
+        case "Name": return "A reusable label for this agent profile."
+        case "Command": return "Executable name or absolute path."
+        case "Config folder": return "Agent account/config state; not the project directory."
+        case "Settings file": return "Claude settings to merge with Glint's temporary overlay."
+        case "Environment file": return "Optional shell file sourced before launch."
+        default: return "Arguments added before one-off command arguments."
+        }
+    }
+
+    private func create() {
+        guard let profile = selectedProfile else { return }
+        let host = hostTarget(for: profile)
+        switch destination {
+        case .currentWorkspaceTab:
+            store.createManagedSession(agent: profile.agent, host: host, profile: profile,
+                                       workingDirectory: workingDirectory)
+        case .newWorkspace:
+            store.createManagedSessionInNewWorkspace(agent: profile.agent, host: host, profile: profile,
+                                                     workingDirectory: workingDirectory)
+        }
+        dismiss()
+    }
+
+    private func chooseDirectory() {
+        let panel = NSOpenPanel(); panel.canChooseDirectories = true; panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false; panel.prompt = "Choose"
+        if panel.runModal() == .OK, let url = panel.url { workingDirectory = url.path }
+    }
+
+    private var selectedHost: HostTarget {
+        selectedProfile.map(hostTarget(for:)) ?? .local
+    }
+
+    private func ensureSelectedProfile() {
+        if !profiles.contains(where: { $0.id == selectedProfileID }) {
+            selectedProfileID = profiles.first?.id ?? ""
+        }
+    }
+
+    private func hostTarget(for profile: AgentProfile) -> HostTarget {
+        guard let hostScope = profile.hostScope else { return .local }
+        return .ssh(alias: hostScope)
+    }
+
+    private func profileSort(_ lhs: AgentProfile, _ rhs: AgentProfile) -> Bool {
+        let l = "\(lhs.hostScope ?? "")|\(lhs.agent.rawValue)|\(lhs.label)"
+        let r = "\(rhs.hostScope ?? "")|\(rhs.agent.rawValue)|\(rhs.label)"
+        return l.localizedCaseInsensitiveCompare(r) == .orderedAscending
+    }
+
+    private func profileIcon(_ agent: AgentKind) -> String {
+        switch agent {
+        case .claude: return "sparkle"
+        case .codex: return "terminal"
+        case .opencode: return "shippingbox"
+        case .terminal: return "apple.terminal"
+        }
+    }
+}
+
+struct AgentProfileEditorView: View {
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var store: WorkspaceStore
+
+    let editingID: String?
+    let saveTitle: String
+    let onSave: (AgentProfile) -> Void
+
+    @State private var agent: AgentKind
+    @State private var hostID: String
+    @State private var baseProfileID: String
+    @State private var profileName: String
+    @State private var command: String
+    @State private var configDir: String
+    @State private var settingsFile: String
+    @State private var envFile: String
+    @State private var extraArguments: String
+    @State private var injectHooks: Bool
+
+    init(initialProfile: AgentProfile, editingID: String?,
+         saveTitle: String, onSave: @escaping (AgentProfile) -> Void) {
+        self.editingID = editingID
+        self.saveTitle = saveTitle
+        self.onSave = onSave
+        _agent = State(initialValue: initialProfile.agent)
+        _hostID = State(initialValue: initialProfile.hostScope.map { "ssh:\($0)" } ?? "local")
+        _baseProfileID = State(initialValue: initialProfile.id)
+        _profileName = State(initialValue: initialProfile.label)
+        _command = State(initialValue: initialProfile.command)
+        _configDir = State(initialValue: initialProfile.configDir ?? "")
+        _settingsFile = State(initialValue: initialProfile.settingsFile ?? "")
+        _envFile = State(initialValue: initialProfile.envFile ?? "")
+        _extraArguments = State(initialValue: initialProfile.args.joined(separator: " "))
+        _injectHooks = State(initialValue: initialProfile.hookMode == .glintOverlay)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(editingID == nil ? "New Profile" : "Edit Profile")
+                        .font(.system(size: 22, weight: .semibold))
+                    Text("Profiles define agent, device, command, and config home.")
+                        .font(.system(size: 12))
+                        .foregroundStyle(Theme.text3)
+                }
+                Spacer()
+                Button { dismiss() } label: { Image(systemName: "xmark") }
+                    .buttonStyle(.plain)
+            }
+            .padding(24)
+
+            Divider().overlay(Color.white.opacity(0.08))
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    if editingID == nil {
+                        formRow("Profile", detail: "Start from an existing profile.") {
+                            Picker("", selection: $baseProfileID) {
+                                ForEach(AgentProfileStore.profiles.sorted(by: profileSort)) { profile in
+                                    Text(profile.displayLabel).tag(profile.id)
+                                }
+                            }
+                            .labelsHidden()
+                            .frame(width: 300)
+                        }
+                    }
+
+                    formRow("Agent", detail: "Choose the CLI this profile launches.") {
+                        Picker("", selection: $agent) {
+                            ForEach(AgentKind.allCases) { kind in
+                                Text(kind.displayName).tag(kind)
+                            }
+                        }
+                        .labelsHidden()
+                        .frame(width: 300)
+                    }
+
+                    formRow("Device", detail: "Remote devices come from ~/.ssh/config.") {
+                        Picker("", selection: $hostID) {
+                            ForEach(hostOptions, id: \.id) { host in
+                                Text(host.label).tag(host.id)
+                            }
+                        }
+                        .labelsHidden()
+                        .frame(width: 300)
+                    }
+
+                    Divider().overlay(Color.white.opacity(0.06))
+
+                    fieldRow("Name", text: $profileName, placeholder: "Codex VS")
+                    if agent != .terminal {
+                        fieldRow("Command", text: $command, placeholder: agent.defaultCommand)
+                        fieldRow("Config folder", text: $configDir, placeholder: "~/.codex")
+                        if agent == .claude {
+                            fieldRow("Settings file", text: $settingsFile, placeholder: "~/.claude/settings.json")
+                        }
+                        fieldRow("Environment file", text: $envFile, placeholder: "Optional shell env file")
+                        fieldRow("Extra arguments", text: $extraArguments, placeholder: "--model …")
+                        if agent == .claude || agent == .codex {
+                            formRow("Status hooks", detail: agent == .codex
+                                    ? "Codex asks you to trust generated hooks once with /hooks."
+                                    : "Injected only into managed sessions.") {
+                                Toggle("Inject Glint hooks", isOn: $injectHooks).labelsHidden()
+                            }
+                        }
+                    }
+                }
+                .padding(24)
+            }
+
+            Divider().overlay(Color.white.opacity(0.08))
+            HStack {
+                Text(profilePreview)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(Theme.text4)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer()
+                Button("Cancel") { dismiss() }.keyboardShortcut(.cancelAction)
+                Button(saveTitle) {
+                    save()
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(!canSave)
+                .tint(store.accent)
+            }
+            .padding(18)
+        }
+        .frame(width: 680, height: 650)
+        .background(Theme.bgWindow)
+        .preferredColorScheme(.dark)
+        .onChange(of: baseProfileID) { _, id in
+            guard editingID == nil,
+                  let profile = AgentProfileStore.profiles.first(where: { $0.id == id }) else { return }
+            load(profile)
+        }
+        .onChange(of: agent) { oldAgent, newAgent in
+            guard editingID == nil else { return }
+            let oldDefault = AgentProfile.defaultProfile(for: oldAgent)
+            let newDefault = AgentProfile.defaultProfile(for: newAgent)
+            if profileName == oldDefault.label {
+                profileName = newDefault.label
+            }
+            if command.isEmpty || command == oldDefault.command {
+                command = newDefault.command
+            }
+            if configDir.isEmpty || configDir == (oldDefault.configDir ?? "") {
+                configDir = newDefault.configDir ?? ""
+            }
+            if settingsFile.isEmpty || settingsFile == (oldDefault.settingsFile ?? "") {
+                settingsFile = newDefault.settingsFile ?? ""
+            }
+            if envFile == (oldDefault.envFile ?? "") {
+                envFile = newDefault.envFile ?? ""
+            }
+            if extraArguments == oldDefault.args.joined(separator: " ") {
+                extraArguments = newDefault.args.joined(separator: " ")
+            }
+            if oldDefault.hookMode == (injectHooks ? .glintOverlay : .disabled) {
+                injectHooks = newDefault.hookMode == .glintOverlay
+            }
+        }
+    }
+
+    private var canSave: Bool {
+        !profileName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && (agent == .terminal || !command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    private var hostOptions: [(id: String, label: String)] {
+        var options = [(id: "local", label: String(localized: "This Mac"))]
+        options += SSHConfigHosts.aliases().map { (id: "ssh:\($0)", label: $0) }
+        if hostID != "local", !options.contains(where: { $0.id == hostID }) {
+            options.append((id: hostID, label: String(hostID.dropFirst("ssh:".count))))
+        }
+        return options
+    }
+
+    private var hostScope: String? {
+        guard hostID != "local" else { return nil }
+        return String(hostID.dropFirst("ssh:".count))
+    }
+
+    private var profilePreview: String {
+        let device = hostScope ?? String(localized: "This Mac")
+        let config = configDir.trimmingCharacters(in: .whitespacesAndNewlines)
+        if config.isEmpty { return "\(agent.displayName) · \(device)" }
+        return "\(agent.displayName) · \(device) · \(config)"
+    }
+
+    @ViewBuilder private func formRow<Content: View>(_ title: String, detail: String,
+                                                      @ViewBuilder content: () -> Content) -> some View {
+        HStack(alignment: .top, spacing: 24) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title).font(.system(size: 13, weight: .medium)).foregroundStyle(Theme.text1)
+                Text(detail).font(.system(size: 11)).foregroundStyle(Theme.text4)
+            }
+            .frame(width: 245, alignment: .leading)
+            Spacer()
+            content()
+        }
+    }
+
+    private func fieldRow(_ title: String, text: Binding<String>, placeholder: String) -> some View {
+        formRow(title, detail: profileFieldHelp(title)) {
+            TextField(placeholder, text: text)
+                .textFieldStyle(.roundedBorder)
+                .frame(width: 300)
+        }
+    }
+
+    private func profileFieldHelp(_ field: String) -> String {
+        switch field {
+        case "Name": return "Reusable label shown when launching sessions."
+        case "Command": return "Executable name or absolute path."
+        case "Config folder": return "Agent account/config state. Codex uses this as CODEX_HOME."
+        case "Settings file": return "Claude settings to merge with Glint's temporary overlay."
+        case "Environment file": return "Optional shell file sourced before launch."
+        default: return "Arguments added before one-off command arguments."
+        }
+    }
+
+    private func load(_ profile: AgentProfile, keepDevice: Bool = false) {
+        agent = profile.agent
+        if !keepDevice {
+            hostID = profile.hostScope.map { "ssh:\($0)" } ?? "local"
+        }
+        profileName = profile.label
+        command = profile.command
+        configDir = profile.configDir ?? ""
+        settingsFile = profile.settingsFile ?? ""
+        envFile = profile.envFile ?? ""
+        extraArguments = profile.args.joined(separator: " ")
+        injectHooks = profile.hookMode == .glintOverlay
+    }
+
+    private func save() {
+        let id = editingID ?? AgentProfileStore.newProfileID(for: agent)
+        let profile = AgentProfile(
+            id: id,
+            label: profileName.trimmingCharacters(in: .whitespacesAndNewlines),
+            agent: agent,
+            hostScope: hostScope,
+            command: agent == .terminal ? "" : command,
+            configDir: agent == .terminal ? nil : nilIfEmpty(configDir),
+            settingsFile: agent == .claude ? nilIfEmpty(settingsFile) : nil,
+            envFile: agent == .terminal ? nil : nilIfEmpty(envFile),
+            args: agent == .terminal ? [] : splitArguments(extraArguments),
+            hookMode: injectHooks && (agent == .claude || agent == .codex) ? .glintOverlay : .disabled
+        )
+        onSave(profile)
+        dismiss()
+    }
+
+    private func profileSort(_ lhs: AgentProfile, _ rhs: AgentProfile) -> Bool {
+        let l = "\(lhs.hostScope ?? "")|\(lhs.agent.rawValue)|\(lhs.label)"
+        let r = "\(rhs.hostScope ?? "")|\(rhs.agent.rawValue)|\(rhs.label)"
+        return l.localizedCaseInsensitiveCompare(r) == .orderedAscending
+    }
+}
+
+private func nilIfEmpty(_ value: String) -> String? {
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+}
+
+private func splitArguments(_ input: String) -> [String] {
+    var result: [String] = [], current = "", quote: Character?, escaped = false
+    for ch in input {
+        if escaped { current.append(ch); escaped = false; continue }
+        if ch == "\\" { escaped = true; continue }
+        if let q = quote {
+            if ch == q { quote = nil } else { current.append(ch) }
+        } else if ch == "'" || ch == "\"" { quote = ch }
+        else if ch.isWhitespace { if !current.isEmpty { result.append(current); current = "" } }
+        else { current.append(ch) }
+    }
+    if escaped { current.append("\\") }
+    if !current.isEmpty { result.append(current) }
+    return result
+}

--- a/Glint/Chrome/SettingsView.swift
+++ b/Glint/Chrome/SettingsView.swift
@@ -125,6 +125,7 @@ struct GlintSettingsView: View {
                     case .general:    GeneralPane()
                     case .appearance: AppearancePane()
                     case .terminal:   TerminalPane()
+                    case .profiles:   ProfilesPane()
                     case .agents:     AgentsPane()
                     case .shortcuts:  ShortcutsPane()
                     case .about:      AboutPane()
@@ -148,7 +149,7 @@ struct GlintSettingsView: View {
 // MARK: - Category model
 
 enum SettingsCategory: String, CaseIterable, Identifiable {
-    case general, appearance, terminal, agents, shortcuts, about
+    case general, appearance, terminal, profiles, agents, shortcuts, about
     var id: String { rawValue }
 
     var title: String {
@@ -156,6 +157,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .general:    return "General"
         case .appearance: return "Appearance"
         case .terminal:   return "Terminal"
+        case .profiles:   return "Profiles"
         case .agents:     return "Agents"
         case .shortcuts:  return "Shortcuts"
         case .about:      return "About"
@@ -166,6 +168,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .general:    return "Startup, layout, updates"
         case .appearance: return "Theme, accent, glass"
         case .terminal:   return "Font, cursor, scrollback"
+        case .profiles:   return "Agent, device, command"
         case .agents:     return "Claude Code, Codex, hook routing"
         case .shortcuts:  return "Keyboard reference"
         case .about:      return nil
@@ -176,6 +179,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .general:    return "gearshape"
         case .appearance: return "paintbrush"
         case .terminal:   return "terminal"
+        case .profiles:   return "person.crop.square"
         case .agents:     return "sparkle"
         case .shortcuts:  return "command"
         case .about:      return "info.circle"
@@ -644,48 +648,145 @@ private struct TerminalPane: View {
     }
 }
 
+private struct ProfilesPane: View {
+    @EnvironmentObject var store: WorkspaceStore
+    @State private var profiles: [AgentProfile] = []
+    @State private var editorSeed = AgentProfile.defaultProfile(for: .codex)
+    @State private var editingID: String?
+    @State private var editorOpen = false
+
+    var body: some View {
+        SettingsCard("Profiles",
+                     footer: "A profile owns the agent, device, command, config folder, environment file, arguments, and hook policy. New workspaces only choose a profile and a working directory.") {
+            SettingsRow("New profile",
+                        subtitle: "Create a reusable launch profile for this Mac or an SSH device.") {
+                Button("New") {
+                    editorSeed = AgentProfile.defaultProfile(for: .codex)
+                    editingID = nil
+                    editorOpen = true
+                }
+                .controlSize(.small)
+                .tint(store.accent)
+            }
+
+            if !profiles.isEmpty {
+                SettingsDivider()
+            }
+
+            ForEach(Array(profiles.enumerated()), id: \.element.id) { index, profile in
+                SettingsRow(profile.displayLabel,
+                            subtitle: profile.summaryLine) {
+                    HStack(spacing: 8) {
+                        if AgentProfileStore.isBuiltInDefault(profile) {
+                            StatusPill(label: "Default", tone: .neutral)
+                        }
+                        Button("Edit") {
+                            editorSeed = profile
+                            editingID = profile.id
+                            editorOpen = true
+                        }
+                        .controlSize(.small)
+                        Button("Duplicate") {
+                            editorSeed = duplicateSeed(from: profile)
+                            editingID = nil
+                            editorOpen = true
+                        }
+                        .controlSize(.small)
+                        Button("Delete", role: .destructive) {
+                            delete(profile)
+                        }
+                        .controlSize(.small)
+                        .disabled(AgentProfileStore.isBuiltInDefault(profile))
+                    }
+                }
+                if index < profiles.count - 1 { SettingsDivider() }
+            }
+        }
+        .onAppear(perform: refresh)
+        .sheet(isPresented: $editorOpen) {
+            AgentProfileEditorView(
+                initialProfile: editorSeed,
+                editingID: editingID,
+                saveTitle: editingID == nil ? "Save Profile" : "Save Changes"
+            ) { profile in
+                AgentProfileStore.save(profile)
+                refresh()
+            }
+            .environmentObject(store)
+        }
+    }
+
+    private func refresh() {
+        profiles = AgentProfileStore.profiles.sorted(by: profileSort)
+    }
+
+    private func duplicateSeed(from profile: AgentProfile) -> AgentProfile {
+        var copy = profile
+        copy.id = AgentProfileStore.newProfileID(for: profile.agent)
+        copy.label = "\(profile.label) Copy"
+        return copy
+    }
+
+    private func delete(_ profile: AgentProfile) {
+        guard !AgentProfileStore.isBuiltInDefault(profile) else { return }
+        AgentProfileStore.delete(profile)
+        refresh()
+    }
+
+    private func profileSort(_ lhs: AgentProfile, _ rhs: AgentProfile) -> Bool {
+        let l = "\(lhs.hostScope ?? "")|\(lhs.agent.rawValue)|\(lhs.label)"
+        let r = "\(rhs.hostScope ?? "")|\(rhs.agent.rawValue)|\(rhs.label)"
+        return l.localizedCaseInsensitiveCompare(r) == .orderedAscending
+    }
+}
+
 private struct AgentsPane: View {
     @EnvironmentObject var store: WorkspaceStore
     @EnvironmentObject var usage: UsageStore
-    @State private var claudeInstallFailed = false
-    @State private var codexInstallFailed = false
-    @State private var opencodeInstallFailed = false
 
     var body: some View {
+        if !store.detachedAgentSessions.isEmpty {
+            SettingsCard("Detached sessions",
+                         footer: "Closing a pane detaches its viewer. The tmux session continues until explicitly killed.") {
+                ForEach(Array(store.detachedAgentSessions.enumerated()), id: \.element.id) { index, session in
+                    SettingsRow(session.tmuxSessionName,
+                                subtitle: session.needsHookTrust
+                                ? "Codex hooks need review: reattach and run /hooks."
+                                : session.workingDirectory) {
+                        HStack(spacing: 8) {
+                            Button("Reattach") { store.reattachSession(session.id) }
+                                .controlSize(.small)
+                            Button("Kill", role: .destructive) { store.killDetachedSession(session.id) }
+                                .controlSize(.small)
+                        }
+                    }
+                    if index < store.detachedAgentSessions.count - 1 { SettingsDivider() }
+                }
+            }
+        }
+
         SettingsCard("Claude Code",
-                     footer: "Glint offers to install a reporter into ~/.claude/settings.json on first launch. Existing hooks are preserved.") {
-            SettingsRow("Status", subtitle: claudeInstallFailed
-                        ? "Install failed — check Console for [glint] logs (often a malformed settings.json)."
-                        : (store.claudeHooksInstalled
-                           ? "Hooks merged into your Claude settings."
-                           : (store.claudeDetected
-                              ? "Claude Code detected — install the reporter to show its status."
-                              : "Claude Code not detected on this Mac."))) {
+                     footer: "Each managed session uses its own temporary settings and wrapper. Glint does not modify ~/.claude/settings.json.") {
+            SettingsRow("Status", subtitle: store.claudeDetected
+                        ? "Temporary hooks are enabled inside Glint managed sessions."
+                        : "Claude Code not detected on this Mac.") {
                 HStack(spacing: 8) {
                     StatusPill(
-                        label: store.claudeHooksInstalled ? "Installed" : (store.claudeDetected ? "Not installed" : "Not detected"),
-                        tone: store.claudeHooksInstalled ? .ok : .neutral
+                        label: store.claudeDetected ? "Per-session" : "Not detected",
+                        tone: store.claudeDetected ? .ok : .neutral
                     )
                     if store.claudeHooksInstalled {
-                        Button("Uninstall") {
+                        Button("Remove legacy hooks") {
                             store.uninstallClaudeHooks()
-                            claudeInstallFailed = false
                         }
-                            .controlSize(.small)
-                    } else {
-                        Button("Install") {
-                            store.installClaudeHooks()
-                            claudeInstallFailed = !store.claudeHooksInstalled
-                        }
-                            .controlSize(.small)
-                            .tint(store.accent)
+                        .controlSize(.small)
                     }
                 }
             }
             SettingsDivider()
             SettingsRow("Hook script",
                         subtitle: "Path of the bash reporter that posts to Glint's local socket.") {
-                Text("~/.glint/hooks/glint-report.sh")
+                Text("~/.cache/glint/sessions/<session-id>/hooks/glint-report.sh")
                     .font(.system(size: 11, design: .monospaced))
                     .foregroundStyle(Theme.text3)
                     .lineLimit(1)
@@ -714,32 +815,20 @@ private struct AgentsPane: View {
         }
 
         SettingsCard("Codex",
-                     footer: "Glint writes its hook entries into ~/.codex/hooks.json so Codex sessions surface the same status as Claude.") {
-            SettingsRow("Status", subtitle: codexInstallFailed
-                        ? "Install failed — check Console for [glint] logs (often a malformed hooks.json)."
-                        : (store.codexHooksInstalled
-                           ? "Hooks merged into your Codex config."
-                           : (store.codexDetected
-                              ? "Codex detected — install the reporter to show its status."
-                              : "Codex not detected on this Mac."))) {
+                     footer: "Managed sessions inject lifecycle hooks with one-run -c overrides. CODEX_HOME and config.toml are left untouched.") {
+            SettingsRow("Status", subtitle: store.codexDetected
+                        ? "Per-session hooks supported. Review them once with /hooks when Codex asks."
+                        : "Codex not detected on this Mac.") {
                 HStack(spacing: 8) {
                     StatusPill(
-                        label: store.codexHooksInstalled ? "Installed" : (store.codexDetected ? "Not installed" : "Not detected"),
-                        tone: store.codexHooksInstalled ? .ok : .neutral
+                        label: store.codexDetected ? "Per-session" : "Not detected",
+                        tone: store.codexDetected ? .ok : .neutral
                     )
                     if store.codexHooksInstalled {
-                        Button("Uninstall") {
+                        Button("Remove legacy hooks") {
                             store.uninstallCodexHooks()
-                            codexInstallFailed = false
                         }
-                            .controlSize(.small)
-                    } else {
-                        Button("Install") {
-                            store.installCodexHooks()
-                            codexInstallFailed = !store.codexHooksInstalled
-                        }
-                            .controlSize(.small)
-                            .tint(store.accent)
+                        .controlSize(.small)
                     }
                 }
             }
@@ -758,32 +847,20 @@ private struct AgentsPane: View {
         }
 
         SettingsCard("OpenCode",
-                     footer: "Glint installs a global OpenCode plugin at ~/.config/opencode/plugins/glint-agent-bridge.js so OpenCode sessions can report status without being shown as Claude.") {
-            SettingsRow("Status", subtitle: opencodeInstallFailed
-                        ? "Install failed — check Console for [glint] logs."
-                        : (store.opencodeHooksInstalled
-                           ? "Plugin installed into your OpenCode plugins directory."
-                           : (store.opencodeDetected
-                              ? "OpenCode detected — install the plugin to show its status."
-                              : "OpenCode not detected on this Mac."))) {
+                     footer: "OpenCode managed sessions currently use terminal-only fallback. Glint does not install a global plugin.") {
+            SettingsRow("Status", subtitle: store.opencodeDetected
+                        ? "Available as a managed terminal session; status hooks are not enabled yet."
+                        : "OpenCode not detected on this Mac.") {
                 HStack(spacing: 8) {
                     StatusPill(
-                        label: store.opencodeHooksInstalled ? "Installed" : (store.opencodeDetected ? "Not installed" : "Not detected"),
-                        tone: store.opencodeHooksInstalled ? .ok : .neutral
+                        label: store.opencodeDetected ? "Terminal only" : "Not detected",
+                        tone: .neutral
                     )
                     if store.opencodeHooksInstalled {
-                        Button("Uninstall") {
+                        Button("Remove legacy plugin") {
                             store.uninstallOpenCodeHooks()
-                            opencodeInstallFailed = false
                         }
-                            .controlSize(.small)
-                    } else {
-                        Button("Install") {
-                            store.installOpenCodeHooks()
-                            opencodeInstallFailed = !store.opencodeHooksInstalled
-                        }
-                            .controlSize(.small)
-                            .tint(store.accent)
+                        .controlSize(.small)
                     }
                 }
             }
@@ -792,15 +869,6 @@ private struct AgentsPane: View {
                         subtitle: "When Glint reopens, run `opencode --continue` in any pane that was running OpenCode at last quit.") {
                 Toggle("", isOn: $store.restoreOpenCodeSession)
                     .toggleStyle(.switch).labelsHidden()
-            }
-            SettingsDivider()
-            SettingsRow("Plugin file",
-                        subtitle: "Loaded by OpenCode automatically on startup; it only reports when Glint's pane environment variables are present.") {
-                Text("~/.config/opencode/plugins/glint-agent-bridge.js")
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundStyle(Theme.text3)
-                    .lineLimit(1)
-                    .truncationMode(.head)
             }
         }
 

--- a/Glint/Chrome/SidebarView.swift
+++ b/Glint/Chrome/SidebarView.swift
@@ -196,7 +196,7 @@ struct SidebarView: View {
 
     private var newWorkspaceCard: some View {
         Button {
-            store.addWorkspace()
+            store.newWorkspaceSessionOpen = true
         } label: {
             HStack(spacing: 10) {
                 Image(systemName: "plus")
@@ -697,7 +697,7 @@ private struct WorkspaceCard: View {
                 }
             } else {
                 Button("Rename") { startEditing() }
-                Button("New Workspace") { store.addWorkspace() }
+                Button("New Workspace") { store.newWorkspaceSessionOpen = true }
                 Divider()
                 Button("Archive") { store.archiveWorkspace(ws.id) }
                 Button("Delete Workspace", role: .destructive) {
@@ -871,12 +871,23 @@ private struct WorkspaceCard: View {
 
     private func workspaceMetadataRow(active: Bool) -> some View {
         HStack(spacing: 5) {
-            if let tabs = tabCountText {
-                metadataBadge(tabs, active: active)
+            ForEach(workspaceMetadataBadges, id: \.self) { badge in
+                metadataBadge(badge, active: active)
             }
-            metadataBadge(paneCountText, active: active)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var workspaceMetadataBadges: [String] {
+        let selectedPaneCount = ws.selectedTab?.root.leaves.count ?? ws.panes.count
+        if ws.tabs.count > 1 {
+            return [
+                "\(ws.tabs.count) \(String(localized: "tabs"))",
+                "\(selectedPaneCount)/\(ws.panes.count) \(String(localized: "panes"))",
+            ]
+        }
+        let unit = String(localized: selectedPaneCount == 1 ? "pane" : "panes")
+        return ["\(selectedPaneCount) \(unit)"]
     }
 
     private func metadataBadge(_ text: String, active: Bool) -> some View {
@@ -1017,25 +1028,7 @@ private struct WorkspaceCard: View {
     }
 
     private var cwdLine: String {
-        // Surface the tab count only once it's meaningful (>1), so single-tab
-        // workspaces read exactly as before.
-        if let tabs = tabCountText {
-            return "\(tabs) · \(paneCountText)"
-        }
-        return paneCountText
-    }
-
-    private var paneCountText: String {
-        let n = ws.panes.count
-        let unit = String(localized: n == 1 ? "pane" : "panes")
-        return "\(n) \(unit)"
-    }
-
-    private var tabCountText: String? {
-        let n = ws.tabs.count
-        guard n > 1 else { return nil }
-        let unit = String(localized: "tabs")
-        return "\(n) \(unit)"
+        ws.detailLine
     }
 
     /// Spoken description for VoiceOver: the agent-status text the card

--- a/Glint/Pane/GhosttySurfaceView.swift
+++ b/Glint/Pane/GhosttySurfaceView.swift
@@ -34,6 +34,7 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
     /// starts at the divider, not 3 blank rows below it.
     private let topAligned: Bool
     private let agentSocketPath: String?
+    private let extraEnvironment: [String: String]
     /// Optional text fed into the PTY as if typed by the user at the start of
     /// the session — ghostty handles the timing (waits until the shell is
     /// ready). Used to auto-resume `claude --continue` / `codex resume --last`
@@ -100,11 +101,13 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
          initialCwd: String? = nil,
          paneKey: String? = nil,
          agentSocketPath: String? = nil,
+         extraEnvironment: [String: String] = [:],
          topAligned: Bool = true,
          initialInput: String? = nil) {
         self.initialCwd = initialCwd
         self.paneKey = paneKey
         self.agentSocketPath = agentSocketPath
+        self.extraEnvironment = extraEnvironment
         self.topAligned = topAligned
         self.initialInput = initialInput
         super.init(frame: frame)
@@ -303,6 +306,9 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
         var envPairs: [(UnsafeMutablePointer<CChar>, UnsafeMutablePointer<CChar>)] = []
         if let pk = paneKey { envPairs.append((strdup("GLINT_PANE_ID"), strdup(pk))) }
         if let sock = agentSocketPath { envPairs.append((strdup("GLINT_AGENT_SOCK"), strdup(sock))) }
+        for (key, value) in extraEnvironment {
+            envPairs.append((strdup(key), strdup(value)))
+        }
         defer { envPairs.forEach { free($0.0); free($0.1) } }
 
         // Reserve a top inset for the floating-island header when this pane

--- a/Glint/Pane/GhosttySurfaceView.swift
+++ b/Glint/Pane/GhosttySurfaceView.swift
@@ -303,10 +303,12 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
 
         // Env vars for CLI-agent hooks (Claude Code etc.) — same strdup
         // discipline; ghostty copies the array during surface_new.
+        var mergedEnvironment = extraEnvironment
+        if let pk = paneKey { mergedEnvironment["GLINT_PANE_ID"] = pk }
+        if let sock = agentSocketPath { mergedEnvironment["GLINT_AGENT_SOCK"] = sock }
         var envPairs: [(UnsafeMutablePointer<CChar>, UnsafeMutablePointer<CChar>)] = []
-        if let pk = paneKey { envPairs.append((strdup("GLINT_PANE_ID"), strdup(pk))) }
-        if let sock = agentSocketPath { envPairs.append((strdup("GLINT_AGENT_SOCK"), strdup(sock))) }
-        for (key, value) in extraEnvironment {
+        for key in mergedEnvironment.keys.sorted() {
+            guard let value = mergedEnvironment[key] else { continue }
             envPairs.append((strdup(key), strdup(value)))
         }
         defer { envPairs.forEach { free($0.0); free($0.1) } }

--- a/Glint/Pane/PaneView.swift
+++ b/Glint/Pane/PaneView.swift
@@ -19,7 +19,8 @@ struct PaneView: View {
            let pane = ws.panes[paneID] {
             paneBody(workspaceID: wsID,
                      focusedPane: ws.selectedTab?.focusedPane ?? paneID,
-                     cwd: pane.workingDirectory)
+                     cwd: pane.workingDirectory,
+                     session: pane.agentSession)
         } else {
             Theme.bgPane
         }
@@ -27,7 +28,8 @@ struct PaneView: View {
 
     private func paneBody(workspaceID: UUID,
                           focusedPane: PaneID,
-                          cwd: String?) -> some View {
+                          cwd: String?,
+                          session: AgentSession?) -> some View {
         if ProcessInfo.processInfo.environment["GLINT_LOG_VISIBLE"] != nil {
             NSLog("[glint.visible] PaneView.body pane=\(paneID.value) ws=\(workspaceID.uuidString.prefix(8))")
         }
@@ -40,6 +42,16 @@ struct PaneView: View {
             )
             if !isFocused {
                 Theme.bgPane.opacity(0.45)
+                    .allowsHitTesting(false)
+            }
+            if session?.needsHookTrust == true {
+                Label("Run /hooks to trust Glint status hooks", systemImage: "checkmark.shield")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(Color.orange)
+                    .padding(.horizontal, 10).padding(.vertical, 6)
+                    .background(.ultraThinMaterial, in: Capsule())
+                    .padding(12)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
                     .allowsHitTesting(false)
             }
         }

--- a/Glint/Resources/Localizable.xcstrings
+++ b/Glint/Resources/Localizable.xcstrings
@@ -1,6 +1,600 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "A profile owns the agent, device, command, config folder, environment file, arguments, and hook policy. New workspaces only choose a profile and a working directory." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Profile 保存 Agent、设备、命令、配置目录、环境文件、参数和 hook 策略。新建工作区时只需要选择 Profile 和工作目录。"
+          }
+        }
+      }
+    },
+    "A reusable label for this agent profile." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "这个 Agent Profile 的可复用名称。"
+          }
+        }
+      }
+    },
+    "Agent" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agent"
+          }
+        }
+      }
+    },
+    "Agent account/config state. Codex uses this as CODEX_HOME." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agent 账号/配置状态目录。Codex 会把它作为 CODEX_HOME。"
+          }
+        }
+      }
+    },
+    "Agent account/config state; not the project directory." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agent 的账号/配置状态目录，不是项目目录。"
+          }
+        }
+      }
+    },
+    "Agent, device, command" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agent、设备、命令"
+          }
+        }
+      }
+    },
+    "Agent, device, command, and config live in profiles." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agent、设备、命令和配置都在 Profile 里管理。"
+          }
+        }
+      }
+    },
+    "Arguments added before one-off command arguments." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加到一次性命令参数之前的参数。"
+          }
+        }
+      }
+    },
+    "Choose the CLI this profile launches." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择这个 Profile 要启动的 CLI。"
+          }
+        }
+      }
+    },
+    "Choose the first session for a new workspace." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "为新工作区选择第一个会话。"
+          }
+        }
+      }
+    },
+    "Choose…" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择…"
+          }
+        }
+      }
+    },
+    "Claude settings to merge with Glint's temporary overlay." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要与 Glint 临时覆盖配置合并的 Claude 设置。"
+          }
+        }
+      }
+    },
+    "Codex asks you to trust generated hooks once with /hooks." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Codex 会要求你用 /hooks 信任一次生成的 hooks。"
+          }
+        }
+      }
+    },
+    "Command" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "命令"
+          }
+        }
+      }
+    },
+    "Config folder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "配置目录"
+          }
+        }
+      }
+    },
+    "Create Profile" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "创建 Profile"
+          }
+        }
+      }
+    },
+    "Create Session" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "创建会话"
+          }
+        }
+      }
+    },
+    "Create Workspace" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "创建工作区"
+          }
+        }
+      }
+    },
+    "Create a reusable launch profile for this Mac or an SSH device." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "为本机或 SSH 设备创建可复用启动 Profile。"
+          }
+        }
+      }
+    },
+    "Default" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "默认"
+          }
+        }
+      }
+    },
+    "Delete" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除"
+          }
+        }
+      }
+    },
+    "Device" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设备"
+          }
+        }
+      }
+    },
+    "Duplicate" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制"
+          }
+        }
+      }
+    },
+    "Edit" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "编辑"
+          }
+        }
+      }
+    },
+    "Edit Profile" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "编辑 Profile"
+          }
+        }
+      }
+    },
+    "Environment file" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "环境文件"
+          }
+        }
+      }
+    },
+    "Executable name or absolute path." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可执行文件名或绝对路径。"
+          }
+        }
+      }
+    },
+    "Extra arguments" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "额外参数"
+          }
+        }
+      }
+    },
+    "First launch may require /hooks trust" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "首次启动可能需要信任 /hooks"
+          }
+        }
+      }
+    },
+    "Inject Glint hooks" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "注入 Glint hooks"
+          }
+        }
+      }
+    },
+    "Injected only into managed sessions." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "只注入到托管会话中。"
+          }
+        }
+      }
+    },
+    "Launch a profile in a persistent tmux session." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用持久 tmux 会话启动一个 Profile。"
+          }
+        }
+      }
+    },
+    "Launch profile" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启动 Profile"
+          }
+        }
+      }
+    },
+    "Name" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名称"
+          }
+        }
+      }
+    },
+    "New" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新建"
+          }
+        }
+      }
+    },
+    "New Agent Session" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新建 Agent 会话"
+          }
+        }
+      }
+    },
+    "New Profile" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新建 Profile"
+          }
+        }
+      }
+    },
+    "New profile" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新建 Profile"
+          }
+        }
+      }
+    },
+    "Optional shell env file" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可选 shell 环境文件"
+          }
+        }
+      }
+    },
+    "Optional shell file sourced before launch." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启动前可选 source 的 shell 文件。"
+          }
+        }
+      }
+    },
+    "Profile" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Profile"
+          }
+        }
+      }
+    },
+    "Profiles" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Profiles"
+          }
+        }
+      }
+    },
+    "Profiles define agent, device, command, and config home." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Profile 定义 Agent、设备、命令和配置目录。"
+          }
+        }
+      }
+    },
+    "Remote devices come from ~/.ssh/config." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "远端设备来自 ~/.ssh/config。"
+          }
+        }
+      }
+    },
+    "Reusable label shown when launching sessions." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启动会话时显示的可复用名称。"
+          }
+        }
+      }
+    },
+    "Save Changes" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存更改"
+          }
+        }
+      }
+    },
+    "Save Profile" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存 Profile"
+          }
+        }
+      }
+    },
+    "Separate from the profile/config folder." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "与 Profile/配置目录分开。"
+          }
+        }
+      }
+    },
+    "Settings file" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置文件"
+          }
+        }
+      }
+    },
+    "Start from an existing profile." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从已有 Profile 开始。"
+          }
+        }
+      }
+    },
+    "Status hooks" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "状态 hooks"
+          }
+        }
+      }
+    },
+    "This Mac" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本机"
+          }
+        }
+      }
+    },
+    "Working directory" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "工作目录"
+          }
+        }
+      }
+    },
+    "hooks" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "hooks"
+          }
+        }
+      }
+    },
     "External control" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -57,16 +651,44 @@
       }
     },
     "—" : {
-
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "—"
+          }
+        }
+      }
     },
     "· %@" : {
-
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "· %@"
+          }
+        }
+      }
     },
     "%@" : {
-
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@"
+          }
+        }
+      }
     },
     "%@%%" : {
-
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@%%"
+          }
+        }
+      }
     },
     "%d of its panes still have something running; everything in this workspace will be terminated." : {
       "extractionState" : "stale",
@@ -91,16 +713,44 @@
       }
     },
     "+%@" : {
-
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "+%@"
+          }
+        }
+      }
     },
     "~/.glint/hooks/glint-report.sh" : {
-
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "~/.glint/hooks/glint-report.sh"
+          }
+        }
+      }
     },
     "⌘N" : {
-
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⌘N"
+          }
+        }
+      }
     },
     "⌘T" : {
-
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⌘T"
+          }
+        }
+      }
     },
     "── session restored ──" : {
       "extractionState" : "manual",
@@ -1288,7 +1938,14 @@
       }
     },
     "New Tab" : {
-
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新建标签页"
+          }
+        }
+      }
     },
     "New Workspace" : {
       "localizations" : {
@@ -1323,7 +1980,14 @@
       }
     },
     "No results" : {
-
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无结果"
+          }
+        }
+      }
     },
     "Not installed" : {
       "extractionState" : "stale",
@@ -2264,7 +2928,14 @@
       }
     },
     "TABS" : {
-
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "标签页"
+          }
+        }
+      }
     },
     "Terminal" : {
       "extractionState" : "stale",

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -78,16 +78,21 @@ struct Pane: Identifiable, Codable {
     /// `restoreClaudeSession` / `restoreCodexSession`. Reflects the CURRENT
     /// state, not sticky: an agent that quit back to the shell clears it.
     var lastAgent: String?
+    /// Stable managed runtime identity. The tmux process outlives the viewer
+    /// surface, so closing/reopening Glint reattaches instead of restarting it.
+    var agentSession: AgentSession?
 
     private enum CodingKeys: String, CodingKey {
-        case id, title, workingDirectory, lastAgent
+        case id, title, workingDirectory, lastAgent, agentSession
     }
 
-    init(id: PaneID, title: String, workingDirectory: String? = nil, lastAgent: String? = nil) {
+    init(id: PaneID, title: String, workingDirectory: String? = nil, lastAgent: String? = nil,
+         agentSession: AgentSession? = nil) {
         self.id = id
         self.title = title
         self.workingDirectory = workingDirectory
         self.lastAgent = lastAgent
+        self.agentSession = agentSession
     }
 
     init(from decoder: Decoder) throws {
@@ -96,6 +101,7 @@ struct Pane: Identifiable, Codable {
         self.title = try c.decode(String.self, forKey: .title)
         self.workingDirectory = try c.decodeIfPresent(String.self, forKey: .workingDirectory)
         self.lastAgent = try c.decodeIfPresent(String.self, forKey: .lastAgent)
+        self.agentSession = try c.decodeIfPresent(AgentSession.self, forKey: .agentSession)
     }
 }
 
@@ -233,16 +239,19 @@ struct PersistedState: Codable {
     var workspaces: [Workspace]
     var selectedWorkspaceID: UUID?
     var sidebarCollapsed: Bool
+    var detachedAgentSessions: [AgentSession]
 
-    init(workspaces: [Workspace], selectedWorkspaceID: UUID?, sidebarCollapsed: Bool) {
+    init(workspaces: [Workspace], selectedWorkspaceID: UUID?, sidebarCollapsed: Bool,
+         detachedAgentSessions: [AgentSession] = []) {
         self.version = Self.currentVersion
         self.workspaces = workspaces
         self.selectedWorkspaceID = selectedWorkspaceID
         self.sidebarCollapsed = sidebarCollapsed
+        self.detachedAgentSessions = detachedAgentSessions
     }
 
     private enum CodingKeys: String, CodingKey {
-        case version, workspaces, selectedWorkspaceID, sidebarCollapsed
+        case version, workspaces, selectedWorkspaceID, sidebarCollapsed, detachedAgentSessions
     }
 
     init(from decoder: Decoder) throws {
@@ -253,6 +262,7 @@ struct PersistedState: Codable {
         self.workspaces = try c.decode([Workspace].self, forKey: .workspaces)
         self.selectedWorkspaceID = try c.decodeIfPresent(UUID.self, forKey: .selectedWorkspaceID)
         self.sidebarCollapsed = try c.decodeIfPresent(Bool.self, forKey: .sidebarCollapsed) ?? false
+        self.detachedAgentSessions = try c.decodeIfPresent([AgentSession].self, forKey: .detachedAgentSessions) ?? []
     }
 
     static var fresh: PersistedState {
@@ -316,6 +326,19 @@ extension Workspace {
         return "\(display)\n\(cwd)"
     }
 
+    /// Compact metadata for workspace rows. Panes are workspace-global, while
+    /// tabs each own their own tree, so multi-tab workspaces show the selected
+    /// tab's pane count over the workspace total to keep the two concepts
+    /// visually distinct.
+    var detailLine: String {
+        let selectedPaneCount = selectedTab?.root.leaves.count ?? panes.count
+        let paneUnit = String(localized: selectedPaneCount == 1 ? "pane" : "panes")
+        guard tabs.count > 1 else { return "\(selectedPaneCount) \(paneUnit)" }
+        let tabUnit = String(localized: "tabs")
+        let totalPaneUnit = String(localized: "panes")
+        return "\(tabs.count) \(tabUnit) · \(selectedPaneCount)/\(panes.count) \(totalPaneUnit)"
+    }
+
     private func tabCwd(_ tab: WorkspaceTab) -> String? {
         panes[tab.focusedPane]?.workingDirectory
             ?? tab.root.leaves.compactMap { panes[$0]?.workingDirectory }.first
@@ -372,6 +395,9 @@ final class WorkspaceStore: ObservableObject {
     @Published var workspaces: [Workspace]
     @Published var selectedWorkspaceID: UUID?
     @Published var sidebarCollapsed: Bool
+    /// Managed tmux sessions with no current viewer pane. They remain alive
+    /// and can be reattached or explicitly killed by the user.
+    @Published var detachedAgentSessions: [AgentSession]
     /// Latest foreground-process name per (workspace, pane). Polled every
     /// few seconds; drives the workspace card icon. Non-persistent.
     @Published var paneProcesses: [WorkspacePaneKey: String] = [:]
@@ -380,6 +406,10 @@ final class WorkspaceStore: ObservableObject {
     /// status (thinking/permission/…) the 1s name poll can't know.
     /// Non-persistent.
     @Published var paneAgentState: [WorkspacePaneKey: PaneAgentState] = [:]
+    /// Authoritative state keyed by stable managed-session identity. Pane
+    /// state above is the current viewer projection kept for existing UI.
+    @Published var agentSessionState: [String: PaneAgentState] = [:]
+    @Published var agentTransportState: [String: AgentTransportState] = [:]
 
     /// Drives the command-palette overlay. Toggled by the toolbar's ⌘
     /// button and the ⌘⇧P global shortcut.
@@ -390,6 +420,8 @@ final class WorkspaceStore: ObservableObject {
     /// inherits the workspace context and feels of-the-app rather than
     /// of-the-OS.
     @Published var settingsOpen: Bool = false
+    @Published var newAgentSessionOpen: Bool = false
+    @Published var newWorkspaceSessionOpen: Bool = false
 
     /// Tick incremented whenever the global ⌘F is fired. `SidebarView`
     /// observes this and pulls focus into its search field. Using a tick
@@ -466,15 +498,12 @@ final class WorkspaceStore: ObservableObject {
         }
     }
 
-    /// Whether Glint's Claude Code hook script is currently registered in
-    /// `~/.claude/settings.json`. Mirrors `AgentHookInstaller.isInstalled()`
-    /// so the Settings UI can react without polling.
+    /// Legacy global integrations are detected only so Settings can remove
+    /// them. Managed sessions never install or refresh these entries.
     @Published var claudeHooksInstalled: Bool = false
 
-    /// Whether Glint's Codex hook script is registered in `~/.codex/hooks.json`.
     @Published var codexHooksInstalled: Bool = false
 
-    /// Whether Glint's OpenCode plugin is installed in `~/.config/opencode/plugins`.
     @Published var opencodeHooksInstalled: Bool = false
 
     /// Whether Glint's modified-Enter shell keybindings are present in the
@@ -652,118 +681,16 @@ final class WorkspaceStore: ObservableObject {
         didSet { UserDefaults.standard.set(!warnBeforeUnsafePaste, forKey: "glint.skipUnsafePasteConfirmation") }
     }
 
-    /// Offer to install both agents' hooks on the very first launch so
-    /// status tracking works out of the box — but ask first (these write
-    /// into another tool's config files), and ask exactly once. "Not Now"
-    /// never re-prompts and launches never silently re-add the entries;
-    /// the Settings → Install button is the only way back in.
-    ///
-    /// For agents that remain installed, Glint-owned hook entries are
-    /// refreshed every launch — script-body and event-list updates shipped
-    /// with new Glint versions must propagate even though the prompt is
-    /// skipped.
-    private struct AgentHookSpec {
-        let handledKey: String
-        let displayName: String
-        let isPresent: () -> Bool
-        let isInstalled: () -> Bool
-        let install: () -> Void
-    }
-
-    private static func agentHookSpecs(socketPath: String) -> [AgentHookSpec] {
-        [
-            AgentHookSpec(
-                handledKey: "glint.claudeHooksAutoInstalled",
-                displayName: "Claude Code",
-                isPresent: AgentHookInstaller.isAgentPresent,
-                isInstalled: AgentHookInstaller.isInstalled,
-                install: { AgentHookInstaller.installIfNeeded(socketPath: socketPath) }
-            ),
-            AgentHookSpec(
-                handledKey: "glint.codexHooksAutoInstalled",
-                displayName: "Codex",
-                isPresent: CodexHookInstaller.isAgentPresent,
-                isInstalled: CodexHookInstaller.isInstalled,
-                install: { CodexHookInstaller.installIfNeeded(socketPath: socketPath) }
-            ),
-            AgentHookSpec(
-                handledKey: "glint.opencodeHooksAutoInstalled",
-                displayName: "OpenCode",
-                isPresent: OpenCodeHookInstaller.isAgentPresent,
-                isInstalled: OpenCodeHookInstaller.isInstalled,
-                install: { OpenCodeHookInstaller.installIfNeeded(socketPath: socketPath) }
-            ),
-        ]
-    }
-
-    private static func autoInstallAgentHooksOnFirstLaunch(socketPath: String) {
-        let defaults = UserDefaults.standard
-        let specs = agentHookSpecs(socketPath: socketPath)
-
-        // Refresh hooks we already manage so script-body / event-list changes
-        // shipped with a new Glint version propagate even when the prompt is
-        // skipped.
-        for spec in specs where defaults.bool(forKey: spec.handledKey) && spec.isInstalled() {
-            spec.install()
-        }
-
-        // Only offer to install for agents the user actually has on this Mac
-        // AND we haven't asked about yet. Absent agents are deliberately NOT
-        // marked handled, so if one is installed later we'll offer hooks for
-        // it on a future launch instead of blindly writing config for tools
-        // that aren't there.
-        let pending = specs.filter { !defaults.bool(forKey: $0.handledKey) && $0.isPresent() }
-        guard !pending.isEmpty else { return }
-
-        // Defer past launch so the alert doesn't pop before the main window.
-        Task { @MainActor in
-            let names = pending.map(\.displayName)
-            let list = ListFormatter.localizedString(byJoining: names)
-            let alert = NSAlert()
-            alert.messageText = String(localized: "Show agent status in the sidebar?")
-            alert.informativeText = String(
-                format: String(localized: "Glint can register status hooks with %@ that report when an agent is thinking, finished, or waiting for approval. They only send events to Glint on this Mac. You can uninstall them anytime in Settings → Agents."),
-                list
-            )
-            alert.addButton(withTitle: String(localized: "Install Hooks"))
-            alert.addButton(withTitle: String(localized: "Not Now"))
-            let install = alert.runModal() == .alertFirstButtonReturn
-            for spec in pending {
-                if install { spec.install() }
-                defaults.set(true, forKey: spec.handledKey)
-            }
-            WorkspaceStore.current?.claudeHooksInstalled = AgentHookInstaller.isInstalled()
-            WorkspaceStore.current?.codexHooksInstalled = CodexHookInstaller.isInstalled()
-            WorkspaceStore.current?.opencodeHooksInstalled = OpenCodeHookInstaller.isInstalled()
-        }
-    }
-
-    /// Re-run the hook installer and refresh `claudeHooksInstalled`.
-    func installClaudeHooks() {
-        AgentHookInstaller.installIfNeeded(socketPath: AgentBridge.shared.socketPath)
-        self.claudeHooksInstalled = AgentHookInstaller.isInstalled()
-    }
-
     /// Remove Glint's hook entries from Claude's settings and delete the
-    /// script. Idempotent.
+    /// legacy script. Idempotent.
     func uninstallClaudeHooks() {
         AgentHookInstaller.uninstall()
         self.claudeHooksInstalled = AgentHookInstaller.isInstalled()
     }
 
-    func installCodexHooks() {
-        CodexHookInstaller.installIfNeeded(socketPath: AgentBridge.shared.socketPath)
-        self.codexHooksInstalled = CodexHookInstaller.isInstalled()
-    }
-
     func uninstallCodexHooks() {
         CodexHookInstaller.uninstall()
         self.codexHooksInstalled = CodexHookInstaller.isInstalled()
-    }
-
-    func installOpenCodeHooks() {
-        OpenCodeHookInstaller.installIfNeeded(socketPath: AgentBridge.shared.socketPath)
-        self.opencodeHooksInstalled = OpenCodeHookInstaller.isInstalled()
     }
 
     func uninstallOpenCodeHooks() {
@@ -834,6 +761,7 @@ final class WorkspaceStore: ObservableObject {
             self.selectedWorkspaceID = restored
         }
         self.sidebarCollapsed = loaded.sidebarCollapsed
+        self.detachedAgentSessions = loaded.detachedAgentSessions
         Self.current = self
 
         // Debounced autosave: any @Published change → save 0.5s later.
@@ -923,7 +851,8 @@ final class WorkspaceStore: ObservableObject {
         // docs/external-pane-control.md. Toggling it later is live.
         if externalControlEnabled { ControlBridge.shared.start() }
         else { ControlBridge.shared.reapStale() }
-        Self.autoInstallAgentHooksOnFirstLaunch(socketPath: AgentBridge.shared.socketPath)
+        // Claude/Codex hooks are now session-scoped and generated when a pane
+        // launches. Never auto-write either tool's global configuration.
         self.claudeHooksInstalled = AgentHookInstaller.isInstalled()
         self.codexHooksInstalled = CodexHookInstaller.isInstalled()
         self.opencodeHooksInstalled = OpenCodeHookInstaller.isInstalled()
@@ -973,6 +902,26 @@ final class WorkspaceStore: ObservableObject {
             NSLog("[glint.visible] MINT surface ws=\(workspaceID.uuidString.prefix(8)) pane=\(paneID.value) inModel=\(known)")
         }
         let paneKey = "\(workspaceID.uuidString):\(paneID.value)"
+        let session = workspaces.first(where: { $0.id == workspaceID })?.panes[paneID]?.agentSession
+        let launch: ManagedSessionLaunch? = {
+            guard let session else { return nil }
+            do {
+                let prepared = try AgentSessionManager.shared.prepare(
+                    session, paneKey: paneKey, bridgeSocket: AgentBridge.shared.socketPath
+                )
+                agentTransportState[session.id] = {
+                    switch session.host { case .local: return .local; case .ssh: return .reconnecting }
+                }()
+                return prepared
+            } catch {
+                agentTransportState[session.id] = .unreachable
+                NSLog("[glint] managed session \(session.id) preparation failed: \(error)")
+                return ManagedSessionLaunch(
+                    environment: [:],
+                    initialInput: "printf '\\nGlint failed to prepare this managed session. Check Console for details.\\n' >&2\n"
+                )
+            }
+        }()
         // Only top-edge panes need the padded launcher (clear + blank rows
         // to escape the floating header). A pane sitting below a vertical
         // split divider already starts mid-window, so padding leaves empty
@@ -999,13 +948,18 @@ final class WorkspaceStore: ObservableObject {
             default: return nil
             }
         }()
+        let initialInput = launch?.initialInput ?? restoreCommand
         let v = GhosttySurfaceView(
             frame: .zero,
             initialCwd: cwd,
             paneKey: paneKey,
-            agentSocketPath: AgentBridge.shared.socketPath,
+            // Hook routing is a managed-session concern. Plain panes receive
+            // no socket, so a globally configured third-party hook cannot
+            // accidentally report ordinary CLI use into Glint.
+            agentSocketPath: nil,
+            extraEnvironment: launch?.environment ?? [:],
             topAligned: topAligned,
-            initialInput: restoreCommand
+            initialInput: initialInput
         )
         surfaceViews[key] = v
         return v
@@ -1131,9 +1085,18 @@ final class WorkspaceStore: ObservableObject {
     /// once we wire `data` through.
     func handleAgentEvent(_ info: [AnyHashable: Any]?) {
         guard let info,
-              let paneStr = info["pane"] as? String,
-              let hook = info["hook"] as? String,
-              let key = Self.parsePaneKey(paneStr) else { return }
+              let hook = info["hook"] as? String else { return }
+        let sessionID = info["session"] as? String
+        let sessionKey: WorkspacePaneKey? = sessionID.flatMap { id in
+            for ws in workspaces {
+                if let pane = ws.panes.first(where: { $0.value.agentSession?.id == id })?.key {
+                    return WorkspacePaneKey(workspace: ws.id, pane: pane)
+                }
+            }
+            return nil
+        }
+        let paneKey = (info["pane"] as? String).flatMap(Self.parsePaneKey)
+        guard let key = sessionKey ?? paneKey else { return }
 
         let explicitKind = (info["agent"] as? String).flatMap(Self.agentKind(named:))
         let foregroundKind = surfaceViews[key]?.foregroundProcessName()
@@ -1144,7 +1107,8 @@ final class WorkspaceStore: ObservableObject {
         // empty token), so an unresolvable kind means "a hook fired for a pane
         // we can't otherwise classify" — better to show an agent than to drop
         // the event and leave the pane looking like a bare shell.
-        let kind = explicitKind ?? paneAgentState[key]?.kind ?? foregroundKind ?? polledKind ?? .claude
+        let kind = explicitKind ?? sessionID.flatMap { agentSessionState[$0]?.kind }
+            ?? paneAgentState[key]?.kind ?? foregroundKind ?? polledKind ?? .claude
 
         // Note: we deliberately do NOT force-write paneProcesses here. The
         // 1s poller owns that dictionary and replaces it wholesale, so any
@@ -1152,7 +1116,7 @@ final class WorkspaceStore: ObservableObject {
         // already prefer paneAgentState (set below), which this event keeps
         // authoritative.
 
-        var state = paneAgentState[key]
+        var state = sessionID.flatMap { agentSessionState[$0] } ?? paneAgentState[key]
             ?? PaneAgentState(kind: kind, status: .idle, detail: nil, updatedAt: Date())
         state.kind = kind
         let oldStatus = state.status
@@ -1215,6 +1179,19 @@ final class WorkspaceStore: ObservableObject {
         }
         state.updatedAt = now
         paneAgentState[key] = state
+        if let sessionID {
+            agentSessionState[sessionID] = state
+            if agentTransportState[sessionID] != .local {
+                agentTransportState[sessionID] = .connected
+            }
+            if kind == .codex, let key = sessionKey,
+               let wi = workspaces.firstIndex(where: { $0.id == key.workspace }),
+               var session = workspaces[wi].panes[key.pane]?.agentSession,
+               session.needsHookTrust {
+                session.needsHookTrust = false
+                workspaces[wi].panes[key.pane]?.agentSession = session
+            }
+        }
 
         // Audio cues fire whenever the user is NOT actively watching this
         // pane — that means Glint isn't the frontmost app, or the user is on
@@ -1313,7 +1290,8 @@ final class WorkspaceStore: ObservableObject {
         let state = PersistedState(
             workspaces: workspaces,
             selectedWorkspaceID: selectedWorkspaceID,
-            sidebarCollapsed: sidebarCollapsed
+            sidebarCollapsed: sidebarCollapsed,
+            detachedAgentSessions: detachedAgentSessions
         )
         Persistence.save(state)
     }
@@ -1406,6 +1384,11 @@ final class WorkspaceStore: ObservableObject {
     /// with a live session (even an idle one — closing kills the session),
     /// or any non-shell foreground process (vim, ssh, a build, …).
     func paneNeedsCloseConfirmation(_ key: WorkspacePaneKey) -> Bool {
+        // A managed pane is only a tmux viewer. Dropping its surface detaches
+        // the client and cannot terminate the process running in tmux.
+        if workspaces.first(where: { $0.id == key.workspace })?.panes[key.pane]?.agentSession != nil {
+            return false
+        }
         if paneAgentState[key] != nil,
            let name = paneProcesses[key]?.lowercased(),
            Self.agentKind(named: name) != nil {
@@ -1462,6 +1445,26 @@ final class WorkspaceStore: ObservableObject {
         // Last pane in this tab → close the whole tab instead (which itself
         // beeps when it's also the workspace's last tab).
         guard workspaces[i].tabs[t].root.leaves.count > 1 else {
+            let target = workspaces[i].tabs[t].focusedPane
+            if workspaces[i].tabs.count == 1,
+               let session = workspaces[i].panes[target]?.agentSession {
+                // A workspace must retain one pane. Detach the managed viewer
+                // and replace it with a fresh plain shell instead of refusing
+                // the close or killing the tmux session.
+                let oldKey = WorkspacePaneKey(workspace: workspaces[i].id, pane: target)
+                detachManagedSession(session)
+                surfaceViews.removeValue(forKey: oldKey)
+                paneAgentState.removeValue(forKey: oldKey)
+                paneProcesses.removeValue(forKey: oldKey)
+                let replacement = PaneID(value: workspaces[i].nextPaneSeq)
+                workspaces[i].nextPaneSeq += 1
+                workspaces[i].panes.removeValue(forKey: target)
+                workspaces[i].panes[replacement] = Pane(id: replacement, title: "zsh",
+                                                        workingDirectory: session.workingDirectory)
+                workspaces[i].tabs[t].root = .leaf(replacement)
+                workspaces[i].tabs[t].focusedPane = replacement
+                return
+            }
             closeTab(workspaces[i].tabs[t].id)
             return
         }
@@ -1478,6 +1481,7 @@ final class WorkspaceStore: ObservableObject {
         }
         let (newRoot, survivor) = Self.removeLeaf(workspaces[i].tabs[t].root, target: target)
         if let newRoot { workspaces[i].tabs[t].root = newRoot }
+        detachManagedSession(workspaces[i].panes[target]?.agentSession)
         workspaces[i].panes.removeValue(forKey: target)
         surfaceViews.removeValue(forKey: key)
         // The pane is gone for good — drop its scrollback snapshot too.
@@ -1640,6 +1644,76 @@ final class WorkspaceStore: ObservableObject {
         workspaces[i].selectedTabID = tab.id
     }
 
+    func createManagedSession(agent: AgentKind, host: HostTarget, profile: AgentProfile,
+                              workingDirectory: String) {
+        guard let i = currentIndex else { return }
+        AgentProfileStore.save(profile)
+        let pane = PaneID(value: workspaces[i].nextPaneSeq)
+        let paneKey = "\(workspaces[i].id.uuidString):\(pane.value)"
+        let session = AgentSession.create(agent: agent, host: host, profile: profile,
+                                          workingDirectory: workingDirectory, pane: paneKey)
+        openSessionInNewTab(session, in: i, paneID: pane)
+    }
+
+    func createManagedSessionInNewWorkspace(agent: AgentKind, host: HostTarget,
+                                            profile: AgentProfile,
+                                            workingDirectory: String) {
+        AgentProfileStore.save(profile)
+        let pick = nextWorkspacePalettePick()
+        var workspace = Workspace.fresh(name: "New workspace", accentHex: pick.0, symbol: pick.1)
+        let pane = PaneID(value: 0)
+        let paneKey = "\(workspace.id.uuidString):\(pane.value)"
+        let session = AgentSession.create(agent: agent, host: host, profile: profile,
+                                          workingDirectory: workingDirectory, pane: paneKey)
+        workspace.panes[pane] = Pane(id: pane, title: session.agent.displayName,
+                                     workingDirectory: session.workingDirectory,
+                                     agentSession: session)
+        workspace.tabs[0].root = .leaf(pane)
+        workspace.tabs[0].focusedPane = pane
+        workspaces.append(workspace)
+        selectedWorkspaceID = workspace.id
+    }
+
+    func reattachSession(_ sessionID: String) {
+        guard let sessionIndex = detachedAgentSessions.firstIndex(where: { $0.id == sessionID }),
+              let i = currentIndex else { return }
+        var session = detachedAgentSessions.remove(at: sessionIndex)
+        let pane = PaneID(value: workspaces[i].nextPaneSeq)
+        session.lastAttachedPane = "\(workspaces[i].id.uuidString):\(pane.value)"
+        openSessionInNewTab(session, in: i, paneID: pane)
+    }
+
+    func killDetachedSession(_ sessionID: String) {
+        guard let i = detachedAgentSessions.firstIndex(where: { $0.id == sessionID }) else { return }
+        let session = detachedAgentSessions[i]
+        do {
+            try AgentSessionManager.shared.kill(session)
+            detachedAgentSessions.remove(at: i)
+        } catch {
+            NSLog("[glint] failed to kill detached session \(session.id): \(error)")
+        }
+    }
+
+    private func openSessionInNewTab(_ session: AgentSession, in workspaceIndex: Int, paneID: PaneID) {
+        let i = workspaceIndex
+        workspaces[i].nextPaneSeq = max(workspaces[i].nextPaneSeq, paneID.value + 1)
+        workspaces[i].panes[paneID] = Pane(id: paneID, title: session.agent.displayName,
+                                          workingDirectory: session.workingDirectory,
+                                          agentSession: session)
+        let tab = WorkspaceTab(id: TabID(value: workspaces[i].nextTabSeq), name: nil,
+                               root: .leaf(paneID), focusedPane: paneID)
+        workspaces[i].nextTabSeq += 1
+        workspaces[i].tabs.append(tab)
+        workspaces[i].selectedTabID = tab.id
+    }
+
+    private func detachManagedSession(_ session: AgentSession?) {
+        guard var session, !detachedAgentSessions.contains(where: { $0.id == session.id }) else { return }
+        session.lastAttachedPane = nil
+        detachedAgentSessions.append(session)
+        agentTransportState[session.id] = .detached
+    }
+
     /// Close a tab and every pane it holds, cleaning up each pane's surface,
     /// scrollback snapshot, and live side-state. Confirms once if any pane is
     /// running something. The workspace's last tab can't be closed — beep
@@ -1668,6 +1742,7 @@ final class WorkspaceStore: ObservableObject {
         let wasSelected = workspaces[i].selectedTabID == tabID
         for pane in panes {
             let key = WorkspacePaneKey(workspace: wsID, pane: pane)
+            detachManagedSession(workspaces[i].panes[pane]?.agentSession)
             workspaces[i].panes.removeValue(forKey: pane)
             surfaceViews.removeValue(forKey: key)
             ScrollbackArchive.delete(
@@ -1765,6 +1840,9 @@ final class WorkspaceStore: ObservableObject {
             return
         }
 
+        for pane in workspaces[idx].panes.values {
+            detachManagedSession(pane.agentSession)
+        }
         // Drop every surface tied to this workspace (their ghostty surfaces
         // get freed in GhosttySurfaceView.deinit when the dict releases them).
         surfaceViews = surfaceViews.filter { $0.key.workspace != id }
@@ -1862,15 +1940,19 @@ final class WorkspaceStore: ObservableObject {
     }
 
     func addWorkspace() {
-        let palette = [
-            ("5E5CE6", "•"), ("FF6582", "•"), ("30D158", "•"),
-            ("FF9F0A", "•"), ("64D2FF", "•"), ("BF5AF2", "•"),
-        ]
-        let pick = palette[workspaces.count % palette.count]
+        let pick = nextWorkspacePalettePick()
         // Auto-named: fallback label is "New workspace" until the shell reports a cwd.
         let ws = Workspace.fresh(name: "New workspace", accentHex: pick.0, symbol: pick.1)
         workspaces.append(ws)
         selectedWorkspaceID = ws.id
+    }
+
+    private func nextWorkspacePalettePick() -> (String, String) {
+        let palette = [
+            ("5E5CE6", "•"), ("FF6582", "•"), ("30D158", "•"),
+            ("FF9F0A", "•"), ("64D2FF", "•"), ("BF5AF2", "•"),
+        ]
+        return palette[workspaces.count % palette.count]
     }
 
     // MARK: tree ops

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -731,6 +731,8 @@ final class WorkspaceStore: ObservableObject {
     /// Persistent NSView per global pane identity. Surfaces are keyed by
     /// (workspaceID, paneID) so switching workspaces doesn't destroy them.
     private var surfaceViews: [WorkspacePaneKey: GhosttySurfaceView] = [:]
+    /// O(1) routing from stable managed-session IDs to their attached viewer pane.
+    private var agentSessionPaneIndex: [String: WorkspacePaneKey] = [:]
 
     private var saveCancellable: AnyCancellable?
     private var cwdTimer: Timer?
@@ -763,6 +765,7 @@ final class WorkspaceStore: ObservableObject {
         self.sidebarCollapsed = loaded.sidebarCollapsed
         self.detachedAgentSessions = loaded.detachedAgentSessions
         Self.current = self
+        rebuildAgentSessionPaneIndex()
 
         // Debounced autosave: any @Published change → save 0.5s later.
         saveCancellable = objectWillChange
@@ -892,6 +895,28 @@ final class WorkspaceStore: ObservableObject {
     struct WorkspacePaneKey: Hashable {
         let workspace: UUID
         let pane: PaneID
+    }
+
+    private func rebuildAgentSessionPaneIndex() {
+        var index: [String: WorkspacePaneKey] = [:]
+        for ws in workspaces {
+            for pane in ws.panes.values {
+                if let session = pane.agentSession {
+                    index[session.id] = WorkspacePaneKey(workspace: ws.id, pane: pane.id)
+                }
+            }
+        }
+        agentSessionPaneIndex = index
+    }
+
+    private func rememberAgentSession(_ session: AgentSession?, workspaceID: UUID, paneID: PaneID) {
+        guard let session else { return }
+        agentSessionPaneIndex[session.id] = WorkspacePaneKey(workspace: workspaceID, pane: paneID)
+    }
+
+    private func forgetAgentSession(_ session: AgentSession?) {
+        guard let session else { return }
+        agentSessionPaneIndex.removeValue(forKey: session.id)
     }
 
     func surfaceView(workspaceID: UUID, paneID: PaneID, cwd: String?) -> GhosttySurfaceView {
@@ -1087,14 +1112,7 @@ final class WorkspaceStore: ObservableObject {
         guard let info,
               let hook = info["hook"] as? String else { return }
         let sessionID = info["session"] as? String
-        let sessionKey: WorkspacePaneKey? = sessionID.flatMap { id in
-            for ws in workspaces {
-                if let pane = ws.panes.first(where: { $0.value.agentSession?.id == id })?.key {
-                    return WorkspacePaneKey(workspace: ws.id, pane: pane)
-                }
-            }
-            return nil
-        }
+        let sessionKey = sessionID.flatMap { agentSessionPaneIndex[$0] }
         let paneKey = (info["pane"] as? String).flatMap(Self.parsePaneKey)
         guard let key = sessionKey ?? paneKey else { return }
 
@@ -1184,7 +1202,7 @@ final class WorkspaceStore: ObservableObject {
             if agentTransportState[sessionID] != .local {
                 agentTransportState[sessionID] = .connected
             }
-            if kind == .codex, let key = sessionKey,
+            if kind == .codex, sessionID != nil,
                let wi = workspaces.firstIndex(where: { $0.id == key.workspace }),
                var session = workspaces[wi].panes[key.pane]?.agentSession,
                session.needsHookTrust {
@@ -1454,6 +1472,8 @@ final class WorkspaceStore: ObservableObject {
                 let oldKey = WorkspacePaneKey(workspace: workspaces[i].id, pane: target)
                 detachManagedSession(session)
                 surfaceViews.removeValue(forKey: oldKey)
+                ScrollbackArchive.delete(
+                    id: ScrollbackArchive.fileID(forPaneKey: "\(workspaces[i].id.uuidString):\(target.value)"))
                 paneAgentState.removeValue(forKey: oldKey)
                 paneProcesses.removeValue(forKey: oldKey)
                 let replacement = PaneID(value: workspaces[i].nextPaneSeq)
@@ -1671,6 +1691,7 @@ final class WorkspaceStore: ObservableObject {
         workspace.tabs[0].root = .leaf(pane)
         workspace.tabs[0].focusedPane = pane
         workspaces.append(workspace)
+        rememberAgentSession(session, workspaceID: workspace.id, paneID: pane)
         selectedWorkspaceID = workspace.id
     }
 
@@ -1689,6 +1710,9 @@ final class WorkspaceStore: ObservableObject {
         do {
             try AgentSessionManager.shared.kill(session)
             detachedAgentSessions.remove(at: i)
+            agentSessionState.removeValue(forKey: session.id)
+            agentTransportState.removeValue(forKey: session.id)
+            agentSessionPaneIndex.removeValue(forKey: session.id)
         } catch {
             NSLog("[glint] failed to kill detached session \(session.id): \(error)")
         }
@@ -1700,6 +1724,7 @@ final class WorkspaceStore: ObservableObject {
         workspaces[i].panes[paneID] = Pane(id: paneID, title: session.agent.displayName,
                                           workingDirectory: session.workingDirectory,
                                           agentSession: session)
+        rememberAgentSession(session, workspaceID: workspaces[i].id, paneID: paneID)
         let tab = WorkspaceTab(id: TabID(value: workspaces[i].nextTabSeq), name: nil,
                                root: .leaf(paneID), focusedPane: paneID)
         workspaces[i].nextTabSeq += 1
@@ -1708,7 +1733,9 @@ final class WorkspaceStore: ObservableObject {
     }
 
     private func detachManagedSession(_ session: AgentSession?) {
-        guard var session, !detachedAgentSessions.contains(where: { $0.id == session.id }) else { return }
+        guard var session else { return }
+        forgetAgentSession(session)
+        guard !detachedAgentSessions.contains(where: { $0.id == session.id }) else { return }
         session.lastAttachedPane = nil
         detachedAgentSessions.append(session)
         agentTransportState[session.id] = .detached
@@ -1843,6 +1870,7 @@ final class WorkspaceStore: ObservableObject {
         for pane in workspaces[idx].panes.values {
             detachManagedSession(pane.agentSession)
         }
+        agentSessionPaneIndex = agentSessionPaneIndex.filter { $0.value.workspace != id }
         // Drop every surface tied to this workspace (their ghostty surfaces
         // get freed in GhosttySurfaceView.deinit when the dict releases them).
         surfaceViews = surfaceViews.filter { $0.key.workspace != id }


### PR DESCRIPTION
## Summary

- add a GUI-first New Agent Session flow with reusable agent profiles
- run managed Claude, Codex, OpenCode, and terminal sessions through per-session tmux runtimes
- inject Claude/Codex status hooks per session instead of writing global agent configuration
- support detached/reattached managed sessions, SSH-backed runtimes, and session-scoped state updates
- add Chinese localizations for the new managed-session UI

## Details

This introduces `AgentSession`, `AgentProfile`, `HostTarget`, and `AgentSessionManager` as the managed runtime layer.

Managed sessions write isolated runtime files under `~/.cache/glint/sessions/<session-id>/`, launch inside tmux, and report hook events back to Glint with stable session identity instead of pane-only identity.

Claude uses a temporary merged settings overlay. Codex uses one-run `-c` hook overrides while preserving the selected `CODEX_HOME` and requiring the normal `/hooks` trust review. Plain terminal sessions and the OpenCode fallback do not inject hooks.

The runtime also includes hardening for common managed-session edge cases:

- use `/usr/bin/nc` for macOS Unix socket hook reports to avoid Homebrew GNU netcat incompatibility
- register `StopFailure` for managed Codex sessions
- resolve tmux before removing detached session metadata/runtime files
- shell-quote generated bootstrap paths
- preserve private file modes for remote runtime files

## Validation

- built Debug locally with:

  ```sh
  xcodebuild \
    -scheme Glint \
    -configuration Debug \
    -project Glint.xcodeproj \
    -derivedDataPath build/DerivedData \
    CODE_SIGNING_ALLOWED=NO \
    build
  ```

- manually smoke-tested local managed session creation and runtime behavior
- manually smoke-tested SSH-backed remote session creation
- manually smoke-tested remote Codex usage with a selected `CODEX_HOME`
- manually verified remote Codex can edit files inside the selected working directory
