### PR TITLE
[codex] support multiple Codex home directories

### DIFF
--- a/Glint.xcodeproj/project.pbxproj
+++ b/Glint.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		F6AFF715FCE5357CEB07683D /* SettingsSafety.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB20921E3CAC1006A8FBD3AE /* SettingsSafety.swift */; };
 		F7ABF70CD455143BF89B89B3 /* SafeJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E2B9ADF809766CE4278047 /* SafeJSON.swift */; };
 		FCB67525DF16A4DCF9B2AF7A /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 376568363043C189904E4E0A /* Localizable.xcstrings */; };
+		FEBC3158CB471E9ABDF931BB /* CodexUsageReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FBF22AEC81DBE92987A8CB4 /* CodexUsageReaderTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -69,6 +70,7 @@
 		08FC2FBC9E8729A5ECBF857C /* PaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneView.swift; sourceTree = "<group>"; };
 		0D29C0D2447094B07854C193 /* NewWorkspaceSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorkspaceSheet.swift; sourceTree = "<group>"; };
 		0F58E2127BAE2C9F5155CF07 /* DevinHookInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevinHookInstallerTests.swift; sourceTree = "<group>"; };
+		0FBF22AEC81DBE92987A8CB4 /* CodexUsageReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexUsageReaderTests.swift; sourceTree = "<group>"; };
 		150EEF32284061D527E51866 /* GlintTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlintTheme.swift; sourceTree = "<group>"; };
 		16137B405E48DBE262A15B6D /* PaneSurfaceRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneSurfaceRepresentable.swift; sourceTree = "<group>"; };
 		1E646AABA8ADCE8A2A5C6F55 /* PaneTreeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneTreeView.swift; sourceTree = "<group>"; };
@@ -156,6 +158,7 @@
 				4EEF00CBEF45A9D60423A207 /* AgentKindResolutionTests.swift */,
 				6AB338782EF6F22B7B381DA8 /* CodexHomeStoreTests.swift */,
 				26141150D2DB4C0589558ECC /* CodexHookInstallerTests.swift */,
+				0FBF22AEC81DBE92987A8CB4 /* CodexUsageReaderTests.swift */,
 				0F58E2127BAE2C9F5155CF07 /* DevinHookInstallerTests.swift */,
 				349714D49AE52D84995314FD /* MascotAssetTests.swift */,
 				EBCC04C19D745AA867D961FD /* PaneAgentKindTests.swift */,
@@ -385,6 +388,7 @@
 				81532B36FEC3039B8EAD9CB1 /* AgentKindResolutionTests.swift in Sources */,
 				C41119D04864077E5B554F59 /* CodexHomeStoreTests.swift in Sources */,
 				0FEECB27EB1ACE11E29ECCEF /* CodexHookInstallerTests.swift in Sources */,
+				FEBC3158CB471E9ABDF931BB /* CodexUsageReaderTests.swift in Sources */,
 				34997DD4A4F9B64A754FE77F /* DevinHookInstallerTests.swift in Sources */,
 				04E75EAD5165E8D96C1C5517 /* MascotAssetTests.swift in Sources */,
 				ED46CD7A6E09551A775AD3B8 /* PaneAgentKindTests.swift in Sources */,

--- a/Glint.xcodeproj/project.pbxproj
+++ b/Glint.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		04E75EAD5165E8D96C1C5517 /* MascotAssetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349714D49AE52D84995314FD /* MascotAssetTests.swift */; };
+		07817DC6A98F8ED2E236CFA1 /* CodexHome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E3B385162995D0F1F5B72D /* CodexHome.swift */; };
 		1115F230E14FBE3C1FC754A2 /* GhosttySurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E298AD81B1615CBBFD69F48A /* GhosttySurfaceView.swift */; };
 		11AB712CD3F25FE8A034F205 /* GitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F54835E4A44EC88236EFBE /* GitService.swift */; };
 		164C6F51683CE7942393E816 /* GitDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7039488F4C2F75498E461311 /* GitDiff.swift */; };
@@ -34,6 +35,7 @@
 		B1DE20B081ACC4536DBD2089 /* GitStatusPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54663E213FE879B96C0D80E7 /* GitStatusPopover.swift */; };
 		B70CAFEBB2416E25B0FFED97 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = C48F9D3C512A0ABE8369D0F4 /* Sparkle */; };
 		C0E8D97C08BA3F0FA33F31E7 /* CommandPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 235E2D958A2244483CAA0812 /* CommandPalette.swift */; };
+		C41119D04864077E5B554F59 /* CodexHomeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AB338782EF6F22B7B381DA8 /* CodexHomeStoreTests.swift */; };
 		C48BD1224EA2C6D3C87B9120 /* AgentPaneSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829D894CF747D6BC08667239 /* AgentPaneSummary.swift */; };
 		C748DE21F23B49B2FFD73DC7 /* WorkspaceIconKindTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E4DF4C5180D50C381B4976 /* WorkspaceIconKindTests.swift */; };
 		CD30F5E1B78B3C46C9990FD6 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C269A6E9AE87961C3356DC /* SidebarView.swift */; };
@@ -76,6 +78,7 @@
 		3023490E670A10EC38870B12 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		349714D49AE52D84995314FD /* MascotAssetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MascotAssetTests.swift; sourceTree = "<group>"; };
 		376568363043C189904E4E0A /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		38E3B385162995D0F1F5B72D /* CodexHome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexHome.swift; sourceTree = "<group>"; };
 		39F54835E4A44EC88236EFBE /* GitService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitService.swift; sourceTree = "<group>"; };
 		3E2E78BBA22734DD486C760B /* Glint.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Glint.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		41DDB9C7B5A277B7924270A3 /* PaneAgentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneAgentState.swift; sourceTree = "<group>"; };
@@ -85,6 +88,7 @@
 		54663E213FE879B96C0D80E7 /* GitStatusPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusPopover.swift; sourceTree = "<group>"; };
 		5A8933F67B4B6EEA3FD4E603 /* WorkspaceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceStore.swift; sourceTree = "<group>"; };
 		6860F8F626EFDB9A289FC727 /* themes.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = themes.json; sourceTree = "<group>"; };
+		6AB338782EF6F22B7B381DA8 /* CodexHomeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexHomeStoreTests.swift; sourceTree = "<group>"; };
 		6D3B64992BBD5A190DFE36D2 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		7039488F4C2F75498E461311 /* GitDiff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitDiff.swift; sourceTree = "<group>"; };
 		7CB74659D174004C620D538A /* GlintApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlintApp.swift; sourceTree = "<group>"; };
@@ -148,6 +152,7 @@
 			isa = PBXGroup;
 			children = (
 				4EEF00CBEF45A9D60423A207 /* AgentKindResolutionTests.swift */,
+				6AB338782EF6F22B7B381DA8 /* CodexHomeStoreTests.swift */,
 				0F58E2127BAE2C9F5155CF07 /* DevinHookInstallerTests.swift */,
 				349714D49AE52D84995314FD /* MascotAssetTests.swift */,
 				EBCC04C19D745AA867D961FD /* PaneAgentKindTests.swift */,
@@ -195,6 +200,7 @@
 				05F2CA2243872C8111048EF2 /* AgentBridge.swift */,
 				265A192AC9BD06DB09346E90 /* AgentHookInstaller.swift */,
 				829D894CF747D6BC08667239 /* AgentPaneSummary.swift */,
+				38E3B385162995D0F1F5B72D /* CodexHome.swift */,
 				21868C7211897C87A6CAD7C3 /* ControlBridge.swift */,
 				41DDB9C7B5A277B7924270A3 /* PaneAgentState.swift */,
 				C9E2B9ADF809766CE4278047 /* SafeJSON.swift */,
@@ -374,6 +380,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				81532B36FEC3039B8EAD9CB1 /* AgentKindResolutionTests.swift in Sources */,
+				C41119D04864077E5B554F59 /* CodexHomeStoreTests.swift in Sources */,
 				34997DD4A4F9B64A754FE77F /* DevinHookInstallerTests.swift in Sources */,
 				04E75EAD5165E8D96C1C5517 /* MascotAssetTests.swift in Sources */,
 				ED46CD7A6E09551A775AD3B8 /* PaneAgentKindTests.swift in Sources */,
@@ -389,6 +396,7 @@
 				3932A4CFEFF6FB81AE283645 /* AgentHookInstaller.swift in Sources */,
 				C48BD1224EA2C6D3C87B9120 /* AgentPaneSummary.swift in Sources */,
 				5157C5439862F21202BCC44D /* AppDelegate.swift in Sources */,
+				07817DC6A98F8ED2E236CFA1 /* CodexHome.swift in Sources */,
 				C0E8D97C08BA3F0FA33F31E7 /* CommandPalette.swift in Sources */,
 				CD7908F096580864CB2992ED /* ContentView.swift in Sources */,
 				EF937781512647E835836F83 /* ControlBridge.swift in Sources */,

--- a/Glint.xcodeproj/project.pbxproj
+++ b/Glint.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		04E75EAD5165E8D96C1C5517 /* MascotAssetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349714D49AE52D84995314FD /* MascotAssetTests.swift */; };
 		07817DC6A98F8ED2E236CFA1 /* CodexHome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E3B385162995D0F1F5B72D /* CodexHome.swift */; };
+		0FEECB27EB1ACE11E29ECCEF /* CodexHookInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26141150D2DB4C0589558ECC /* CodexHookInstallerTests.swift */; };
 		1115F230E14FBE3C1FC754A2 /* GhosttySurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E298AD81B1615CBBFD69F48A /* GhosttySurfaceView.swift */; };
 		11AB712CD3F25FE8A034F205 /* GitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F54835E4A44EC88236EFBE /* GitService.swift */; };
 		164C6F51683CE7942393E816 /* GitDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7039488F4C2F75498E461311 /* GitDiff.swift */; };
@@ -74,6 +75,7 @@
 		21868C7211897C87A6CAD7C3 /* ControlBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlBridge.swift; sourceTree = "<group>"; };
 		235E2D958A2244483CAA0812 /* CommandPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPalette.swift; sourceTree = "<group>"; };
 		25DADCEBA9C483C729B69388 /* Glint.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Glint.entitlements; sourceTree = "<group>"; };
+		26141150D2DB4C0589558ECC /* CodexHookInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexHookInstallerTests.swift; sourceTree = "<group>"; };
 		265A192AC9BD06DB09346E90 /* AgentHookInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookInstaller.swift; sourceTree = "<group>"; };
 		3023490E670A10EC38870B12 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		349714D49AE52D84995314FD /* MascotAssetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MascotAssetTests.swift; sourceTree = "<group>"; };
@@ -153,6 +155,7 @@
 			children = (
 				4EEF00CBEF45A9D60423A207 /* AgentKindResolutionTests.swift */,
 				6AB338782EF6F22B7B381DA8 /* CodexHomeStoreTests.swift */,
+				26141150D2DB4C0589558ECC /* CodexHookInstallerTests.swift */,
 				0F58E2127BAE2C9F5155CF07 /* DevinHookInstallerTests.swift */,
 				349714D49AE52D84995314FD /* MascotAssetTests.swift */,
 				EBCC04C19D745AA867D961FD /* PaneAgentKindTests.swift */,
@@ -381,6 +384,7 @@
 			files = (
 				81532B36FEC3039B8EAD9CB1 /* AgentKindResolutionTests.swift in Sources */,
 				C41119D04864077E5B554F59 /* CodexHomeStoreTests.swift in Sources */,
+				0FEECB27EB1ACE11E29ECCEF /* CodexHookInstallerTests.swift in Sources */,
 				34997DD4A4F9B64A754FE77F /* DevinHookInstallerTests.swift in Sources */,
 				04E75EAD5165E8D96C1C5517 /* MascotAssetTests.swift in Sources */,
 				ED46CD7A6E09551A775AD3B8 /* PaneAgentKindTests.swift in Sources */,

--- a/Glint/Agent/AgentHookInstaller.swift
+++ b/Glint/Agent/AgentHookInstaller.swift
@@ -514,7 +514,11 @@ enum CodexHookInstaller {
         let codexDir = codexHome.standardizedFileURL
         let url = codexDir.appendingPathComponent("hooks.json")
         do {
-            try FileManager.default.createDirectory(at: codexDir, withIntermediateDirectories: true)
+            try FileManager.default.createDirectory(
+                at: codexDir,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
         } catch {
             throw CodexHookInstallerError.cannotCreateHome(error.localizedDescription)
         }

--- a/Glint/Agent/AgentHookInstaller.swift
+++ b/Glint/Agent/AgentHookInstaller.swift
@@ -405,6 +405,16 @@ enum CodexHookInstaller {
         return false
     }
 
+    static func status(in codexHome: URL) -> CodexHookStatus {
+        let url = codexHome.appendingPathComponent("hooks.json")
+        guard FileManager.default.fileExists(atPath: url.path) else { return .notInstalled }
+        guard let data = try? Data(contentsOf: url),
+              (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) != nil else {
+            return .error("Invalid hooks.json")
+        }
+        return isInstalled(in: codexHome) ? .installed : .notInstalled
+    }
+
     /// Whether the Codex CLI itself looks installed on this Mac.
     static func isAgentPresent() -> Bool {
         AgentPresence.directoryExists(".codex")

--- a/Glint/Agent/AgentHookInstaller.swift
+++ b/Glint/Agent/AgentHookInstaller.swift
@@ -382,8 +382,11 @@ enum CodexHookInstaller {
     ]
 
     static func isInstalled() -> Bool {
-        let url = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".codex/hooks.json")
+        configuredHomes().contains { isInstalled(in: $0.resolvedURL) }
+    }
+
+    static func isInstalled(in codexHome: URL) -> Bool {
+        let url = codexHome.appendingPathComponent("hooks.json")
         guard let data = try? Data(contentsOf: url),
               let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let hooks = root["hooks"] as? [String: Any] else {
@@ -410,16 +413,35 @@ enum CodexHookInstaller {
 
     static func installIfNeeded(socketPath: String) {
         guard let scriptPath = AgentHookInstaller.ensureReporterScript() else { return }
-        mergeCodexHooks(scriptPath: scriptPath)
+        for home in configuredHomes().filter(\.isEnabled) {
+            do {
+                try mergeCodexHooks(scriptPath: scriptPath, codexHome: home.resolvedURL)
+            } catch {
+                NSLog("[glint] codex hook install failed for \(home.resolvedURL.path): \(error)")
+            }
+        }
         _ = socketPath
+    }
+
+    static func install(in codexHome: URL) throws {
+        guard let scriptPath = AgentHookInstaller.ensureReporterScript() else {
+            throw CodexHookInstallerError.reporterUnavailable
+        }
+        try mergeCodexHooks(scriptPath: scriptPath, codexHome: codexHome)
     }
 
     /// Remove Glint's entries from `~/.codex/hooks.json`. The reporter script
     /// itself is shared with Claude, so we only delete it when neither agent
     /// still references it.
     static func uninstall() {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        let url = home.appendingPathComponent(".codex/hooks.json")
+        for home in configuredHomes() {
+            try? uninstall(from: home.resolvedURL)
+        }
+        removeReporterIfUnused()
+    }
+
+    static func uninstall(from codexHome: URL) throws {
+        let url = codexHome.appendingPathComponent("hooks.json")
         if let data = try? Data(contentsOf: url),
            var root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
             var hooks = (root["hooks"] as? [String: Any]) ?? [:]
@@ -448,20 +470,22 @@ enum CodexHookInstaller {
                 }
                 if root.isEmpty {
                     // Whole file was just our hooks → remove it cleanly.
-                    try? FileManager.default.removeItem(at: url)
+                    try FileManager.default.removeItem(at: url)
                 } else if let out = SafeJSON.data(
                     root,
                     options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
                 ) {
                     let mode = posixPermissions(atPath: url.path)
-                    try? out.write(to: url, options: [.atomic])
+                    try out.write(to: url, options: [.atomic])
                     setPosixPermissions(mode, atPath: url.path)
                 }
                 NSLog("[glint] codex hooks removed from \(url.path)")
             }
         }
-        // Only nuke the shared reporter if no other installed agent still
-        // references it — Claude, Codex, and Devin all share the same script.
+    }
+
+    private static func removeReporterIfUnused() {
+        let home = FileManager.default.homeDirectoryForCurrentUser
         if !AgentHookInstaller.isInstalled() && !CodexHookInstaller.isInstalled()
             && !DevinHookInstaller.isInstalled() {
             let script = home.appendingPathComponent(".glint/hooks/glint-report.sh")
@@ -469,15 +493,13 @@ enum CodexHookInstaller {
         }
     }
 
-    private static func mergeCodexHooks(scriptPath: String) {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        let codexDir = home.appendingPathComponent(".codex", isDirectory: true)
+    static func mergeCodexHooks(scriptPath: String, codexHome: URL) throws {
+        let codexDir = codexHome.standardizedFileURL
         let url = codexDir.appendingPathComponent("hooks.json")
         do {
             try FileManager.default.createDirectory(at: codexDir, withIntermediateDirectories: true)
         } catch {
-            NSLog("[glint] couldn't create ~/.codex: \(error)")
-            return
+            throw CodexHookInstallerError.cannotCreateHome(error.localizedDescription)
         }
 
         var root: [String: Any] = [:]
@@ -487,8 +509,7 @@ enum CodexHookInstaller {
                 let backup = url.appendingPathExtension("glint-backup")
                 try? FileManager.default.copyItem(at: url, to: backup)
                 setPosixPermissions(posixPermissions(atPath: url.path), atPath: backup.path)
-                NSLog("[glint] ~/.codex/hooks.json isn't a JSON object; backed up to \(backup.lastPathComponent), skipping merge")
-                return
+                throw CodexHookInstallerError.invalidHooksJSON
             }
             root = dict
         }
@@ -522,8 +543,7 @@ enum CodexHookInstaller {
             root,
             options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
         ) else {
-            NSLog("[glint] ~/.codex/hooks.json: hook tree not serializable, skipping write")
-            return
+            throw CodexHookInstallerError.invalidHookTree
         }
         do {
             // Same mode-preservation dance as the Claude merge above.
@@ -538,8 +558,16 @@ enum CodexHookInstaller {
             setPosixPermissions(mode, atPath: url.path)
             NSLog("[glint] codex hooks merged into \(url.path)")
         } catch {
-            NSLog("[glint] writing ~/.codex/hooks.json failed: \(error)")
+            throw CodexHookInstallerError.writeFailed(error.localizedDescription)
         }
+    }
+
+    private static func configuredHomes(defaults: UserDefaults = .standard) -> [CodexHome] {
+        guard let data = defaults.data(forKey: CodexHomeStore.storageKey),
+              let homes = try? JSONDecoder().decode([CodexHome].self, from: data),
+              !homes.isEmpty else { return [.default] }
+        var seen = Set<URL>()
+        return homes.filter { seen.insert($0.resolvedURL).inserted }
     }
 
     private static func equalsJSON(_ a: Any?, _ b: Any) -> Bool {
@@ -550,6 +578,24 @@ enum CodexHookInstaller {
             return false
         }
         return da == db
+    }
+}
+
+enum CodexHookInstallerError: LocalizedError, Equatable {
+    case reporterUnavailable
+    case cannotCreateHome(String)
+    case invalidHooksJSON
+    case invalidHookTree
+    case writeFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .reporterUnavailable: return "Could not create the Glint reporter script."
+        case .cannotCreateHome(let detail): return "Could not create the Codex Home directory: \(detail)"
+        case .invalidHooksJSON: return "Invalid hooks.json. The file was not modified."
+        case .invalidHookTree: return "The hook configuration cannot be encoded as JSON."
+        case .writeFailed(let detail): return "Could not write hooks.json: \(detail)"
+        }
     }
 }
 

--- a/Glint/Agent/AgentHookInstaller.swift
+++ b/Glint/Agent/AgentHookInstaller.swift
@@ -457,14 +457,14 @@ enum CodexHookInstaller {
         do {
             data = try Data(contentsOf: url)
         } catch {
-            throw CodexHookInstallerError.writeFailed(error.localizedDescription)
+            throw CodexHookInstallerError.readFailed(error.localizedDescription)
         }
         guard var root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             throw CodexHookInstallerError.invalidHooksJSON
         }
         var hooks = (root["hooks"] as? [String: Any]) ?? [:]
         var touched = false
-        for (event, bucket) in hooks {
+        for (event, bucket) in Array(hooks) {
             guard let arr = bucket as? [Any] else { continue }
             let filtered = arr.filter { entry in
                 guard let group = entry as? [String: Any],
@@ -607,6 +607,7 @@ enum CodexHookInstallerError: LocalizedError, Equatable {
     case cannotCreateHome(String)
     case invalidHooksJSON
     case invalidHookTree
+    case readFailed(String)
     case writeFailed(String)
 
     var errorDescription: String? {
@@ -615,6 +616,7 @@ enum CodexHookInstallerError: LocalizedError, Equatable {
         case .cannotCreateHome(let detail): return "Could not create the Codex Home directory: \(detail)"
         case .invalidHooksJSON: return "Invalid hooks.json. The file was not modified."
         case .invalidHookTree: return "The hook configuration cannot be encoded as JSON."
+        case .readFailed(let detail): return "Could not read hooks.json: \(detail)"
         case .writeFailed(let detail): return "Could not write hooks.json: \(detail)"
         }
     }

--- a/Glint/Agent/AgentHookInstaller.swift
+++ b/Glint/Agent/AgentHookInstaller.swift
@@ -452,45 +452,52 @@ enum CodexHookInstaller {
 
     static func uninstall(from codexHome: URL) throws {
         let url = codexHome.appendingPathComponent("hooks.json")
-        if let data = try? Data(contentsOf: url),
-           var root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
-            var hooks = (root["hooks"] as? [String: Any]) ?? [:]
-            var touched = false
-            for (event, bucket) in hooks {
-                guard let arr = bucket as? [Any] else { continue }
-                let filtered = arr.filter { entry in
-                    guard let group = entry as? [String: Any],
-                          let inner = group["hooks"] as? [[String: Any]] else { return true }
-                    return !inner.contains { ($0["command"] as? String)?.contains("glint-report.sh") == true }
-                }
-                if filtered.count != arr.count {
-                    touched = true
-                    if filtered.isEmpty {
-                        hooks.removeValue(forKey: event)
-                    } else {
-                        hooks[event] = filtered
-                    }
-                }
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            throw CodexHookInstallerError.writeFailed(error.localizedDescription)
+        }
+        guard var root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw CodexHookInstallerError.invalidHooksJSON
+        }
+        var hooks = (root["hooks"] as? [String: Any]) ?? [:]
+        var touched = false
+        for (event, bucket) in hooks {
+            guard let arr = bucket as? [Any] else { continue }
+            let filtered = arr.filter { entry in
+                guard let group = entry as? [String: Any],
+                      let inner = group["hooks"] as? [[String: Any]] else { return true }
+                return !inner.contains { ($0["command"] as? String)?.contains("glint-report.sh") == true }
             }
-            if touched {
-                if hooks.isEmpty {
-                    root.removeValue(forKey: "hooks")
+            if filtered.count != arr.count {
+                touched = true
+                if filtered.isEmpty {
+                    hooks.removeValue(forKey: event)
                 } else {
-                    root["hooks"] = hooks
+                    hooks[event] = filtered
                 }
-                if root.isEmpty {
-                    // Whole file was just our hooks → remove it cleanly.
-                    try FileManager.default.removeItem(at: url)
-                } else if let out = SafeJSON.data(
-                    root,
-                    options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
-                ) {
-                    let mode = posixPermissions(atPath: url.path)
-                    try out.write(to: url, options: [.atomic])
-                    setPosixPermissions(mode, atPath: url.path)
-                }
-                NSLog("[glint] codex hooks removed from \(url.path)")
             }
+        }
+        if touched {
+            if hooks.isEmpty {
+                root.removeValue(forKey: "hooks")
+            } else {
+                root["hooks"] = hooks
+            }
+            if root.isEmpty {
+                // Whole file was just our hooks → remove it cleanly.
+                try FileManager.default.removeItem(at: url)
+            } else if let out = SafeJSON.data(
+                root,
+                options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+            ) {
+                let mode = posixPermissions(atPath: url.path)
+                try out.write(to: url, options: [.atomic])
+                setPosixPermissions(mode, atPath: url.path)
+            }
+            NSLog("[glint] codex hooks removed from \(url.path)")
         }
     }
 

--- a/Glint/Agent/CodexHome.swift
+++ b/Glint/Agent/CodexHome.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Combine
+
+struct CodexHome: Codable, Identifiable, Hashable {
+    var id: UUID
+    var label: String?
+    var path: String
+    var isEnabled: Bool
+
+    init(id: UUID = UUID(), label: String? = nil, path: String, isEnabled: Bool = true) {
+        self.id = id
+        self.label = label
+        self.path = path
+        self.isEnabled = isEnabled
+    }
+
+    static var `default`: CodexHome {
+        CodexHome(label: "Default", path: "~/.codex")
+    }
+
+    var resolvedURL: URL {
+        URL(
+            fileURLWithPath: (path as NSString).expandingTildeInPath,
+            isDirectory: true
+        ).standardizedFileURL
+    }
+}
+
+enum CodexHookStatus: Hashable {
+    case installed
+    case notInstalled
+    case error(String)
+}
+
+enum CodexAuthStatus: Hashable {
+    case found
+    case missing
+    case invalid(String)
+}
+
+enum CodexQuotaStatus: Hashable {
+    case available(AgentQuota)
+    case unavailable(String)
+    case loading
+}
+
+struct CodexHomeStatus: Identifiable, Hashable {
+    var id: UUID { home.id }
+    var home: CodexHome
+    var resolvedURL: URL
+    var hookStatus: CodexHookStatus
+    var authStatus: CodexAuthStatus
+    var quotaStatus: CodexQuotaStatus
+}
+
+@MainActor
+final class CodexHomeStore: ObservableObject {
+    @Published private(set) var homes: [CodexHome]
+
+    nonisolated static let storageKey = "glint.codexHomes"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        if let data = defaults.data(forKey: Self.storageKey),
+           let decoded = try? JSONDecoder().decode([CodexHome].self, from: data),
+           !decoded.isEmpty {
+            homes = Self.deduplicated(decoded)
+        } else {
+            homes = [.default]
+        }
+    }
+
+    var enabledHomes: [CodexHome] {
+        homes.filter(\.isEnabled)
+    }
+
+    func add(path: String, label: String? = nil) -> Bool {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        let home = CodexHome(label: label?.nilIfBlank, path: trimmed)
+        guard !contains(resolvedURL: home.resolvedURL) else { return false }
+        homes.append(home)
+        save()
+        return true
+    }
+
+    func update(_ home: CodexHome) -> Bool {
+        guard let index = homes.firstIndex(where: { $0.id == home.id }) else { return false }
+        guard !homes.enumerated().contains(where: { offset, existing in
+            offset != index && existing.resolvedURL == home.resolvedURL
+        }) else { return false }
+        homes[index] = home
+        save()
+        return true
+    }
+
+    func setEnabled(_ isEnabled: Bool, for id: UUID) {
+        guard let index = homes.firstIndex(where: { $0.id == id }),
+              homes[index].isEnabled != isEnabled else { return }
+        homes[index].isEnabled = isEnabled
+        save()
+    }
+
+    @discardableResult
+    func remove(id: UUID) -> Bool {
+        guard let home = homes.first(where: { $0.id == id }),
+              home.resolvedURL != CodexHome.default.resolvedURL else { return false }
+        homes.removeAll { $0.id == id }
+        save()
+        return true
+    }
+
+    func isDefault(_ home: CodexHome) -> Bool {
+        home.resolvedURL == CodexHome.default.resolvedURL
+    }
+
+    private func contains(resolvedURL: URL) -> Bool {
+        homes.contains { $0.resolvedURL == resolvedURL }
+    }
+
+    private func save() {
+        guard let data = try? JSONEncoder().encode(homes) else { return }
+        defaults.set(data, forKey: Self.storageKey)
+    }
+
+    private static func deduplicated(_ homes: [CodexHome]) -> [CodexHome] {
+        var seen = Set<URL>()
+        return homes.filter { seen.insert($0.resolvedURL).inserted }
+    }
+}
+
+private extension String {
+    var nilIfBlank: String? {
+        let value = trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+}

--- a/Glint/Agent/CodexHome.swift
+++ b/Glint/Agent/CodexHome.swift
@@ -60,6 +60,13 @@ struct CodexHomeStatus: Identifiable, Hashable {
     var quotaStatus: CodexQuotaStatus
 }
 
+enum CodexHomeAddResult: Equatable {
+    case added
+    case emptyPath
+    case relativePath
+    case duplicate
+}
+
 @MainActor
 final class CodexHomeStore: ObservableObject {
     @Published private(set) var homes: [CodexHome]
@@ -83,14 +90,15 @@ final class CodexHomeStore: ObservableObject {
         homes.filter(\.isEnabled)
     }
 
-    func add(path: String, label: String? = nil) -> Bool {
+    func add(path: String, label: String? = nil) -> CodexHomeAddResult {
         let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return false }
+        guard !trimmed.isEmpty else { return .emptyPath }
+        guard trimmed.hasPrefix("/") || trimmed.hasPrefix("~") else { return .relativePath }
         let home = CodexHome(label: label?.nilIfBlank, path: trimmed)
-        guard !contains(resolvedURL: home.resolvedURL) else { return false }
+        guard !contains(resolvedURL: home.resolvedURL) else { return .duplicate }
         homes.append(home)
         save()
-        return true
+        return .added
     }
 
     func update(_ home: CodexHome) -> Bool {

--- a/Glint/Agent/CodexHome.swift
+++ b/Glint/Agent/CodexHome.swift
@@ -14,8 +14,10 @@ struct CodexHome: Codable, Identifiable, Hashable {
         self.isEnabled = isEnabled
     }
 
+    static let defaultID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+
     static var `default`: CodexHome {
-        CodexHome(label: "Default", path: "~/.codex")
+        CodexHome(id: defaultID, label: "Default", path: "~/.codex")
     }
 
     var resolvedURL: URL {

--- a/Glint/Agent/CodexHome.swift
+++ b/Glint/Agent/CodexHome.swift
@@ -131,6 +131,27 @@ final class CodexHomeStore: ObservableObject {
     }
 }
 
+@MainActor
+enum CodexHomeRemoval {
+    /// Removing Glint's configuration must not depend on an external
+    /// `hooks.json` being readable. Return the cleanup error for UI reporting,
+    /// but always remove the non-default home from the store.
+    static func remove(
+        _ home: CodexHome,
+        from store: CodexHomeStore,
+        cleanup: (URL) throws -> Void
+    ) -> String? {
+        var cleanupError: String?
+        do {
+            try cleanup(home.resolvedURL)
+        } catch {
+            cleanupError = error.localizedDescription
+        }
+        _ = store.remove(id: home.id)
+        return cleanupError
+    }
+}
+
 private extension String {
     var nilIfBlank: String? {
         let value = trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Glint/Agent/CodexHome.swift
+++ b/Glint/Agent/CodexHome.swift
@@ -44,6 +44,11 @@ enum CodexQuotaStatus: Hashable {
     case available(AgentQuota)
     case unavailable(String)
     case loading
+
+    static func placeholder(isHomeEnabled: Bool, isUsageEnabled: Bool) -> CodexQuotaStatus {
+        if !isHomeEnabled { return .unavailable("Disabled") }
+        return isUsageEnabled ? .loading : .unavailable("Usage off")
+    }
 }
 
 struct CodexHomeStatus: Identifiable, Hashable {

--- a/Glint/Agent/UsageStore.swift
+++ b/Glint/Agent/UsageStore.swift
@@ -5,7 +5,7 @@ import IOKit
 
 /// One agent's rate-limit snapshot. Percentages are 0–100 (fraction of the
 /// window already consumed); `nil` fields mean "not reported by this source".
-struct AgentQuota: Equatable, Codable {
+struct AgentQuota: Hashable, Codable {
     /// Rolling session window (Codex `primary`, ~5h). 0–100.
     var sessionPercent: Double
     /// Longer rolling window (Codex `secondary`, ~7d). nil when unknown.

--- a/Glint/Agent/UsageStore.swift
+++ b/Glint/Agent/UsageStore.swift
@@ -72,6 +72,23 @@ enum CodexQuotaPresentation {
     }
 }
 
+struct CodexRefreshCoordinator {
+    private(set) var generation = 0
+
+    mutating func begin() -> Int {
+        generation += 1
+        return generation
+    }
+
+    mutating func invalidate() {
+        generation += 1
+    }
+
+    func accepts(_ candidate: Int) -> Bool {
+        candidate == generation
+    }
+}
+
 /// Polls per-agent usage/rate-limit data and republishes it for the sidebar.
 ///
 /// Data sources are asymmetric on purpose:
@@ -125,6 +142,7 @@ final class UsageStore: ObservableObject {
             guard codexEnabled != oldValue else { return }
             UserDefaults.standard.set(codexEnabled, forKey: Self.codexKey)
             if !codexEnabled {
+                codexRefreshCoordinator.invalidate()
                 codex = nil
                 codexHomeStatuses = []
                 Self.saveQuota(nil, agent: .codex)
@@ -137,6 +155,7 @@ final class UsageStore: ObservableObject {
     private static let claudeKey = "glint.showClaudeUsage"
     private static let codexKey = "glint.showCodexUsage"
     private var timer: Timer?
+    private var codexRefreshCoordinator = CodexRefreshCoordinator()
     /// Refresh cadence. Rate-limit windows move on the order of minutes, so a
     /// minute of staleness is invisible and keeps disk/network churn trivial.
     private let interval: TimeInterval = 60
@@ -175,10 +194,13 @@ final class UsageStore: ObservableObject {
     /// Refresh whichever agents are currently enabled and publish results.
     func refreshNow() {
         if codexEnabled {
+            let generation = codexRefreshCoordinator.begin()
             Task { [weak self] in
                 let homes = Self.configuredCodexHomes().filter(\.isEnabled)
                 await MainActor.run {
-                    self?.codexHomeStatuses = homes.map {
+                    guard let self,
+                          self.codexRefreshCoordinator.accepts(generation) else { return }
+                    self.codexHomeStatuses = homes.map {
                         CodexHomeStatus(
                             home: $0,
                             resolvedURL: $0.resolvedURL,
@@ -206,7 +228,11 @@ final class UsageStore: ObservableObject {
                     for await status in group { byID[status.id] = status }
                     return homes.compactMap { byID[$0.id] }
                 }
-                await MainActor.run { self?.applyCodex(statuses) }
+                await MainActor.run {
+                    guard let self,
+                          self.codexRefreshCoordinator.accepts(generation) else { return }
+                    self.applyCodex(statuses)
+                }
             }
         }
         if claudeEnabled {

--- a/Glint/Agent/UsageStore.swift
+++ b/Glint/Agent/UsageStore.swift
@@ -45,6 +45,32 @@ struct AgentQuota: Hashable, Codable {
     }
 }
 
+struct CodexSidebarQuota: Identifiable, Hashable {
+    let id: UUID
+    let name: String
+    let quota: AgentQuota
+}
+
+enum CodexQuotaPresentation {
+    static func sidebarItems(
+        from statuses: [CodexHomeStatus],
+        fallback: AgentQuota?
+    ) -> [CodexSidebarQuota] {
+        let items = statuses.compactMap { status -> CodexSidebarQuota? in
+            guard case .available(let quota) = status.quotaStatus,
+                  let quota = quota.sanitized() else { return nil }
+            return CodexSidebarQuota(
+                id: status.id,
+                name: status.home.label ?? status.resolvedURL.lastPathComponent,
+                quota: quota
+            )
+        }
+        if !items.isEmpty { return items }
+        guard let fallback = fallback?.sanitized() else { return [] }
+        return [CodexSidebarQuota(id: CodexHome.default.id, name: "Codex", quota: fallback)]
+    }
+}
+
 /// Polls per-agent usage/rate-limit data and republishes it for the sidebar.
 ///
 /// Data sources are asymmetric on purpose:
@@ -73,6 +99,10 @@ final class UsageStore: ObservableObject {
     @Published private(set) var claude: AgentQuota?
     @Published private(set) var codex: AgentQuota?
     @Published private(set) var codexHomeStatuses: [CodexHomeStatus] = []
+
+    var codexSidebarQuotas: [CodexSidebarQuota] {
+        CodexQuotaPresentation.sidebarItems(from: codexHomeStatuses, fallback: codex)
+    }
 
     /// Per-agent switches, persisted, default off — opt-in, since Claude's
     /// poll needs login-keychain access (a system prompt on first read).

--- a/Glint/Agent/UsageStore.swift
+++ b/Glint/Agent/UsageStore.swift
@@ -72,6 +72,7 @@ struct AgentQuota: Hashable, Codable {
 final class UsageStore: ObservableObject {
     @Published private(set) var claude: AgentQuota?
     @Published private(set) var codex: AgentQuota?
+    @Published private(set) var codexHomeStatuses: [CodexHomeStatus] = []
 
     /// Per-agent switches, persisted, default off — opt-in, since Claude's
     /// poll needs login-keychain access (a system prompt on first read).
@@ -88,7 +89,11 @@ final class UsageStore: ObservableObject {
         didSet {
             guard codexEnabled != oldValue else { return }
             UserDefaults.standard.set(codexEnabled, forKey: Self.codexKey)
-            if !codexEnabled { codex = nil; Self.saveQuota(nil, agent: .codex) }
+            if !codexEnabled {
+                codex = nil
+                codexHomeStatuses = []
+                Self.saveQuota(nil, agent: .codex)
+            }
             syncTimer()
             if codexEnabled { refreshNow() }
         }
@@ -136,8 +141,37 @@ final class UsageStore: ObservableObject {
     func refreshNow() {
         if codexEnabled {
             Task { [weak self] in
-                let codex = await CodexUsageReader.readPreferLive()
-                await MainActor.run { self?.apply(codex, to: .codex) }
+                let homes = Self.configuredCodexHomes().filter(\.isEnabled)
+                await MainActor.run {
+                    self?.codexHomeStatuses = homes.map {
+                        CodexHomeStatus(
+                            home: $0,
+                            resolvedURL: $0.resolvedURL,
+                            hookStatus: CodexHookInstaller.status(in: $0.resolvedURL),
+                            authStatus: CodexLiveReader.authStatus(from: $0.resolvedURL),
+                            quotaStatus: .loading
+                        )
+                    }
+                }
+                let statuses = await withTaskGroup(of: CodexHomeStatus.self) { group in
+                    for home in homes {
+                        group.addTask {
+                            let quota = await CodexUsageReader.readPreferLive(from: home.resolvedURL)
+                            return CodexHomeStatus(
+                                home: home,
+                                resolvedURL: home.resolvedURL,
+                                hookStatus: CodexHookInstaller.status(in: home.resolvedURL),
+                                authStatus: CodexLiveReader.authStatus(from: home.resolvedURL),
+                                quotaStatus: quota.map(CodexQuotaStatus.available)
+                                    ?? .unavailable("Quota unavailable")
+                            )
+                        }
+                    }
+                    var byID: [UUID: CodexHomeStatus] = [:]
+                    for await status in group { byID[status.id] = status }
+                    return homes.compactMap { byID[$0.id] }
+                }
+                await MainActor.run { self?.applyCodex(statuses) }
             }
         }
         if claudeEnabled {
@@ -148,6 +182,24 @@ final class UsageStore: ObservableObject {
                 }
             }
         }
+    }
+
+    private func applyCodex(_ statuses: [CodexHomeStatus]) {
+        guard codexEnabled else { return }
+        codexHomeStatuses = statuses
+        let quota = statuses.lazy.compactMap { status -> AgentQuota? in
+            guard case .available(let quota) = status.quotaStatus else { return nil }
+            return quota
+        }.first
+        apply(quota, to: .codex)
+    }
+
+    nonisolated private static func configuredCodexHomes() -> [CodexHome] {
+        guard let data = UserDefaults.standard.data(forKey: CodexHomeStore.storageKey),
+              let homes = try? JSONDecoder().decode([CodexHome].self, from: data),
+              !homes.isEmpty else { return [.default] }
+        var seen = Set<URL>()
+        return homes.filter { seen.insert($0.resolvedURL).inserted }
     }
 
     /// Publish and persist a fresh snapshot. A `nil` result (transient network
@@ -241,14 +293,13 @@ enum CodexUsageReader {
     /// active session, ChatGPT login only); fall back to the on-disk session
     /// snapshot on any failure or in API-key mode. The disk read is bounced off
     /// the main actor since it touches the filesystem.
-    static func readPreferLive() async -> AgentQuota? {
-        if let live = await CodexLiveReader.read() { return live }
-        return await Task.detached(priority: .utility) { read() }.value
+    static func readPreferLive(from codexHome: URL = CodexHome.default.resolvedURL) async -> AgentQuota? {
+        if let live = await CodexLiveReader.read(from: codexHome) { return live }
+        return await Task.detached(priority: .utility) { read(from: codexHome) }.value
     }
 
-    static func read() -> AgentQuota? {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        let sessions = home.appendingPathComponent(".codex/sessions", isDirectory: true)
+    static func read(from codexHome: URL = CodexHome.default.resolvedURL) -> AgentQuota? {
+        let sessions = codexHome.appendingPathComponent("sessions", isDirectory: true)
         let files = recentRolloutFiles(under: sessions, limit: 6)
         // Walk newest-first; the first file that yields a rate_limits line wins
         // (an idle older session would only carry staler numbers).
@@ -364,8 +415,8 @@ enum CodexLiveReader {
         let rate_limit: RateLimit?
     }
 
-    static func read() async -> AgentQuota? {
-        guard let (token, accountId) = loadAuth() else { return nil }
+    static func read(from codexHome: URL = CodexHome.default.resolvedURL) async -> AgentQuota? {
+        guard let (token, accountId) = loadAuth(from: codexHome) else { return nil }
         var req = URLRequest(url: endpoint)
         req.httpMethod = "GET"
         req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
@@ -380,9 +431,18 @@ enum CodexLiveReader {
     /// (access token, account id) when in ChatGPT-OAuth mode. The access token
     /// is owned and rotated by Codex; we only read it. An empty/absent token
     /// (API-key login) yields `nil` so the caller uses the disk fallback.
-    private static func loadAuth() -> (String, String?)? {
-        let path = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".codex/auth.json")
+    static func authStatus(from codexHome: URL) -> CodexAuthStatus {
+        let path = codexHome.appendingPathComponent("auth.json")
+        guard FileManager.default.fileExists(atPath: path.path) else { return .missing }
+        guard let data = try? Data(contentsOf: path),
+              (try? JSONDecoder().decode(Auth.self, from: data)) != nil else {
+            return .invalid("Invalid auth.json")
+        }
+        return .found
+    }
+
+    private static func loadAuth(from codexHome: URL) -> (String, String?)? {
+        let path = codexHome.appendingPathComponent("auth.json")
         guard let data = try? Data(contentsOf: path),
               let auth = try? JSONDecoder().decode(Auth.self, from: data),
               let token = auth.tokens?.access_token, !token.isEmpty else { return nil }

--- a/Glint/Agent/UsageStore.swift
+++ b/Glint/Agent/UsageStore.swift
@@ -54,7 +54,8 @@ struct CodexSidebarQuota: Identifiable, Hashable {
 enum CodexQuotaPresentation {
     static func sidebarItems(
         from statuses: [CodexHomeStatus],
-        fallback: AgentQuota?
+        fallback: AgentQuota?,
+        hasEnabledHomes: Bool = true
     ) -> [CodexSidebarQuota] {
         let items = statuses.compactMap { status -> CodexSidebarQuota? in
             guard case .available(let quota) = status.quotaStatus,
@@ -66,7 +67,7 @@ enum CodexQuotaPresentation {
             )
         }
         if !items.isEmpty { return items }
-        guard let fallback = fallback?.sanitized() else { return [] }
+        guard hasEnabledHomes, let fallback = fallback?.sanitized() else { return [] }
         return [CodexSidebarQuota(id: CodexHome.default.id, name: "Codex", quota: fallback)]
     }
 }
@@ -101,7 +102,11 @@ final class UsageStore: ObservableObject {
     @Published private(set) var codexHomeStatuses: [CodexHomeStatus] = []
 
     var codexSidebarQuotas: [CodexSidebarQuota] {
-        CodexQuotaPresentation.sidebarItems(from: codexHomeStatuses, fallback: codex)
+        CodexQuotaPresentation.sidebarItems(
+            from: codexHomeStatuses,
+            fallback: codex,
+            hasEnabledHomes: Self.configuredCodexHomes().contains(where: \.isEnabled)
+        )
     }
 
     /// Per-agent switches, persisted, default off — opt-in, since Claude's
@@ -217,6 +222,11 @@ final class UsageStore: ObservableObject {
     private func applyCodex(_ statuses: [CodexHomeStatus]) {
         guard codexEnabled else { return }
         codexHomeStatuses = statuses
+        guard !statuses.isEmpty else {
+            codex = nil
+            Self.saveQuota(nil, agent: .codex)
+            return
+        }
         let quota = statuses.lazy.compactMap { status -> AgentQuota? in
             guard case .available(let quota) = status.quotaStatus else { return nil }
             return quota

--- a/Glint/App/GlintApp.swift
+++ b/Glint/App/GlintApp.swift
@@ -6,6 +6,7 @@ struct GlintApp: App {
     @StateObject private var workspaceStore = WorkspaceStore()
     @StateObject private var updater = UpdaterController()
     @StateObject private var usage = UsageStore()
+    @StateObject private var codexHomes = CodexHomeStore()
 
     init() {
         #if DEBUG
@@ -48,6 +49,7 @@ struct GlintApp: App {
                 .environmentObject(workspaceStore)
                 .environmentObject(updater)
                 .environmentObject(usage)
+                .environmentObject(codexHomes)
                 .frame(minWidth: 980, minHeight: 600)
                 .preferredColorScheme(.dark)
                 // Live language switching: AppleLanguages (set in init) only

--- a/Glint/Chrome/SettingsView.swift
+++ b/Glint/Chrome/SettingsView.swift
@@ -1032,7 +1032,7 @@ private struct AgentsPane: View {
     @EnvironmentObject var usage: UsageStore
     @EnvironmentObject var codexHomes: CodexHomeStore
     @State private var claudeInstallFailed = false
-    @State private var codexInstallFailed = false
+    @State private var codexAddError: String?
     @State private var opencodeInstallFailed = false
     @State private var devinInstallFailed = false
     @State private var newCodexHomePath = ""
@@ -1139,8 +1139,8 @@ private struct AgentsPane: View {
                         .tint(store.accent)
                         .disabled(newCodexHomePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
-                if codexInstallFailed {
-                    Text("That directory is already configured or the path is empty.")
+                if let codexAddError {
+                    Text(codexAddError)
                         .font(.system(size: 10.5))
                         .foregroundStyle(Color.orange)
                 }
@@ -1317,9 +1317,19 @@ private struct AgentsPane: View {
     }
 
     private func addCodexHome() {
-        let added = codexHomes.add(path: newCodexHomePath, label: newCodexHomeLabel)
-        codexInstallFailed = !added
-        guard added else { return }
+        switch codexHomes.add(path: newCodexHomePath, label: newCodexHomeLabel) {
+        case .added:
+            codexAddError = nil
+        case .emptyPath:
+            codexAddError = "Enter a Codex Home path."
+            return
+        case .relativePath:
+            codexAddError = "Use an absolute path or a path starting with ~."
+            return
+        case .duplicate:
+            codexAddError = "That directory is already configured."
+            return
+        }
         newCodexHomePath = ""
         newCodexHomeLabel = ""
         usage.refreshNow()

--- a/Glint/Chrome/SettingsView.swift
+++ b/Glint/Chrome/SettingsView.swift
@@ -1030,10 +1030,14 @@ private struct TerminalPane: View {
 private struct AgentsPane: View {
     @EnvironmentObject var store: WorkspaceStore
     @EnvironmentObject var usage: UsageStore
+    @EnvironmentObject var codexHomes: CodexHomeStore
     @State private var claudeInstallFailed = false
     @State private var codexInstallFailed = false
     @State private var opencodeInstallFailed = false
     @State private var devinInstallFailed = false
+    @State private var newCodexHomePath = ""
+    @State private var newCodexHomeLabel = ""
+    @State private var codexHomeErrors: [UUID: String] = [:]
 
     var body: some View {
         SettingsCard("Claude Code",
@@ -1097,39 +1101,54 @@ private struct AgentsPane: View {
             }
         }
 
-        SettingsCard("Codex",
-                     footer: "Glint writes its hook entries into ~/.codex/hooks.json so Codex sessions surface the same status as Claude.") {
-            SettingsRow("Status", subtitle: codexInstallFailed
-                        ? "Install failed — check Console for [glint] logs (often a malformed hooks.json)."
-                        : (store.codexHooksInstalled
-                           ? "Hooks merged into your Codex config."
-                           : (store.codexDetected
-                              ? "Codex detected — install the reporter to show its status."
-                              : "Codex not detected on this Mac."))) {
-                HStack(spacing: 8) {
-                    StatusPill(
-                        label: store.codexHooksInstalled ? "Installed" : (store.codexDetected ? "Not installed" : "Not detected"),
-                        tone: store.codexHooksInstalled ? .ok : .neutral
-                    )
-                    if store.codexHooksInstalled {
-                        Button("Uninstall") {
-                            store.uninstallCodexHooks()
-                            codexInstallFailed = false
-                        }
-                            .controlSize(.small)
-                    } else {
-                        Button("Install") {
-                            store.installCodexHooks()
-                            codexInstallFailed = !store.codexHooksInstalled
-                        }
-                            .controlSize(.small)
-                            .tint(store.accent)
-                    }
-                }
+        SettingsCard("Codex Home Directories",
+                     footer: "Codex Home stores local auth, config, sessions, and hooks. Glint only installs its own hooks and reads status; Codex continues to manage authentication and configuration.") {
+            ForEach(Array(codexHomes.homes.enumerated()), id: \.element.id) { index, home in
+                CodexHomeSettingsRow(
+                    home: home,
+                    isDefault: codexHomes.isDefault(home),
+                    status: status(for: home),
+                    error: codexHomeErrors[home.id] ?? (
+                        FileManager.default.fileExists(atPath: home.resolvedURL.path)
+                        ? nil
+                        : "Directory does not exist. Installing the hook will create it."
+                    ),
+                    accent: store.accent,
+                    onToggle: { enabled in
+                        codexHomes.setEnabled(enabled, for: home.id)
+                        usage.refreshNow()
+                    },
+                    onInstall: { installHook(for: home) },
+                    onUninstall: { uninstallHook(for: home) },
+                    onOpen: { NSWorkspace.shared.open(home.resolvedURL) },
+                    onRemove: { removeHome(home) }
+                )
+                if index < codexHomes.homes.count - 1 { SettingsDivider() }
             }
             SettingsDivider()
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 8) {
+                    TextField("Label (optional)", text: $newCodexHomeLabel)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 130)
+                    TextField("~/work/.codex", text: $newCodexHomePath)
+                        .textFieldStyle(.roundedBorder)
+                    Button("Add") { addCodexHome() }
+                        .controlSize(.small)
+                        .tint(store.accent)
+                        .disabled(newCodexHomePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+                if codexInstallFailed {
+                    Text("That directory is already configured or the path is empty.")
+                        .font(.system(size: 10.5))
+                        .foregroundStyle(Color.orange)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            SettingsDivider()
             SettingsRow("Show usage in sidebar",
-                        subtitle: "Display Codex's 5-hour and weekly limits in the sidebar.") {
+                        subtitle: "Display the first available enabled Codex Home's 5-hour and weekly limits in the sidebar.") {
                 Toggle("", isOn: $usage.codexEnabled)
                     .toggleStyle(.switch).labelsHidden()
             }
@@ -1272,6 +1291,160 @@ private struct AgentsPane: View {
                         .toggleStyle(.switch).labelsHidden()
                 }
             }
+        }
+    }
+
+    private func status(for home: CodexHome) -> CodexHomeStatus {
+        if let current = usage.codexHomeStatuses.first(where: { $0.id == home.id }) {
+            return current
+        }
+        return CodexHomeStatus(
+            home: home,
+            resolvedURL: home.resolvedURL,
+            hookStatus: CodexHookInstaller.status(in: home.resolvedURL),
+            authStatus: CodexLiveReader.authStatus(from: home.resolvedURL),
+            quotaStatus: usage.codexEnabled ? .loading : .unavailable("Usage off")
+        )
+    }
+
+    private func addCodexHome() {
+        let added = codexHomes.add(path: newCodexHomePath, label: newCodexHomeLabel)
+        codexInstallFailed = !added
+        guard added else { return }
+        newCodexHomePath = ""
+        newCodexHomeLabel = ""
+        usage.refreshNow()
+    }
+
+    private func installHook(for home: CodexHome) {
+        do {
+            try CodexHookInstaller.install(in: home.resolvedURL)
+            codexHomeErrors[home.id] = nil
+        } catch {
+            codexHomeErrors[home.id] = error.localizedDescription
+        }
+        store.codexHooksInstalled = CodexHookInstaller.isInstalled()
+        usage.refreshNow()
+    }
+
+    private func uninstallHook(for home: CodexHome) {
+        do {
+            try CodexHookInstaller.uninstall(from: home.resolvedURL)
+            codexHomeErrors[home.id] = nil
+        } catch {
+            codexHomeErrors[home.id] = error.localizedDescription
+        }
+        store.codexHooksInstalled = CodexHookInstaller.isInstalled()
+        usage.refreshNow()
+    }
+
+    private func removeHome(_ home: CodexHome) {
+        guard !codexHomes.isDefault(home) else { return }
+        do {
+            try CodexHookInstaller.uninstall(from: home.resolvedURL)
+            _ = codexHomes.remove(id: home.id)
+            codexHomeErrors[home.id] = nil
+        } catch {
+            codexHomeErrors[home.id] = error.localizedDescription
+        }
+        store.codexHooksInstalled = CodexHookInstaller.isInstalled()
+        usage.refreshNow()
+    }
+}
+
+private struct CodexHomeSettingsRow: View {
+    let home: CodexHome
+    let isDefault: Bool
+    let status: CodexHomeStatus
+    let error: String?
+    let accent: Color
+    let onToggle: (Bool) -> Void
+    let onInstall: () -> Void
+    let onUninstall: () -> Void
+    let onOpen: () -> Void
+    let onRemove: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack(spacing: 8) {
+                Toggle("", isOn: Binding(get: { home.isEnabled }, set: onToggle))
+                    .toggleStyle(.checkbox)
+                    .labelsHidden()
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(home.label ?? home.resolvedURL.lastPathComponent)
+                        .font(.system(size: 12.5, weight: .semibold))
+                        .foregroundStyle(Theme.text1)
+                    Text(home.path)
+                        .font(.system(size: 10.5, design: .monospaced))
+                        .foregroundStyle(Theme.text4)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                if isDefault {
+                    Text("Default")
+                        .font(.system(size: 9.5, weight: .semibold))
+                        .foregroundStyle(accent)
+                }
+                Spacer()
+                Button("Open") { onOpen() }
+                    .controlSize(.mini)
+                    .disabled(!FileManager.default.fileExists(atPath: home.resolvedURL.path))
+                if case .installed = status.hookStatus {
+                    Button("Remove Hook") { onUninstall() }.controlSize(.mini)
+                } else {
+                    Button("Install Hook") { onInstall() }.controlSize(.mini).tint(accent)
+                }
+                if !isDefault {
+                    Button(role: .destructive) { onRemove() } label: {
+                        Image(systemName: "trash")
+                    }
+                    .buttonStyle(.borderless)
+                    .help("Remove this Codex Home from Glint")
+                }
+            }
+            HStack(spacing: 12) {
+                statusLabel("Hook", hookText)
+                statusLabel("Auth", authText)
+                statusLabel("Quota", quotaText)
+            }
+            if let error {
+                Text(error)
+                    .font(.system(size: 10.5))
+                    .foregroundStyle(Color.orange)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .opacity(home.isEnabled ? 1 : 0.62)
+    }
+
+    private func statusLabel(_ name: String, _ value: String) -> some View {
+        Text("\(name): \(value)")
+            .font(.system(size: 10.5, weight: .medium))
+            .foregroundStyle(Theme.text3)
+    }
+
+    private var hookText: String {
+        switch status.hookStatus {
+        case .installed: return "Installed"
+        case .notInstalled: return "Not installed"
+        case .error(let message): return message
+        }
+    }
+
+    private var authText: String {
+        switch status.authStatus {
+        case .found: return "Found"
+        case .missing: return "Missing"
+        case .invalid(let message): return message
+        }
+    }
+
+    private var quotaText: String {
+        switch status.quotaStatus {
+        case .available(let quota): return "\(Int(quota.sessionPercent.rounded()))% used"
+        case .unavailable(let message): return message
+        case .loading: return "Loading…"
         }
     }
 }

--- a/Glint/Chrome/SettingsView.swift
+++ b/Glint/Chrome/SettingsView.swift
@@ -1038,6 +1038,7 @@ private struct AgentsPane: View {
     @State private var newCodexHomePath = ""
     @State private var newCodexHomeLabel = ""
     @State private var codexHomeErrors: [UUID: String] = [:]
+    @State private var codexRemovalWarning: String?
 
     var body: some View {
         SettingsCard("Claude Code",
@@ -1140,6 +1141,11 @@ private struct AgentsPane: View {
                 }
                 if codexInstallFailed {
                     Text("That directory is already configured or the path is empty.")
+                        .font(.system(size: 10.5))
+                        .foregroundStyle(Color.orange)
+                }
+                if let codexRemovalWarning {
+                    Text(codexRemovalWarning)
                         .font(.system(size: 10.5))
                         .foregroundStyle(Color.orange)
                 }
@@ -1340,12 +1346,12 @@ private struct AgentsPane: View {
 
     private func removeHome(_ home: CodexHome) {
         guard !codexHomes.isDefault(home) else { return }
-        do {
-            try CodexHookInstaller.uninstall(from: home.resolvedURL)
-            _ = codexHomes.remove(id: home.id)
-            codexHomeErrors[home.id] = nil
-        } catch {
-            codexHomeErrors[home.id] = error.localizedDescription
+        let cleanupError = CodexHomeRemoval.remove(home, from: codexHomes) {
+            try CodexHookInstaller.uninstall(from: $0)
+        }
+        codexHomeErrors[home.id] = nil
+        codexRemovalWarning = cleanupError.map {
+            "Removed from Glint, but hook cleanup failed: \($0)"
         }
         store.codexHooksInstalled = CodexHookInstaller.isInstalled()
         usage.refreshNow()

--- a/Glint/Chrome/SettingsView.swift
+++ b/Glint/Chrome/SettingsView.swift
@@ -1154,7 +1154,7 @@ private struct AgentsPane: View {
             .padding(.vertical, 10)
             SettingsDivider()
             SettingsRow("Show usage in sidebar",
-                        subtitle: "Display the first available enabled Codex Home's 5-hour and weekly limits in the sidebar.") {
+                        subtitle: "Display available enabled Codex Home usage in the sidebar.") {
                 Toggle("", isOn: $usage.codexEnabled)
                     .toggleStyle(.switch).labelsHidden()
             }
@@ -1309,7 +1309,10 @@ private struct AgentsPane: View {
             resolvedURL: home.resolvedURL,
             hookStatus: CodexHookInstaller.status(in: home.resolvedURL),
             authStatus: CodexLiveReader.authStatus(from: home.resolvedURL),
-            quotaStatus: usage.codexEnabled ? .loading : .unavailable("Usage off")
+            quotaStatus: .placeholder(
+                isHomeEnabled: home.isEnabled,
+                isUsageEnabled: usage.codexEnabled
+            )
         )
     }
 

--- a/Glint/Chrome/SidebarView.swift
+++ b/Glint/Chrome/SidebarView.swift
@@ -93,7 +93,7 @@ struct SidebarView: View {
                 .scrollContentBackground(.hidden)
 
                 VStack(spacing: 0) {
-                    QuotaSection(claude: usage.claude, codex: usage.codex)
+                    QuotaSection(claude: usage.claude, codexHomes: usage.codexSidebarQuotas)
                     newWorkspaceCard
                         .padding(.horizontal, 10)
                         .padding(.top, 10)
@@ -368,7 +368,7 @@ struct SidebarView: View {
 private struct QuotaSection: View {
     @EnvironmentObject var store: WorkspaceStore
     let claude: AgentQuota?
-    let codex: AgentQuota?
+    let codexHomes: [CodexSidebarQuota]
 
     /// Brand fills, matching the sidebar mascot shadows.
     private static let claudeColor = Color(red: 235/255, green: 140/255, blue: 82/255)
@@ -376,7 +376,7 @@ private struct QuotaSection: View {
     private static let warnColor = Color(red: 1.0, green: 0.745, blue: 0.18) // #FFBE2E
 
     var body: some View {
-        if claude == nil && codex == nil {
+        if claude == nil && codexHomes.isEmpty {
             EmptyView()
         } else {
             VStack(spacing: 10) {
@@ -387,10 +387,10 @@ private struct QuotaSection: View {
                              quota: claude,
                              color: Self.claudeColor, warn: Self.warnColor)
                 }
-                if let codex {
-                    QuotaRow(name: "Codex",
+                ForEach(codexHomes) { item in
+                    QuotaRow(name: item.name,
                              iconAsset: MascotAsset.codex(for: nil),
-                             quota: codex,
+                             quota: item.quota,
                              color: Self.codexColor, warn: Self.warnColor)
                 }
             }

--- a/GlintTests/CodexHomeStoreTests.swift
+++ b/GlintTests/CodexHomeStoreTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import Glint
+
+@MainActor
+final class CodexHomeStoreTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "CodexHomeStoreTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func testFreshStoreExposesDefaultWithoutPersistingIt() {
+        let store = CodexHomeStore(defaults: defaults)
+
+        XCTAssertEqual(store.homes.count, 1)
+        XCTAssertEqual(store.homes[0].path, "~/.codex")
+        XCTAssertTrue(store.homes[0].isEnabled)
+        XCTAssertNil(defaults.data(forKey: CodexHomeStore.storageKey))
+    }
+
+    func testEquivalentPathsCannotBeAddedTwice() {
+        let store = CodexHomeStore(defaults: defaults)
+        let absoluteDefault = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".codex").path
+
+        XCTAssertFalse(store.add(path: absoluteDefault, label: "Duplicate"))
+        XCTAssertEqual(store.homes.count, 1)
+    }
+
+    func testChangesPersistAndDisabledHomesAreExcluded() {
+        var store = CodexHomeStore(defaults: defaults)
+        XCTAssertTrue(store.add(path: "~/work/.codex", label: "Work"))
+        let work = try! XCTUnwrap(store.homes.last)
+        store.setEnabled(false, for: work.id)
+
+        store = CodexHomeStore(defaults: defaults)
+        XCTAssertEqual(store.homes.count, 2)
+        XCTAssertEqual(store.homes.last?.label, "Work")
+        XCTAssertEqual(store.enabledHomes.map(\.path), ["~/.codex"])
+    }
+
+    func testDefaultCannotBeRemoved() {
+        let store = CodexHomeStore(defaults: defaults)
+
+        XCTAssertFalse(store.remove(id: store.homes[0].id))
+        XCTAssertEqual(store.homes.count, 1)
+    }
+}

--- a/GlintTests/CodexHomeStoreTests.swift
+++ b/GlintTests/CodexHomeStoreTests.swift
@@ -56,4 +56,20 @@ final class CodexHomeStoreTests: XCTestCase {
         XCTAssertFalse(store.remove(id: store.homes[0].id))
         XCTAssertEqual(store.homes.count, 1)
     }
+
+    func testCustomHomeIsRemovedEvenWhenHookCleanupFails() throws {
+        struct CleanupError: LocalizedError {
+            var errorDescription: String? { "Invalid hooks.json" }
+        }
+        let store = CodexHomeStore(defaults: defaults)
+        XCTAssertTrue(store.add(path: "~/broken/.codex", label: "Broken"))
+        let broken = try XCTUnwrap(store.homes.last)
+
+        let warning = CodexHomeRemoval.remove(broken, from: store) { _ in
+            throw CleanupError()
+        }
+
+        XCTAssertEqual(warning, "Invalid hooks.json")
+        XCTAssertFalse(store.homes.contains(where: { $0.id == broken.id }))
+    }
 }

--- a/GlintTests/CodexHomeStoreTests.swift
+++ b/GlintTests/CodexHomeStoreTests.swift
@@ -39,13 +39,13 @@ final class CodexHomeStoreTests: XCTestCase {
         let absoluteDefault = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".codex").path
 
-        XCTAssertFalse(store.add(path: absoluteDefault, label: "Duplicate"))
+        XCTAssertEqual(store.add(path: absoluteDefault, label: "Duplicate"), .duplicate)
         XCTAssertEqual(store.homes.count, 1)
     }
 
     func testChangesPersistAndDisabledHomesAreExcluded() {
         var store = CodexHomeStore(defaults: defaults)
-        XCTAssertTrue(store.add(path: "~/work/.codex", label: "Work"))
+        XCTAssertEqual(store.add(path: "~/work/.codex", label: "Work"), .added)
         let work = try! XCTUnwrap(store.homes.last)
         store.setEnabled(false, for: work.id)
 
@@ -67,7 +67,7 @@ final class CodexHomeStoreTests: XCTestCase {
             var errorDescription: String? { "Invalid hooks.json" }
         }
         let store = CodexHomeStore(defaults: defaults)
-        XCTAssertTrue(store.add(path: "~/broken/.codex", label: "Broken"))
+        XCTAssertEqual(store.add(path: "~/broken/.codex", label: "Broken"), .added)
         let broken = try XCTUnwrap(store.homes.last)
 
         let warning = CodexHomeRemoval.remove(broken, from: store) { _ in
@@ -76,5 +76,14 @@ final class CodexHomeStoreTests: XCTestCase {
 
         XCTAssertEqual(warning, "Invalid hooks.json")
         XCTAssertFalse(store.homes.contains(where: { $0.id == broken.id }))
+    }
+
+    func testAddRejectsRelativePaths() {
+        let store = CodexHomeStore(defaults: defaults)
+
+        XCTAssertEqual(store.add(path: "work/.codex"), .relativePath)
+        XCTAssertEqual(store.add(path: "  "), .emptyPath)
+        XCTAssertEqual(store.homes.count, 1)
+        XCTAssertNil(defaults.data(forKey: CodexHomeStore.storageKey))
     }
 }

--- a/GlintTests/CodexHomeStoreTests.swift
+++ b/GlintTests/CodexHomeStoreTests.swift
@@ -29,6 +29,11 @@ final class CodexHomeStoreTests: XCTestCase {
         XCTAssertNil(defaults.data(forKey: CodexHomeStore.storageKey))
     }
 
+    func testDefaultHomeHasStableIdentity() {
+        XCTAssertEqual(CodexHome.default.id, CodexHome.default.id)
+        XCTAssertEqual(CodexHome.default.id, CodexHome.defaultID)
+    }
+
     func testEquivalentPathsCannotBeAddedTwice() {
         let store = CodexHomeStore(defaults: defaults)
         let absoluteDefault = FileManager.default.homeDirectoryForCurrentUser

--- a/GlintTests/CodexHookInstallerTests.swift
+++ b/GlintTests/CodexHookInstallerTests.swift
@@ -42,6 +42,16 @@ final class CodexHookInstallerTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: hooksURL.appendingPathExtension("glint-backup").path))
     }
 
+    func testUninstallRefusesInvalidJSON() throws {
+        let hooksURL = home.appendingPathComponent("hooks.json")
+        try "not json".write(to: hooksURL, atomically: true, encoding: .utf8)
+
+        XCTAssertThrowsError(try CodexHookInstaller.uninstall(from: home)) { error in
+            XCTAssertEqual(error as? CodexHookInstallerError, .invalidHooksJSON)
+        }
+        XCTAssertEqual(try String(contentsOf: hooksURL), "not json")
+    }
+
     func testUninstallOnlyRemovesGlintHooks() throws {
         let hooksURL = home.appendingPathComponent("hooks.json")
         let existing = #"{"hooks":{"Stop":[{"matcher":"*","hooks":[{"type":"command","command":"user-hook"}]}]}}"#

--- a/GlintTests/CodexHookInstallerTests.swift
+++ b/GlintTests/CodexHookInstallerTests.swift
@@ -52,6 +52,18 @@ final class CodexHookInstallerTests: XCTestCase {
         XCTAssertEqual(try String(contentsOf: hooksURL), "not json")
     }
 
+    func testUninstallReportsReadFailure() throws {
+        let hooksURL = home.appendingPathComponent("hooks.json")
+        try FileManager.default.createDirectory(at: hooksURL, withIntermediateDirectories: false)
+
+        XCTAssertThrowsError(try CodexHookInstaller.uninstall(from: home)) { error in
+            guard case .readFailed = error as? CodexHookInstallerError else {
+                return XCTFail("Expected readFailed, got \(error)")
+            }
+            XCTAssertTrue(error.localizedDescription.hasPrefix("Could not read hooks.json:"))
+        }
+    }
+
     func testUninstallOnlyRemovesGlintHooks() throws {
         let hooksURL = home.appendingPathComponent("hooks.json")
         let existing = #"{"hooks":{"Stop":[{"matcher":"*","hooks":[{"type":"command","command":"user-hook"}]}]}}"#

--- a/GlintTests/CodexHookInstallerTests.swift
+++ b/GlintTests/CodexHookInstallerTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import Glint
+
+final class CodexHookInstallerTests: XCTestCase {
+    private var home: URL!
+
+    override func setUpWithError() throws {
+        home = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("glint-codex-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: home)
+    }
+
+    func testMergePreservesUnrelatedHooksAndIsIdempotent() throws {
+        let hooksURL = home.appendingPathComponent("hooks.json")
+        let existing = #"{"hooks":{"Stop":[{"matcher":"*","hooks":[{"type":"command","command":"user-hook"}]}]},"custom":true}"#
+        try existing.write(to: hooksURL, atomically: true, encoding: .utf8)
+
+        try CodexHookInstaller.mergeCodexHooks(scriptPath: "/tmp/glint-report.sh", codexHome: home)
+        try CodexHookInstaller.mergeCodexHooks(scriptPath: "/tmp/glint-report.sh", codexHome: home)
+
+        XCTAssertTrue(CodexHookInstaller.isInstalled(in: home))
+        let root = try JSONSerialization.jsonObject(with: Data(contentsOf: hooksURL)) as? [String: Any]
+        XCTAssertEqual(root?["custom"] as? Bool, true)
+        let stop = (root?["hooks"] as? [String: Any])?["Stop"] as? [Any]
+        XCTAssertEqual(stop?.count, 2)
+    }
+
+    func testInvalidJSONIsBackedUpAndNotOverwritten() throws {
+        let hooksURL = home.appendingPathComponent("hooks.json")
+        try "not json".write(to: hooksURL, atomically: true, encoding: .utf8)
+
+        XCTAssertThrowsError(
+            try CodexHookInstaller.mergeCodexHooks(scriptPath: "/tmp/glint-report.sh", codexHome: home)
+        ) { error in
+            XCTAssertEqual(error as? CodexHookInstallerError, .invalidHooksJSON)
+        }
+        XCTAssertEqual(try String(contentsOf: hooksURL), "not json")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: hooksURL.appendingPathExtension("glint-backup").path))
+    }
+
+    func testUninstallOnlyRemovesGlintHooks() throws {
+        let hooksURL = home.appendingPathComponent("hooks.json")
+        let existing = #"{"hooks":{"Stop":[{"matcher":"*","hooks":[{"type":"command","command":"user-hook"}]}]}}"#
+        try existing.write(to: hooksURL, atomically: true, encoding: .utf8)
+        try CodexHookInstaller.mergeCodexHooks(scriptPath: "/tmp/glint-report.sh", codexHome: home)
+
+        try CodexHookInstaller.uninstall(from: home)
+
+        XCTAssertFalse(CodexHookInstaller.isInstalled(in: home))
+        let root = try JSONSerialization.jsonObject(with: Data(contentsOf: hooksURL)) as? [String: Any]
+        let stop = (root?["hooks"] as? [String: Any])?["Stop"] as? [Any]
+        XCTAssertEqual(stop?.count, 1)
+    }
+}

--- a/GlintTests/CodexHookInstallerTests.swift
+++ b/GlintTests/CodexHookInstallerTests.swift
@@ -65,4 +65,17 @@ final class CodexHookInstallerTests: XCTestCase {
         let stop = (root?["hooks"] as? [String: Any])?["Stop"] as? [Any]
         XCTAssertEqual(stop?.count, 1)
     }
+
+    func testCreatingMissingHomeUsesPrivateDirectoryPermissions() throws {
+        let missingHome = home.appendingPathComponent("private-codex-home", isDirectory: true)
+
+        try CodexHookInstaller.mergeCodexHooks(
+            scriptPath: "/tmp/glint-report.sh",
+            codexHome: missingHome
+        )
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: missingHome.path)
+        let permissions = try XCTUnwrap(attributes[.posixPermissions] as? NSNumber)
+        XCTAssertEqual(permissions.intValue & 0o777, 0o700)
+    }
 }

--- a/GlintTests/CodexUsageReaderTests.swift
+++ b/GlintTests/CodexUsageReaderTests.swift
@@ -103,4 +103,15 @@ final class CodexUsageReaderTests: XCTestCase {
         coordinator.invalidate()
         XCTAssertFalse(coordinator.accepts(newer))
     }
+
+    func testDisabledHomeStatusDoesNotRemainLoading() {
+        XCTAssertEqual(
+            CodexQuotaStatus.placeholder(isHomeEnabled: false, isUsageEnabled: true),
+            .unavailable("Disabled")
+        )
+        XCTAssertEqual(
+            CodexQuotaStatus.placeholder(isHomeEnabled: true, isUsageEnabled: true),
+            .loading
+        )
+    }
 }

--- a/GlintTests/CodexUsageReaderTests.swift
+++ b/GlintTests/CodexUsageReaderTests.swift
@@ -91,4 +91,16 @@ final class CodexUsageReaderTests: XCTestCase {
 
         XCTAssertTrue(items.isEmpty)
     }
+
+    func testOlderRefreshIsRejectedAfterNewRefreshBegins() {
+        var coordinator = CodexRefreshCoordinator()
+        let older = coordinator.begin()
+        let newer = coordinator.begin()
+
+        XCTAssertFalse(coordinator.accepts(older))
+        XCTAssertTrue(coordinator.accepts(newer))
+
+        coordinator.invalidate()
+        XCTAssertFalse(coordinator.accepts(newer))
+    }
 }

--- a/GlintTests/CodexUsageReaderTests.swift
+++ b/GlintTests/CodexUsageReaderTests.swift
@@ -39,4 +39,38 @@ final class CodexUsageReaderTests: XCTestCase {
             .write(to: authURL, atomically: true, encoding: .utf8)
         XCTAssertEqual(CodexLiveReader.authStatus(from: home), .found)
     }
+
+    func testSidebarUsesQuotaFromLaterAvailableHome() {
+        let unavailable = CodexHome(label: "API", path: "~/api/.codex")
+        let subscription = CodexHome(label: "Subscription", path: "~/subscription/.codex")
+        let quota = AgentQuota(
+            sessionPercent: 27,
+            weeklyPercent: 40,
+            sessionResetsAt: nil,
+            weeklyResetsAt: nil,
+            planType: "plus"
+        )
+        let statuses = [
+            CodexHomeStatus(
+                home: unavailable,
+                resolvedURL: unavailable.resolvedURL,
+                hookStatus: .notInstalled,
+                authStatus: .found,
+                quotaStatus: .unavailable("Quota unavailable")
+            ),
+            CodexHomeStatus(
+                home: subscription,
+                resolvedURL: subscription.resolvedURL,
+                hookStatus: .installed,
+                authStatus: .found,
+                quotaStatus: .available(quota)
+            ),
+        ]
+
+        let items = CodexQuotaPresentation.sidebarItems(from: statuses, fallback: nil)
+
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items[0].name, "Subscription")
+        XCTAssertEqual(items[0].quota, quota)
+    }
 }

--- a/GlintTests/CodexUsageReaderTests.swift
+++ b/GlintTests/CodexUsageReaderTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import Glint
+
+final class CodexUsageReaderTests: XCTestCase {
+    private var home: URL!
+
+    override func setUpWithError() throws {
+        home = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("glint-codex-usage-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: home)
+    }
+
+    func testReadsQuotaFromRequestedHome() throws {
+        let sessions = home.appendingPathComponent("sessions/2026/06/22", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessions, withIntermediateDirectories: true)
+        let rollout = sessions.appendingPathComponent("rollout-test.jsonl")
+        let line = #"{"type":"event_msg","payload":{"rate_limits":{"primary":{"used_percent":25,"resets_at":1900000000},"secondary":{"used_percent":50,"resets_at":1900100000},"plan_type":"pro"}}}"#
+        try line.write(to: rollout, atomically: true, encoding: .utf8)
+
+        let quota = try XCTUnwrap(CodexUsageReader.read(from: home))
+
+        XCTAssertEqual(quota.sessionPercent, 25)
+        XCTAssertEqual(quota.weeklyPercent, 50)
+        XCTAssertEqual(quota.planType, "pro")
+    }
+
+    func testAuthStatusIsPerHomeAndNonfatal() throws {
+        XCTAssertEqual(CodexLiveReader.authStatus(from: home), .missing)
+
+        let authURL = home.appendingPathComponent("auth.json")
+        try "invalid".write(to: authURL, atomically: true, encoding: .utf8)
+        XCTAssertEqual(CodexLiveReader.authStatus(from: home), .invalid("Invalid auth.json"))
+
+        try #"{"tokens":{"access_token":"token","account_id":"account"}}"#
+            .write(to: authURL, atomically: true, encoding: .utf8)
+        XCTAssertEqual(CodexLiveReader.authStatus(from: home), .found)
+    }
+}

--- a/GlintTests/CodexUsageReaderTests.swift
+++ b/GlintTests/CodexUsageReaderTests.swift
@@ -73,4 +73,22 @@ final class CodexUsageReaderTests: XCTestCase {
         XCTAssertEqual(items[0].name, "Subscription")
         XCTAssertEqual(items[0].quota, quota)
     }
+
+    func testSidebarHidesFallbackWhenEveryHomeIsDisabled() {
+        let cached = AgentQuota(
+            sessionPercent: 27,
+            weeklyPercent: 40,
+            sessionResetsAt: nil,
+            weeklyResetsAt: nil,
+            planType: "plus"
+        )
+
+        let items = CodexQuotaPresentation.sidebarItems(
+            from: [],
+            fallback: cached,
+            hasEnabledHomes: false
+        )
+
+        XCTAssertTrue(items.isEmpty)
+    }
 }


### PR DESCRIPTION
## What

Adds first-class support for multiple Codex Home directories.

- Keep `~/.codex` as the enabled default without eagerly persisting settings.
- Add, remove, enable, and disable additional Codex Homes in Settings.
- Install or remove Glint hooks per home while preserving unrelated hooks.
- Read auth and quota status independently for each enabled home.
- Display per-home Hook, Auth, and Quota status in Settings.
- Render available per-home Codex quota rows in the sidebar.

## Why

Codex supports isolated environments through `CODEX_HOME`, but Glint assumed all Codex state lived under `~/.codex`. Custom homes therefore could not receive Glint hooks or contribute auth/quota information.

The sidebar also previously consumed a separate single-value quota aggregate while Settings consumed per-home status. With multiple homes those values could diverge, so a quota visible in Settings might not render in the sidebar. The sidebar now derives its rows directly from the per-home status collection, with the previous snapshot retained as a compatibility fallback.

## Implementation

- Introduce `CodexHome`, `CodexHomeStore`, and per-home status models.
- Normalize paths to standardized absolute URLs, reject relative paths, and reject duplicates.
- Protect the default home from accidental removal.
- Parameterize the Codex hook installer by home URL and iterate enabled homes from the existing compatibility entry points.
- Create missing home directories with `0700` permissions only when installing hooks.
- Back up and reject invalid `hooks.json` instead of overwriting it.
- Parameterize live and disk quota readers by home URL and isolate failures per home.
- Add a focused Codex Home management section without changing Codex authentication or configuration.

## Compatibility and scope

- Existing users continue to use `~/.codex` without any configuration or migration.
- Glint only manages its own hook entries and reads Codex state.
- Glint does not copy or modify `auth.json`, `config.toml`, sessions, logs, or other Codex-managed files.
- The socket communication model remains unchanged.

## Non-goals

This PR does not switch Codex sessions between homes and does not manage `CODEX_HOME` at runtime. Users still choose the active Codex Home by launching Codex with `CODEX_HOME` themselves. Glint only installs hooks and reads status/quota from configured homes.

## Review follow-ups

- Clear and hide cached Codex quota when every configured home is disabled.
- Gate asynchronous quota refreshes so an older request cannot restore removed or disabled homes.
- Remove a custom home from Glint even when its external `hooks.json` cannot be cleaned up, while surfacing a warning to the user.
- Give the default Codex Home a stable identity across stores and SwiftUI renders.
- Show disabled homes as `Disabled` instead of leaving their quota status at `Loading…`.
- Create new Codex Home directories with private `0700` permissions.
- Reject relative paths with an explicit validation message and update sidebar copy for multiple homes.

## Validation

- `xcodebuild test -project Glint.xcodeproj -scheme Glint -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`
  - 70 tests passed.
- Debug application build succeeded.
- Manually verified two configured homes (API and subscription): the subscription quota is available in Settings and renders in the sidebar.
