### PR TITLE
fix(review): diff pane shows no color for CRLF (Windows) files

### DIFF
--- a/Glint/Review/ReviewWindow.swift
+++ b/Glint/Review/ReviewWindow.swift
@@ -613,7 +613,16 @@ struct DiffDocument: Sendable {
         var out: [DiffLine] = []
         var oldLine = 0, newLine = 0
         var id = 0
-        for raw in text.split(separator: "\n", omittingEmptySubsequences: false) {
+        // Normalize CRLF / lone CR to LF before splitting. Swift treats "\r\n" as
+        // a single Character (extended grapheme cluster), so split(separator: "\n")
+        // never matches it and silently merges every CRLF-terminated line into one
+        // blob — a Windows-authored file (its diff body keeps the source's CRLF)
+        // then parses as zero adds/dels, so nothing tints and the raw +/- markers
+        // leak through as un-parsed text. Git's own meta lines are LF, so only the
+        // diff body is affected (the file-list numstat, pure git output, is fine).
+        let normed = text.replacingOccurrences(of: "\r\n", with: "\n")
+                         .replacingOccurrences(of: "\r", with: "\n")
+        for raw in normed.split(separator: "\n", omittingEmptySubsequences: false) {
             let line = String(raw)
             // The only truly-empty element is the trailing split artifact after
             // the diff's final newline; real blank context lines are " ".


### PR DESCRIPTION
## Problem / 问题

**EN** — For a file authored on Windows (CRLF line endings), the Review window's diff pane showed **no green/red tint** and the raw `+`/`-` markers leaked through as plain text — even though the file list showed correct stats like `109+ 3-`. LF files (e.g. YAML) rendered fine.

**中文** — Windows 编辑(CRLF 换行)的文件,在 Review 窗口的 diff 面板里**完全没有绿/红着色**,原始 `+`/`-` 标记作为纯文本泄漏出来;但文件列表的统计(如 `109+ 3-`)却是对的。LF 文件(如 YAML)正常。

## Root cause / 根因

**EN** — `DiffDocument.parse` split the diff body with `text.split(separator: "\n")`. Swift treats `"\r\n"` as a **single `Character`** (an extended grapheme cluster), so the `"\n"` separator never matches a CRLF line ending — every CRLF-terminated line silently merged into one giant blob, which then classified as context. Result: zero add/del lines detected → no tint, and the un-split blob text (still carrying its `+`/`-`) rendered verbatim. Git's own meta lines (`index` / `+++` / `---` / `@@`) are always LF, so only the diff **body** was affected — which is why the numstat-based file list stayed correct.

**中文** — `DiffDocument.parse` 用 `text.split(separator: "\n")` 切分 diff 正文。Swift 把 `"\r\n"` 当作**单个字符**(扩展字形簇),所以 `"\n"` 分隔符永远匹配不到 CRLF —— 所有 CRLF 结尾的行被静默合并成一大坨,整体被归为 context。结果:检测到 0 增/0 删 → 没有着色,而未切分的整块文本(仍带着 `+`/`-`)被原样渲染。git 自身的元信息行(`index` / `+++` / `---` / `@@`)始终是 LF,所以只有 diff **正文**受影响 —— 这也解释了为什么基于 numstat 的文件列表统计一直是对的。

## Fix / 修复

**EN** — Normalize `\r\n` and lone `\r` to `\n` before splitting. One line of intent + two `replacingOccurrences` passes; the rest of the parser is unchanged.

**中文** — 切行前先把 `\r\n` 和单独的 `\r` 归一成 `\n`。一行意图 + 两次 `replacingOccurrences`,解析器其余部分不动。

## Verification / 验证

- **EN** — Reproduced against a real CRLF Java diff (`PayServiceTest.java`): before `+0 / -0`, after `+109 / -3` (matches `git diff --numstat`). LF/YAML diffs unchanged.
- **中文** — 用真实 CRLF 的 Java diff(`PayServiceTest.java`)验证:修复前 `+0 / -0`,修复后 `+109 / -3`(与 `git diff --numstat` 一致)。LF/YAML 的 diff 不受影响。
- `xcodebuild -scheme Glint -configuration Debug` → **BUILD SUCCEEDED**.

## Scope / 范围

Only `DiffDocument.parse` (`Glint/Review/ReviewWindow.swift`, +10/−1). Independent of #30.

---
`Co-Authored-By: Claude <noreply@anthropic.com>`