### PR TITLE
fix(palette): command palette search field now reliably takes focus / 修复命令面板搜索框不自动获焦

### DIFF
--- a/Glint/Chrome/CommandPalette.swift
+++ b/Glint/Chrome/CommandPalette.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 /// Centered modal overlay summoned by ⌘⇧P or the toolbar's ⌘ button.
 /// Type to fuzzy-filter; ↑↓ to move selection; ⏎ to execute; ⎋ to close.
@@ -60,7 +61,17 @@ struct CommandPalette: View {
             .shadow(color: Color.black.opacity(0.5), radius: 30, y: 12)
             .padding(.top, -80) // bias slightly above center
         }
-        .onAppear { queryFocused = true }
+        .onAppear {
+            // The terminal surface is the window's AppKit first responder.
+            // SwiftUI's @FocusState can't reliably pry it loose synchronously
+            // (the view host isn't wired yet at onAppear time), so resign it
+            // first, then claim the field on the next runloop once the
+            // responder bookkeeping has settled. PaneSurfaceRepresentable
+            // skips its own focus sync while the palette is open
+            // (`deferFocus`), so the ~1/s pass can't yank focus back here.
+            NSApp.keyWindow?.makeFirstResponder(nil)
+            DispatchQueue.main.async { queryFocused = true }
+        }
         .onChange(of: query) { _, _ in
             // Typing resets the selection to the top hit; treat it like
             // keyboard input so the list scrolls back up with it.

--- a/Glint/Pane/PaneSurfaceRepresentable.swift
+++ b/Glint/Pane/PaneSurfaceRepresentable.swift
@@ -10,6 +10,11 @@ struct PaneSurfaceRepresentable: NSViewRepresentable {
     /// The reverse direction (clicks) goes through store.focus(_:), so a
     /// writable binding would just be a lie about the data flow.
     let focused: Bool
+    /// True while an in-window overlay (the command palette) is managing the
+    /// window's first responder. When set, this view must NOT touch focus:
+    /// updateNSView re-runs ~1/s, and re-grabbing the terminal surface here
+    /// races the palette's search field and yanks focus back off it.
+    let deferFocus: Bool
 
     func makeNSView(context: Context) -> NoDragContainerView {
         let container = NoDragContainerView()
@@ -38,12 +43,21 @@ struct PaneSurfaceRepresentable: NSViewRepresentable {
         // search box. resignFirstResponder already pushed ghostty into
         // the unfocused state; leave it alone until the responder dance
         // unwinds naturally.
+        //
+        // `deferFocus` covers the command palette: while it's open, skip
+        // the focus sync entirely so this ~1/s pass can't race the
+        // palette's search field for first responder.
+        guard !deferFocus else { return }
         let textEditorActive = surfaceView.window?.firstResponder is NSText
         if !textEditorActive {
             surfaceView.setGhosttyFocus(focused)
         }
         if focused, !textEditorActive, surfaceView.window?.firstResponder !== surfaceView {
             DispatchQueue.main.async {
+                // Re-check on the runloop: a text field (command palette,
+                // search box) may have claimed focus between this update and
+                // the dispatch. Stealing it back here is the very bug.
+                guard !(surfaceView.window?.firstResponder is NSText) else { return }
                 surfaceView.window?.makeFirstResponder(surfaceView)
             }
         } else if !focused, surfaceView.window?.firstResponder === surfaceView {

--- a/Glint/Pane/PaneView.swift
+++ b/Glint/Pane/PaneView.swift
@@ -44,7 +44,8 @@ struct PaneView: View {
             paneBacking
             PaneSurfaceRepresentable(
                 surfaceView: store.surfaceView(workspaceID: workspaceID, paneID: paneID, cwd: cwd),
-                focused: isFocused
+                focused: isFocused,
+                deferFocus: store.commandPaletteOpen
             )
             if !isFocused {
                 // Dim unfocused panes with a black wash in BOTH modes. A


### PR DESCRIPTION
## Problem / 问题

**EN:** When the command palette (⌘⇧P) opened, its search field usually did **not** get focus — keystrokes fell through to the terminal underneath. The user had to click into the field before typing.

**中文：** 打开命令面板（⌘⇧P）时，搜索框通常**不会**获得焦点——按键直接落到下面的终端里，用户必须先点一下输入框才能打字。

## Root cause / 根因

**EN:** Two compounding causes:

1. **Initial claim too weak.** `CommandPalette` set `queryFocused = true` synchronously in `onAppear`. The terminal surface is the window's AppKit first responder, and SwiftUI's `@FocusState` couldn't reliably resign it before the palette's view host was wired up, so the claim silently no-op'd.
2. **Terminal steals it back.** `PaneSurfaceRepresentable.updateNSView` re-runs ~1/s (driven by the sidebar's elapsed-time `TimelineView`) and re-grabs first responder for the focused pane. During the focus handoff it raced the palette's field and yanked focus back. The existing `firstResponder is NSText` guard only protects steady state, not the handoff window.

**中文：** 两个叠加的因素：

1. **初次抢焦点太弱。** `CommandPalette` 在 `onAppear` 里**同步**设置 `queryFocused = true`。终端 surface 是窗口的 AppKit first responder，SwiftUI 的 `@FocusState` 在面板 view host 接线完成前无法可靠地劝退它，于是这次请求静默失效。
2. **终端把焦点抢回去。** `PaneSurfaceRepresentable.updateNSView` 约每秒重跑一次（由侧栏的计时 `TimelineView` 驱动），并为聚焦的 pane 重新抢占 first responder。焦点交接期间它和面板输入框竞态，把焦点又抢回终端。现有的 `firstResponder is NSText` 守卫只护得住稳态，护不住交接空窗。

## Fix / 修复

**EN:**
- **`CommandPalette`** — on appear, resign the AppKit first responder (`makeFirstResponder(nil)`), then claim the field on the next runloop once responder bookkeeping has settled.
- **`PaneSurfaceRepresentable`** — new `deferFocus` flag; while set, the view skips its focus sync entirely so the ~1/s pass can't race the palette. Also re-check first-responder *inside* the queued `makeFirstResponder` so a text field claimed mid-update (palette or sidebar search) is never clobbered.
- **`PaneView`** — pass `deferFocus: store.commandPaletteOpen`.

Closing the palette restores terminal focus on the next pass (the overlay's removal re-renders the pane and re-grabs the surface).

**中文：**
- **`CommandPalette`** —— 打开时先劝退 AppKit first responder（`makeFirstResponder(nil)`），待响应者簿记落定后，于下一 runloop 再 `queryFocused = true` 申请焦点。
- **`PaneSurfaceRepresentable`** —— 新增 `deferFocus` 标志；为 true 时整个跳过焦点同步，这样每秒一次的更新就不会和面板竞态。同时在排队的 `makeFirstResponder` **内部**重新检查 first responder，确保中途被文本框（面板或侧栏搜索）拿走的焦点不会被覆盖。
- **`PaneView`** —— 传入 `deferFocus: store.commandPaletteOpen`。

关闭面板后，下一次更新会把焦点还给终端（遮罩移除会触发 pane 重绘并重新抢占 surface）。

## Verification / 验证

**EN:** Built (Debug, macOS). Manually confirmed the palette search field now takes focus on open and holds it; focus returns to the terminal on close.

**中文：** Debug 构建通过（macOS）。手动确认：打开面板时搜索框现在能获得并保持焦点；关闭后焦点回到终端。

### Files / 文件
- `Glint/Chrome/CommandPalette.swift`
- `Glint/Pane/PaneSurfaceRepresentable.swift`
- `Glint/Pane/PaneView.swift`