### PR TITLE
fix(shortcut): ⌘W closes the focused secondary window instead of the terminal

### DIFF
--- a/Glint.xcodeproj/project.pbxproj
+++ b/Glint.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		D3D6CF13B67D30E9DA557F83 /* UsageStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A1F24DAA7220AD4EE961E2 /* UsageStore.swift */; };
 		E464D0233508CD31C1235054 /* AgentBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05F2CA2243872C8111048EF2 /* AgentBridge.swift */; };
 		EF3ACBA990526130228FAD0B /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D3B64992BBD5A190DFE36D2 /* SettingsView.swift */; };
+		B7F3C2901E8D4A6F9C2B5E18 /* CloseOnCmdW.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1A9D0B3F7285C6A0D3E9F1 /* CloseOnCmdW.swift */; };
 		EF937781512647E835836F83 /* ControlBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21868C7211897C87A6CAD7C3 /* ControlBridge.swift */; };
 		F6AFF715FCE5357CEB07683D /* SettingsSafety.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB20921E3CAC1006A8FBD3AE /* SettingsSafety.swift */; };
 		F7ABF70CD455143BF89B89B3 /* SafeJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E2B9ADF809766CE4278047 /* SafeJSON.swift */; };
@@ -68,6 +69,7 @@
 		5A8933F67B4B6EEA3FD4E603 /* WorkspaceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceStore.swift; sourceTree = "<group>"; };
 		6860F8F626EFDB9A289FC727 /* themes.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = themes.json; sourceTree = "<group>"; };
 		6D3B64992BBD5A190DFE36D2 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		4E1A9D0B3F7285C6A0D3E9F1 /* CloseOnCmdW.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseOnCmdW.swift; sourceTree = "<group>"; };
 		7039488F4C2F75498E461311 /* GitDiff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitDiff.swift; sourceTree = "<group>"; };
 		7CB74659D174004C620D538A /* GlintApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlintApp.swift; sourceTree = "<group>"; };
 		81DADCF27E710CC77846E961 /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GhosttyKit.xcframework; path = Vendor/GhosttyKit.xcframework; sourceTree = "<group>"; };
@@ -132,6 +134,7 @@
 				150EEF32284061D527E51866 /* GlintTheme.swift */,
 				0D29C0D2447094B07854C193 /* NewWorkspaceSheet.swift */,
 				6D3B64992BBD5A190DFE36D2 /* SettingsView.swift */,
+			4E1A9D0B3F7285C6A0D3E9F1 /* CloseOnCmdW.swift */,
 				A8C269A6E9AE87961C3356DC /* SidebarView.swift */,
 				050E267AE14712D4D6633B4F /* Theme.swift */,
 				C0656F7C1D48AE0429C1888B /* VisualEffectBackground.swift */,
@@ -343,6 +346,7 @@
 				F7ABF70CD455143BF89B89B3 /* SafeJSON.swift in Sources */,
 				F6AFF715FCE5357CEB07683D /* SettingsSafety.swift in Sources */,
 				EF3ACBA990526130228FAD0B /* SettingsView.swift in Sources */,
+			B7F3C2901E8D4A6F9C2B5E18 /* CloseOnCmdW.swift in Sources */,
 				CD30F5E1B78B3C46C9990FD6 /* SidebarView.swift in Sources */,
 				7FC12666816053BEB64079CB /* Theme.swift in Sources */,
 				692D1A7D490E07D796535EAA /* UpdaterController.swift in Sources */,

--- a/Glint/Chrome/CloseOnCmdW.swift
+++ b/Glint/Chrome/CloseOnCmdW.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+/// ⌘W 关闭附着的 sheet。
+///
+/// 主菜单的 ⌘W 绑的是终端「Close Pane」(终端动作),会抢走这个事件。
+/// sheet 没有独立 NSWindow(它附在主窗口上),所以不能像 Review 审阅窗口
+/// 那样重写 `performKeyEquivalent`;改成在 sheet 的视图树里抢先注册一个
+/// 同名 shortcut —— `NSWindow.performKeyEquivalent` 遍历视图树**先于**
+/// mainMenu,所以 sheet 显示时这里先匹配到并 dismiss。
+struct CloseOnCmdW: ViewModifier {
+    @Environment(\.dismiss) private var dismiss
+
+    func body(content: Content) -> some View {
+        content.background {
+            Button(action: { dismiss() }) { EmptyView() }
+                .keyboardShortcut("w", modifiers: .command)
+                .accessibilityHidden(true)
+        }
+    }
+}
+
+extension View {
+    /// 让附着的 sheet 用 ⌘W 关闭(见 `CloseOnCmdW`)。
+    func closeOnCmdW() -> some View { modifier(CloseOnCmdW()) }
+}

--- a/Glint/Chrome/NewWorkspaceSheet.swift
+++ b/Glint/Chrome/NewWorkspaceSheet.swift
@@ -55,6 +55,7 @@ struct NewWorkspaceSheet: View {
         .frame(width: 760, height: 540)
         .background(Theme.bgWindow)
         .preferredColorScheme(.dark)
+        .closeOnCmdW()
         .onAppear {
             // Clamp to an ENABLED tab: an unknown rawValue OR the disabled `.ssh`
             // (Phase 2) would otherwise land on a blank EmptyView with no nav out.

--- a/Glint/Chrome/SettingsView.swift
+++ b/Glint/Chrome/SettingsView.swift
@@ -38,6 +38,7 @@ struct GlintSettingsView: View {
         .frame(width: 760, height: 540)
         .background(Theme.bgWindow)
         .preferredColorScheme(.dark)
+        .closeOnCmdW()
     }
 
     // MARK: - Sidebar

--- a/Glint/Review/ReviewWindow.swift
+++ b/Glint/Review/ReviewWindow.swift
@@ -764,6 +764,22 @@ private final class NoSafeAreaHostingView<Content: View>: NSHostingView<Content>
 
 // MARK: - Window controller
 
+// The app-wide ⌘W is bound to "Close Pane" (a SwiftUI menu command in GlintApp
+// whose closure fires regardless of key window — and AppDelegate.patchMainMenu
+// strips ⌘W off the system Close item so that pane-close wins). From the Review
+// window a plain ⌘W should just close this window (standard macOS key-window
+// behavior), so swallow it here before it reaches the main menu.
+private final class ReviewWindow: NSWindow {
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        if flags == .command, event.charactersIgnoringModifiers?.lowercased() == "w" {
+            performClose(nil)
+            return true
+        }
+        return super.performKeyEquivalent(with: event)
+    }
+}
+
 @MainActor
 final class ReviewWindowController: NSObject, NSWindowDelegate {
     static let shared = ReviewWindowController()
@@ -793,7 +809,7 @@ final class ReviewWindowController: NSObject, NSWindowDelegate {
     }
 
     private func makeWindow() -> NSWindow {
-        let w = NSWindow(
+        let w = ReviewWindow(
             contentRect: NSRect(x: 0, y: 0, width: 1040, height: 660),
             styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered, defer: false)


### PR DESCRIPTION
## Problem / 问题

**EN:** The app-wide ⌘W is bound to the terminal "Close Pane" action, and `AppDelegate.patchMainMenu` strips ⌘W off the system Close menu item so pane-close wins. That menu binding fires its closure regardless of which window is key, so when a secondary window was focused — the Review window, Settings sheet, or New Workspace sheet — ⌘W didn't close it; it closed a terminal pane (and could take down the whole window).

**中文:** 全局 ⌘W 绑在终端的「Close Pane」动作上(`AppDelegate.patchMainMenu` 还把系统 Close 菜单项的 ⌘W 去掉了)。这个菜单绑定不管哪个窗口在前台都会触发,所以当审阅窗口、设置 sheet、新建工作区 sheet 在前台时,⌘W 关不掉它们,反而关了终端 pane,甚至可能关掉整个窗口。

## Fix / 修复

**EN:**
- **Review window** (separate `NSWindow`): a `ReviewWindow` subclass overrides `performKeyEquivalent` — plain ⌘W calls `performClose(self)` and returns `true`, swallowing the event before the main menu.
- **Sheets** (Settings, New Workspace): a new `CloseOnCmdW` view modifier adds a hidden `Button` with a ⌘W `keyboardShortcut`. Since `NSWindow.performKeyEquivalent` walks the view tree *before* the main menu, the sheet's shortcut wins and dismisses it. Reusable — any future sheet just adds `.closeOnCmdW()`.

Plain ⌘W only. ⌘⇧W still closes the tab; ⌘W in the terminal window still closes the pane (unchanged).

**中文:**
- **审阅窗口**(独立 `NSWindow`):新增 `ReviewWindow` 子类,重写 `performKeyEquivalent`——纯 ⌘W 调 `performClose(self)` 并返回 `true`,在主菜单之前吞掉事件。
- **Sheet**(设置、新建工作区):新增 `CloseOnCmdW` 视图修饰器,放一个隐藏 `Button` 绑 ⌘W `keyboardShortcut`。因为 `NSWindow.performKeyEquivalent` 遍历视图树*先于*主菜单,sheet 的快捷键会胜出并关闭。可复用——以后新 sheet 加一行 `.closeOnCmdW()` 即可。

仅纯 ⌘W 生效。⌘⇧W 仍是关 tab;终端窗口前台时 ⌘W 仍是关 pane(不变)。

## Test / 测试

Verified manually in a Debug build:
- Review window focused → ⌘W closes it ✓
- Settings sheet → ⌘W closes it ✓
- New Workspace sheet (any tab) → ⌘W closes it ✓
- Terminal window focused → ⌘W still closes the pane ✓

中文:已在 Debug 构建中手动验证以上四项场景。
