### PR TITLE
perf(review): O(1) child lookup in TreeNode.build (was O(N²) on a flat dir)

### DIFF
--- a/Glint/Review/ReviewWindow.swift
+++ b/Glint/Review/ReviewWindow.swift
@@ -471,6 +471,15 @@ final class TreeNode {
     /// each level sorted case-insensitively.
     static func build(_ files: [GitFileChange]) -> [TreeNode] {
         let root = TreeNode(name: "", path: "", isDir: true)
+        // Index each node by its accumulated path so revisiting a directory (the
+        // common case — many files share a parent) is an O(1) lookup instead of a
+        // linear scan over siblings. Without this, a single flat directory with N
+        // files made build O(N²); this runs on the main actor inside reload(), so
+        // a large-diff repo would hitch. A path in git diff output is unambiguously
+        // a file (a reported change) or a directory (an implied parent) — never
+        // both — so keying by path alone is an exact match for the old
+        // `name == c && isDir == !isLeaf` test.
+        var byPath: [String: TreeNode] = [:]
         for f in files {
             let comps = f.path.split(separator: "/").map(String.init)
             guard !comps.isEmpty else { continue }
@@ -478,11 +487,12 @@ final class TreeNode {
             var acc = ""
             for (i, c) in comps.enumerated() {
                 acc = acc.isEmpty ? c : acc + "/" + c
-                let isLeaf = i == comps.count - 1
-                if let existing = cur.children.first(where: { $0.name == c && $0.isDir == !isLeaf }) {
+                if let existing = byPath[acc] {
                     cur = existing
                 } else {
+                    let isLeaf = i == comps.count - 1
                     let node = TreeNode(name: c, path: acc, isDir: !isLeaf, file: isLeaf ? f : nil)
+                    byPath[acc] = node
                     cur.children.append(node)
                     cur = node
                 }


### PR DESCRIPTION
## What / 改动

**EN** — `TreeNode.build` (the Review window's file-list tree) looked up each child node with a linear scan over siblings (`cur.children.first(where:)`). With N files in one flat directory the whole build was **O(N²)**, and it runs on the main actor inside `reload()`, so opening the Review window on a large-diff repo hitched.

Fix: key every node by its accumulated path in a `[String: TreeNode]` dictionary, so revisiting a shared parent is **O(1)** → build drops to **O(N·D)**.

**中文** — Review 窗口文件列表的目录树构建(`TreeNode.build`)原先对每个子节点做兄弟线性扫描(`cur.children.first(where:)`)。一个扁平目录里有 N 个文件时整体构建是 **O(N²)**,而它在 `reload()` 里跑在主线程,所以大 diff 仓库打开 Review 窗口会卡顿。

修复:用 `[String: TreeNode]` 字典按累加路径索引每个节点,重访共享父目录变成 **O(1)**,构建降到 **O(N·D)**。

## Behavior equivalence / 行为等价

**EN** — Identical output for all real git input. A path in `git diff` output is unambiguously either a *file* (a reported change) or a *directory* (an implied parent) — never both — so keying by path alone is an exact match for the old `name == c && isDir == !isLeaf` predicate. The only difference is on impossible input (a path that is simultaneously a file and a directory), which git never produces.

**中文** — 对真实 git 输入输出完全一致。`git diff` 里一条路径要么是文件(被报告的改动)要么是目录(隐含的父级),不可能二者皆是,所以按路径建索引与旧的 `name == c && isDir == !isLeaf` 判定完全等价。唯一差异只出现在「同一路径既是文件又是目录」这种 git 不会产生的不可能输入上。

## Verification / 验证

- `xcodebuild -scheme Glint -configuration Debug` — **BUILD SUCCEEDED** (no new warnings).
- No tests yet — the Glint target has no test suite. Pure refactor; adding parser unit tests is tracked separately.

## Scope / 范围

Only `TreeNode.build`. Diff parsing, window controller, and all other paths untouched.

---
`Co-Authored-By: Claude <noreply@anthropic.com>`