### PR TITLE
fix(terminal): guard ⌘-clicked file:// URLs against launching code

### DIFF
--- a/Glint/Ghostty/GhosttyManager.swift
+++ b/Glint/Ghostty/GhosttyManager.swift
@@ -353,7 +353,15 @@ final class GhosttyManager {
                 String(decoding: UnsafeBufferPointer(start: bytes, count: Int(info.len)), as: UTF8.self)
             }
             DispatchQueue.main.async {
-                if let u = URL(string: urlString) {
+                guard let u = URL(string: urlString) else { return }
+                // A `file://` URL points at local content — route it through
+                // the same open-or-reveal guard as a ⌘-clicked text path, so a
+                // hostile OSC-8 link (`file:///…/Evil.app`) can't launch code
+                // just because it arrived as a URL rather than printable text.
+                // Other schemes (http/https/mailto/…) open with their handler.
+                if u.isFileURL {
+                    GhosttySurfaceView.openOrReveal(u)
+                } else {
                     NSWorkspace.shared.open(u)
                 }
             }

--- a/Glint/Pane/GhosttySurfaceView.swift
+++ b/Glint/Pane/GhosttySurfaceView.swift
@@ -1446,11 +1446,8 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
         // apps, bundles, installers, URL shortcuts, and anything carrying the
         // POSIX execute bit are revealed in Finder instead of opened with their
         // default handler. Plain documents (source, logs, images, PDFs) open.
-        if shouldRevealRatherThanOpen(url) {
-            NSWorkspace.shared.activateFileViewerSelecting([url])
-        } else {
-            NSWorkspace.shared.open(url)
-        }
+        // Shared with the OSC-8 OPEN_URL path via `openOrReveal`.
+        Self.openOrReveal(url)
         return true
     }
 
@@ -1464,9 +1461,24 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
         "pkg", "mpkg", "dmg",
     ]
 
+    /// Open `url` with its default handler, or — when opening it could execute
+    /// code (apps, bundles, installers, URL shortcuts, anything with the POSIX
+    /// execute bit, packages, directories) — reveal it in Finder instead.
+    /// Shared trust boundary for both ⌘-click paths: a plain-text file token
+    /// (`openFileUnderPointer`) and an OSC-8 hyperlink whose URL is `file://`
+    /// (the OPEN_URL action). Terminal output is untrusted; a hostile program
+    /// can print any path or `file://` link and the user only has to click it.
+    static func openOrReveal(_ url: URL) {
+        if shouldRevealRatherThanOpen(url) {
+            NSWorkspace.shared.activateFileViewerSelecting([url])
+        } else {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
     /// True when a ⌘-clicked path should be revealed in Finder rather than
     /// opened, because opening it could execute code.
-    private func shouldRevealRatherThanOpen(_ url: URL) -> Bool {
+    private static func shouldRevealRatherThanOpen(_ url: URL) -> Bool {
         if Self.revealOnlyExtensions.contains(url.pathExtension.lowercased()) {
             return true
         }


### PR DESCRIPTION
## Summary

Guards `file://` URLs opened via ⌘-click against launching code, closing a trust-boundary gap between the two ⌘-click code paths.

## 概述

堵住 ⌘-click 打开 `file://` URL 时的代码执行隐患——此前两条 ⌘-click 路径信任边界不一致。

---

## The problem · 问题

The terminal has two ⌘-click code paths:

- **Plain-text file path** (`openFileUnderPointer`): resolves the word under the cursor to a local file and opens it through `shouldRevealRatherThanOpen` — apps / bundles / executables / packages / directories are **revealed in Finder**, never launched. Terminal output is treated as untrusted.
- **OSC-8 hyperlink / URL** (`GHOSTTY_ACTION_OPEN_URL` in `GhosttyManager`): called `NSWorkspace.shared.open(u)` unconditionally for **every** scheme.

So a hostile program could print an OSC-8 link whose visible text says one thing but whose URL is `file:///Applications/Calculator.app` (or any app / bundle), and ⌘-clicking it would **launch** it — bypassing exactly the protection the text path enforces.

终端里有两条 ⌘-click 路径：
- **文本文件路径**（`openFileUnderPointer`）：把光标下的词解析成本地文件，经 `shouldRevealRatherThanOpen` 判断——`.app` / bundle / 可执行文件 / 目录一律在 **Finder 中 reveal**，绝不启动。终端输出视为不可信。
- **OSC-8 超链接 / URL**（`GhosttyManager` 的 `GHOSTTY_ACTION_OPEN_URL`）：对**任意** scheme 无条件 `NSWorkspace.shared.open(u)`。

于是恶意程序可打印一条可见文字与真实 URL 不一致的 OSC-8 链接（真实 URL 为 `file:///Applications/Calculator.app` 之类），用户 ⌘-click 即被**启动**——恰好绕过文本路径已有的防护。

---

## The fix · 修复

Extract one shared helper and use it on both paths:

```swift
/// Shared trust boundary for both ⌘-click paths: a plain-text file token
/// (openFileUnderPointer) and an OSC-8 hyperlink whose URL is file://
/// (the OPEN_URL action).
static func openOrReveal(_ url: URL) {
    if shouldRevealRatherThanOpen(url) {
        NSWorkspace.shared.activateFileViewerSelecting([url])
    } else {
        NSWorkspace.shared.open(url)
    }
}
```

- `openFileUnderPointer` now calls `Self.openOrReveal(url)`.
- `OPEN_URL` routes `file://` URLs through `GhosttySurfaceView.openOrReveal(u)`; other schemes (`http` / `https` / `mailto` / custom) open unchanged.
- `shouldRevealRatherThanOpen` is now `private static` (it was already stateless).

抽取一个共享封装，两条路径共用：
- `openFileUnderPointer` 改调 `Self.openOrReveal(url)`。
- `OPEN_URL` 的 `file://` 走 `GhosttySurfaceView.openOrReveal(u)`，其余 scheme 照常 open。
- `shouldRevealRatherThanOpen` 提为 `private static`（本就无状态）。

---

## Behavior impact · 行为影响

| ⌘-click target | Before | After |
|---|---|---|
| `http` / `https` / `mailto` / custom scheme | open | unchanged · 不变 |
| `file://` → document (txt / pdf / image) | open | unchanged · 不变 |
| `file://` → `.app` / bundle / executable / dir | **launched · 启动** | revealed in Finder · Finder 中 reveal |

The only behavior change is that `file://` links to launch-capable files no longer execute — and it now matches the text path. No legitimate use case is affected.

唯一的行为变化是：`file://` 指向可启动文件时不再执行代码，且与文本路径行为对齐。不影响任何正常使用场景。

---

## Testing · 测试

- `xcodebuild -project Glint.xcodeproj -scheme Glint -configuration Debug build` → **BUILD SUCCEEDED**.
- (Manual, suggested) ⌘-click an OSC-8 `file://` link to an `.app` → now revealed in Finder, not launched.

---

This is a standalone security hardening; `ControlBridge` token-gating for `list`/`focus` was reviewed and judged **not** worth changing (socket is same-user-only via `0700` parent dir, so `list` leaks nothing a same-user process couldn't already read).

本 PR 为独立的安全加固；`ControlBridge` 中 `list`/`focus` 的 token 门经评估**不必**改动（socket 受 0700 父目录限制为同用户，`list` 泄露的信息同用户进程本就能读到）。
