### PR TITLE
[codex] restore sidebar status updates from shared app-server hooks

### DIFF
--- a/Glint.xcodeproj/project.pbxproj
+++ b/Glint.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		930665E39CE84564CBF9D300 /* GlintTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 150EEF32284061D527E51866 /* GlintTheme.swift */; };
 		942ED7C1C1A2E823BA52F67A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3023490E670A10EC38870B12 /* Assets.xcassets */; };
 		9F605AB2DC185A94ED28E6D4 /* AgentChoice.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3EB9A1E80F3CC4BCA468774 /* AgentChoice.swift */; };
+		A019A2AD685F1407D7E2A7E1 /* AgentHookRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0082D535969C315B8D75D7 /* AgentHookRoutingTests.swift */; };
 		A91EFEF0FEA392A0745724DE /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = 89B8883C4456681F07B6D662 /* AppIcon.icon */; };
 		AB89FA6EF5785EC4026F4402 /* VisualEffectBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0656F7C1D48AE0429C1888B /* VisualEffectBackground.swift */; };
 		ABFF3BCAC4AE8CCCAFF89CA0 /* NewWorkspaceSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D29C0D2447094B07854C193 /* NewWorkspaceSheet.swift */; };
@@ -119,6 +120,7 @@
 		F5A69ACF962AEDE189F98649 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		F8A1F24DAA7220AD4EE961E2 /* UsageStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageStore.swift; sourceTree = "<group>"; };
 		FC6FFB5185C403F6F44A1687 /* GhosttyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyManager.swift; sourceTree = "<group>"; };
+		FF0082D535969C315B8D75D7 /* AgentHookRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookRoutingTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -161,6 +163,7 @@
 		5F9010EBEE9DCDE13D866A74 /* GlintTests */ = {
 			isa = PBXGroup;
 			children = (
+				FF0082D535969C315B8D75D7 /* AgentHookRoutingTests.swift */,
 				4EEF00CBEF45A9D60423A207 /* AgentKindResolutionTests.swift */,
 				6AB338782EF6F22B7B381DA8 /* CodexHomeStoreTests.swift */,
 				26141150D2DB4C0589558ECC /* CodexHookInstallerTests.swift */,
@@ -394,6 +397,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A019A2AD685F1407D7E2A7E1 /* AgentHookRoutingTests.swift in Sources */,
 				81532B36FEC3039B8EAD9CB1 /* AgentKindResolutionTests.swift in Sources */,
 				C41119D04864077E5B554F59 /* CodexHomeStoreTests.swift in Sources */,
 				0FEECB27EB1ACE11E29ECCEF /* CodexHookInstallerTests.swift in Sources */,

--- a/Glint/Agent/AgentBridge.swift
+++ b/Glint/Agent/AgentBridge.swift
@@ -6,6 +6,10 @@ import Darwin
 ///
 ///     {"pane":"<workspace-uuid>:<pane-seq>","hook":"UserPromptSubmit"}
 ///
+/// Codex hooks may instead originate in its shared app-server, which has no
+/// pane environment. Those events carry base64-encoded session/cwd metadata
+/// and are associated with a pane by `WorkspaceStore`.
+///
 /// The bridge parses, posts `.glintAgentEvent` on the main queue, and
 /// `WorkspaceStore` translates it into pane state.
 final class AgentBridge {
@@ -144,28 +148,52 @@ final class AgentBridge {
     }
 
     private struct HookEnvelope: Decodable {
-        let pane: String
+        let pane: String?
         let hook: String
         let agent: String?
+        let sessionB64: String?
+        let cwdB64: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case pane, hook, agent
+            case sessionB64 = "session_b64"
+            case cwdB64 = "cwd_b64"
+        }
+    }
+
+    static func decodeHookLine(_ line: Data) -> [String: String]? {
+        guard let env = try? JSONDecoder().decode(HookEnvelope.self, from: line) else {
+            return nil
+        }
+        var result = ["hook": env.hook]
+        if let pane = env.pane, !pane.isEmpty { result["pane"] = pane }
+        if let agent = env.agent, !agent.isEmpty { result["agent"] = agent }
+        if let encoded = env.sessionB64,
+           let data = Data(base64Encoded: encoded),
+           let value = String(data: data, encoding: .utf8),
+           !value.isEmpty {
+            result["session"] = value
+        }
+        if let encoded = env.cwdB64,
+           let data = Data(base64Encoded: encoded),
+           let value = String(data: data, encoding: .utf8),
+           !value.isEmpty {
+            result["cwd"] = value
+        }
+        guard result["pane"] != nil || result["session"] != nil else { return nil }
+        return result
     }
 
     private func handle(line: Data) {
-        guard let env = try? JSONDecoder().decode(HookEnvelope.self, from: line) else {
+        guard let decoded = Self.decodeHookLine(line) else {
             NSLog("[glint] agent: malformed hook line (\(line.count) bytes)")
             return
         }
         DispatchQueue.main.async {
-            var userInfo: [String: Any] = [
-                "pane": env.pane,
-                "hook": env.hook,
-            ]
-            if let agent = env.agent, !agent.isEmpty {
-                userInfo["agent"] = agent
-            }
             NotificationCenter.default.post(
                 name: .glintAgentEvent,
                 object: nil,
-                userInfo: userInfo
+                userInfo: decoded
             )
         }
     }

--- a/Glint/Agent/AgentHookInstaller.swift
+++ b/Glint/Agent/AgentHookInstaller.swift
@@ -319,8 +319,10 @@ enum AgentHookInstaller {
         }
     }
 
-    /// Pure POSIX sh — runs inside the pty so `$GLINT_PANE_ID` resolves.
-    /// Stays cheap (single send, swallows stdin).
+    /// Pure POSIX sh. Claude and other agents inherit the pane route. Codex may
+    /// execute hooks in a shared app-server instead, so its events always use
+    /// the stable session identity from stdin and let Glint bind that session
+    /// to the pane that submitted the prompt.
     ///
     /// Uses `/usr/bin/nc` (absolute) not bare `nc`: Homebrew's GNU netcat
     /// (`/opt/homebrew/bin/nc`, netcat 0.7.1) shadows it and rejects `-U`
@@ -333,19 +335,50 @@ enum AgentHookInstaller {
     /// existing Claude installs keep working without a script rewrite.
     static let scriptBody: String = """
     #!/bin/sh
-    # Glint CLI-agent hook reporter. Argv[1] = hook event, argv[2] = agent kind.
-    [ -z "$GLINT_PANE_ID" ] && exit 0
-    [ -z "$GLINT_AGENT_SOCK" ] && exit 0
-    [ ! -S "$GLINT_AGENT_SOCK" ] && exit 0
-
+    # Glint CLI-agent hook reporter. argv: event, agent kind.
     HOOK="${1:-Unknown}"
     AGENT="${2:-claude}"
-    # Drain stdin (claude/codex pass the hook payload there). We ignore it for
-    # now — only the hook name + agent are needed to drive pane state.
-    cat >/dev/null 2>&1
+    PANE="${GLINT_PANE_ID:-}"
+    SOCK="${GLINT_AGENT_SOCK:-}"
 
-    printf '{"pane":"%s","hook":"%s","agent":"%s"}\\n' "$GLINT_PANE_ID" "$HOOK" "$AGENT" \\
-      | /usr/bin/nc -U -w 1 "$GLINT_AGENT_SOCK" >/dev/null 2>&1 || true
+    if [ "$AGENT" != "codex" ] && [ -n "$PANE" ] && [ -n "$SOCK" ]; then
+      cat >/dev/null 2>&1
+      [ ! -S "$SOCK" ] && exit 0
+      printf '{"pane":"%s","hook":"%s","agent":"%s"}\\n' "$PANE" "$HOOK" "$AGENT" \\
+        | /usr/bin/nc -U -w 1 "$SOCK" >/dev/null 2>&1 || true
+      exit 0
+    fi
+
+    # Codex's shared app-server lacks GLINT_* variables. Keep the configured
+    # hook command identical for every pane (so Codex can trust it once), and
+    # forward only routing metadata from the hook payload.
+    [ "$AGENT" != "codex" ] && { cat >/dev/null 2>&1; exit 0; }
+    umask 077
+    TMP=$(/usr/bin/mktemp "${TMPDIR:-/tmp}/glint-hook.XXXXXX") || { cat >/dev/null 2>&1; exit 0; }
+    trap '/bin/rm -f "$TMP"' EXIT HUP INT TERM
+    cat >"$TMP"
+    SESSION=$(/usr/bin/plutil -extract session_id raw -o - "$TMP" 2>/dev/null || true)
+    CWD=$(/usr/bin/plutil -extract cwd raw -o - "$TMP" 2>/dev/null || true)
+    /bin/rm -f "$TMP"
+    trap - EXIT HUP INT TERM
+    [ -z "$SESSION" ] && exit 0
+    SESSION_B64=$(printf '%s' "$SESSION" | /usr/bin/base64 | /usr/bin/tr -d '\\r\\n')
+    CWD_B64=$(printf '%s' "$CWD" | /usr/bin/base64 | /usr/bin/tr -d '\\r\\n')
+
+    send_codex_event() {
+      TARGET_SOCK="$1"
+      [ ! -S "$TARGET_SOCK" ] && return 0
+      printf '{"hook":"%s","agent":"codex","session_b64":"%s","cwd_b64":"%s"}\\n' \\
+        "$HOOK" "$SESSION_B64" "$CWD_B64" \\
+        | /usr/bin/nc -U -w 1 "$TARGET_SOCK" >/dev/null 2>&1 || true
+    }
+
+    if [ -n "$SOCK" ] && [ -S "$SOCK" ]; then
+      send_codex_event "$SOCK"
+    else
+      send_codex_event "$HOME/.glint/run/agent.sock"
+      send_codex_event "$HOME/.glint/run/agent-debug.sock"
+    fi
     exit 0
     """
 
@@ -363,9 +396,9 @@ enum AgentHookInstaller {
 ///       }
 ///     }
 ///
-/// Codex passes the entire hook payload on stdin, same as Claude — the
-/// shared `glint-report.sh` swallows it and only forwards the event name
-/// plus the agent kind ("codex") to Glint's local socket.
+/// Codex passes the entire hook payload on stdin. The shared reporter extracts
+/// only session/cwd routing metadata and forwards it with the event name to
+/// Glint's local socket.
 enum CodexHookInstaller {
     /// Events Glint reacts to. Codex has no Notification event, but it does
     /// expose tool boundaries; PreToolUse is important for clearing a pending

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -445,6 +445,17 @@ final class WorkspaceStore: ObservableObject {
     /// status (thinking/permission/…) the 1s name poll can't know.
     /// Non-persistent.
     @Published var paneAgentState: [WorkspacePaneKey: PaneAgentState] = [:]
+    /// Codex 0.141+ runs hooks in a shared app-server, so hook processes no
+    /// longer inherit GLINT_PANE_ID. Bind its stable session id after the first
+    /// submitted prompt and use that route for the rest of the session.
+    private struct CodexSessionRoute {
+        var pane: WorkspacePaneKey
+        var lastSeen: Date
+    }
+    private static let codexSessionRouteTTL: TimeInterval = 12 * 60 * 60
+    private static let codexSessionRouteLimit = 256
+    private var codexSessionPanes: [String: CodexSessionRoute] = [:]
+    private var recentPaneReturns: [WorkspacePaneKey: Date] = [:]
 
     /// Drives the command-palette overlay. Toggled by the toolbar's ⌘
     /// button and the ⌘⇧P global shortcut. Mutually exclusive with the agent
@@ -1380,14 +1391,11 @@ final class WorkspaceStore: ObservableObject {
 
     // MARK: agent hook events
 
-    /// Translate one hook from the AgentBridge into pane state. The hook
-    /// itself only carries the event name — full payload routing comes later
-    /// once we wire `data` through.
+    /// Translate one hook from the AgentBridge into pane state.
     func handleAgentEvent(_ info: [AnyHashable: Any]?) {
         guard let info,
-              let paneStr = info["pane"] as? String,
               let hook = info["hook"] as? String,
-              let key = Self.parsePaneKey(paneStr) else { return }
+              let key = resolveAgentEventPane(info, hook: hook) else { return }
 
         let explicitKind = (info["agent"] as? String).flatMap(Self.agentKind(named:))
         let foregroundKind = surfaceViews[key]?.foregroundProcessName()
@@ -1522,8 +1530,14 @@ final class WorkspaceStore: ObservableObject {
     func handlePaneReturn(_ info: [AnyHashable: Any]?) {
         guard let info,
               let paneStr = info["pane"] as? String,
-              let key = Self.parsePaneKey(paneStr),
-              var state = paneAgentState[key],
+              let key = Self.parsePaneKey(paneStr) else { return }
+        // Permission approval is not a new prompt. Recording it as a submit
+        // candidate could make a different, newly-started Codex session bind
+        // to this pane if both events land within the routing window.
+        if paneAgentState[key]?.status != .needsPermission {
+            recentPaneReturns[key] = Date()
+        }
+        guard var state = paneAgentState[key],
               state.status == .needsPermission else { return }
         let now = Date()
         state.status = .tool
@@ -1531,6 +1545,104 @@ final class WorkspaceStore: ObservableObject {
         state.turnStartedAt = now
         paneAgentState[key] = state
         clearDockBadge(for: key)
+    }
+
+    /// Resolve direct pane-addressed hooks, or bind a shared Codex session on
+    /// its first submitted prompt. The Return timestamp is process-local, so
+    /// when production and debug Glint are both running only the owning app
+    /// claims the session. A unique cwd match covers `codex "prompt"` and
+    /// other launches that submit without a separate terminal Return.
+    private func resolveAgentEventPane(
+        _ info: [AnyHashable: Any],
+        hook: String,
+        now: Date = Date()
+    ) -> WorkspacePaneKey? {
+        if let pane = info["pane"] as? String,
+           let key = Self.parsePaneKey(pane) {
+            return key
+        }
+        guard (info["agent"] as? String) == "codex",
+              let session = info["session"] as? String,
+              !session.isEmpty else { return nil }
+
+        pruneCodexSessionRoutes(now: now)
+        if var route = codexSessionPanes[session] {
+            route.lastSeen = now
+            codexSessionPanes[session] = route
+            let key = route.pane
+            if let view = surfaceViews[key], view.hasLiveSurface {
+                if hook != "UserPromptSubmit" {
+                    return key
+                }
+                let kind = Self.codexRoutingCandidateKind(
+                    foregroundProcessName: view.foregroundProcessName(),
+                    polledProcessName: paneProcesses[key],
+                    stateKind: paneAgentState[key]?.kind
+                )
+                if kind == .codex {
+                    recentPaneReturns.removeValue(forKey: key)
+                    return key
+                }
+            }
+            codexSessionPanes.removeValue(forKey: session)
+        }
+        guard hook == "UserPromptSubmit" else { return nil }
+
+        let codexPanes = surfaceViews.compactMap { key, view -> WorkspacePaneKey? in
+            guard view.hasLiveSurface else { return nil }
+            // A known foreground process is authoritative even when it is not
+            // an agent. Falling through from "zsh" to stale hook state would
+            // incorrectly keep an exited Codex pane in the routing candidates.
+            let kind = Self.codexRoutingCandidateKind(
+                foregroundProcessName: view.foregroundProcessName(),
+                polledProcessName: paneProcesses[key],
+                stateKind: paneAgentState[key]?.kind
+            )
+            return kind == .codex ? key : nil
+        }
+        let recentlySubmitted = codexPanes.compactMap { key -> (WorkspacePaneKey, Date)? in
+            guard let date = recentPaneReturns[key],
+                  now.timeIntervalSince(date) >= 0,
+                  now.timeIntervalSince(date) <= 10 else { return nil }
+            return (key, date)
+        }
+        let key: WorkspacePaneKey?
+        if let latest = recentlySubmitted.max(by: { $0.1 < $1.1 }) {
+            key = latest.0
+        } else if let cwd = info["cwd"] as? String, !cwd.isEmpty {
+            let normalized = URL(fileURLWithPath: cwd).standardizedFileURL.path
+            let matches = codexPanes.filter { candidate in
+                let known = surfaceViews[candidate]?.cachedCwd
+                    ?? workspaces.first(where: { $0.id == candidate.workspace })?
+                        .panes[candidate.pane]?.workingDirectory
+                guard let known else { return false }
+                return URL(fileURLWithPath: known).standardizedFileURL.path == normalized
+            }
+            key = matches.count == 1 ? matches[0] : nil
+        } else {
+            key = nil
+        }
+        guard let key else {
+            NSLog("[glint] agent: could not route Codex session \(session)")
+            return nil
+        }
+        codexSessionPanes[session] = CodexSessionRoute(pane: key, lastSeen: now)
+        pruneCodexSessionRoutes(now: now)
+        recentPaneReturns.removeValue(forKey: key)
+        return key
+    }
+
+    private func pruneCodexSessionRoutes(now: Date) {
+        codexSessionPanes = codexSessionPanes.filter {
+            now.timeIntervalSince($0.value.lastSeen) <= Self.codexSessionRouteTTL
+        }
+        let overflow = codexSessionPanes.count - Self.codexSessionRouteLimit
+        guard overflow > 0 else { return }
+        for (session, _) in codexSessionPanes
+            .sorted(by: { $0.value.lastSeen < $1.value.lastSeen })
+            .prefix(overflow) {
+            codexSessionPanes.removeValue(forKey: session)
+        }
     }
 
     /// Clear any `.justCompleted` / `.failed` panes back to `.idle` — but
@@ -1760,6 +1872,17 @@ final class WorkspaceStore: ObservableObject {
         if lower.contains("opencode") { return .opencode }
         if lower.contains("devin") { return .devin }
         return nil
+    }
+
+    static func codexRoutingCandidateKind(
+        foregroundProcessName: String?,
+        polledProcessName: String?,
+        stateKind: PaneAgentKind?
+    ) -> PaneAgentKind? {
+        if let processName = foregroundProcessName ?? polledProcessName {
+            return agentKind(named: processName)
+        }
+        return stateKind
     }
 
     private static func isBenignShellProcessName(_ name: String) -> Bool {

--- a/GlintTests/AgentHookRoutingTests.swift
+++ b/GlintTests/AgentHookRoutingTests.swift
@@ -1,0 +1,196 @@
+import XCTest
+@testable import Glint
+
+final class AgentHookRoutingTests: XCTestCase {
+    func testDirectPaneEnvelopeStillDecodes() throws {
+        let line = try XCTUnwrap(
+            #"{"pane":"12345678-1234-1234-1234-123456789ABC:7","hook":"Stop","agent":"claude"}"#
+                .data(using: .utf8)
+        )
+
+        XCTAssertEqual(AgentBridge.decodeHookLine(line), [
+            "pane": "12345678-1234-1234-1234-123456789ABC:7",
+            "hook": "Stop",
+            "agent": "claude",
+        ])
+    }
+
+    func testSharedCodexEnvelopeDecodesRoutingMetadata() throws {
+        let session = Data("019eed23-2baa-7043-be10-c1254064dbee".utf8).base64EncodedString()
+        let cwd = Data("/Volumes/Work Space/repo".utf8).base64EncodedString()
+        let line = try JSONSerialization.data(withJSONObject: [
+            "hook": "UserPromptSubmit",
+            "agent": "codex",
+            "session_b64": session,
+            "cwd_b64": cwd,
+        ])
+
+        XCTAssertEqual(AgentBridge.decodeHookLine(line), [
+            "hook": "UserPromptSubmit",
+            "agent": "codex",
+            "session": "019eed23-2baa-7043-be10-c1254064dbee",
+            "cwd": "/Volumes/Work Space/repo",
+        ])
+    }
+
+    func testEnvelopeWithoutPaneOrSessionIsRejected() throws {
+        let line = try XCTUnwrap(#"{"hook":"Stop","agent":"codex"}"#.data(using: .utf8))
+        XCTAssertNil(AgentBridge.decodeHookLine(line))
+    }
+
+    @MainActor
+    func testKnownShellDoesNotFallBackToStaleCodexState() {
+        XCTAssertNil(WorkspaceStore.codexRoutingCandidateKind(
+            foregroundProcessName: "zsh",
+            polledProcessName: "codex",
+            stateKind: .codex
+        ))
+    }
+
+    @MainActor
+    func testMissingProcessInfoCanUseCurrentCodexState() {
+        XCTAssertEqual(WorkspaceStore.codexRoutingCandidateKind(
+            foregroundProcessName: nil,
+            polledProcessName: nil,
+            stateKind: .codex
+        ), .codex)
+    }
+
+    func testReporterKeepsCodexCommandStableAndDrainsPayload() throws {
+        let body = AgentHookInstaller.scriptBody
+        XCTAssertTrue(body.contains("plutil -extract session_id"))
+        XCTAssertTrue(body.contains("agent-debug.sock"))
+        XCTAssertFalse(body.contains(#"${3:-"#))
+        XCTAssertFalse(body.contains("CodexPaneShim"))
+
+        let temp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("glint-reporter-\(UUID().uuidString)")
+        try body.write(to: temp, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let check = Process()
+        check.executableURL = URL(fileURLWithPath: "/bin/sh")
+        check.arguments = ["-n", temp.path]
+        try check.run()
+        check.waitUntilExit()
+        XCTAssertEqual(check.terminationStatus, 0)
+    }
+
+    func testReporterForwardsSharedCodexMetadataOverUnixSocket() throws {
+        // Unix-domain socket paths are capped at 104 bytes on Darwin; XCTest's
+        // default temporary directory is already too deep.
+        let root = URL(fileURLWithPath: "/tmp/gr-\(UUID().uuidString)", isDirectory: true)
+        let runDirectory = root.appendingPathComponent(".glint/run", isDirectory: true)
+        let socket = runDirectory.appendingPathComponent("agent.sock")
+        let script = root.appendingPathComponent("glint-report.sh")
+        try FileManager.default.createDirectory(at: runDirectory, withIntermediateDirectories: true)
+        try AgentHookInstaller.scriptBody.write(to: script, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let listenerOutput = Pipe()
+        let listener = Process()
+        listener.executableURL = URL(fileURLWithPath: "/usr/bin/nc")
+        listener.arguments = ["-lU", socket.path]
+        listener.standardOutput = listenerOutput
+        try listener.run()
+        defer { if listener.isRunning { listener.terminate() } }
+        let socketDeadline = Date().addingTimeInterval(1)
+        while !FileManager.default.fileExists(atPath: socket.path), Date() < socketDeadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: socket.path))
+
+        let reporter = Process()
+        reporter.executableURL = URL(fileURLWithPath: "/bin/sh")
+        reporter.arguments = [script.path, "UserPromptSubmit", "codex"]
+        var environment = ProcessInfo.processInfo.environment
+        environment["HOME"] = root.path
+        environment.removeValue(forKey: "GLINT_PANE_ID")
+        environment.removeValue(forKey: "GLINT_AGENT_SOCK")
+        reporter.environment = environment
+        let input = Pipe()
+        reporter.standardInput = input
+        try reporter.run()
+        input.fileHandleForWriting.write(
+            Data(#"{"session_id":"session-123","cwd":"/Volumes/Work Space/repo"}"#.utf8)
+        )
+        try input.fileHandleForWriting.close()
+        reporter.waitUntilExit()
+        XCTAssertEqual(reporter.terminationStatus, 0)
+
+        let deadline = Date().addingTimeInterval(3)
+        while listener.isRunning && Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+        }
+        XCTAssertFalse(listener.isRunning, "reporter did not connect to the Unix socket")
+        let line = listenerOutput.fileHandleForReading.readDataToEndOfFile()
+        XCTAssertEqual(AgentBridge.decodeHookLine(line), [
+            "hook": "UserPromptSubmit",
+            "agent": "codex",
+            "session": "session-123",
+            "cwd": "/Volumes/Work Space/repo",
+        ])
+    }
+
+    func testReporterPrefersExplicitSocketWithoutBroadcasting() throws {
+        let root = URL(fileURLWithPath: "/tmp/gp-\(UUID().uuidString)", isDirectory: true)
+        let runDirectory = root.appendingPathComponent(".glint/run", isDirectory: true)
+        let explicitSocket = root.appendingPathComponent("explicit.sock")
+        let debugSocket = runDirectory.appendingPathComponent("agent-debug.sock")
+        let script = root.appendingPathComponent("glint-report.sh")
+        try FileManager.default.createDirectory(at: runDirectory, withIntermediateDirectories: true)
+        try AgentHookInstaller.scriptBody.write(to: script, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let explicitOutput = Pipe()
+        let explicitListener = Process()
+        explicitListener.executableURL = URL(fileURLWithPath: "/usr/bin/nc")
+        explicitListener.arguments = ["-lU", explicitSocket.path]
+        explicitListener.standardOutput = explicitOutput
+        try explicitListener.run()
+        defer { if explicitListener.isRunning { explicitListener.terminate() } }
+
+        let debugListener = Process()
+        debugListener.executableURL = URL(fileURLWithPath: "/usr/bin/nc")
+        debugListener.arguments = ["-lU", debugSocket.path]
+        try debugListener.run()
+        defer { if debugListener.isRunning { debugListener.terminate() } }
+
+        let socketDeadline = Date().addingTimeInterval(1)
+        while (!FileManager.default.fileExists(atPath: explicitSocket.path)
+               || !FileManager.default.fileExists(atPath: debugSocket.path)),
+              Date() < socketDeadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: explicitSocket.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: debugSocket.path))
+
+        let reporter = Process()
+        reporter.executableURL = URL(fileURLWithPath: "/bin/sh")
+        reporter.arguments = [script.path, "UserPromptSubmit", "codex"]
+        var environment = ProcessInfo.processInfo.environment
+        environment["HOME"] = root.path
+        environment["GLINT_PANE_ID"] = "workspace:1"
+        environment["GLINT_AGENT_SOCK"] = explicitSocket.path
+        reporter.environment = environment
+        let input = Pipe()
+        reporter.standardInput = input
+        try reporter.run()
+        input.fileHandleForWriting.write(
+            Data(#"{"session_id":"session-explicit","cwd":"/tmp/repo"}"#.utf8)
+        )
+        try input.fileHandleForWriting.close()
+        reporter.waitUntilExit()
+        XCTAssertEqual(reporter.terminationStatus, 0)
+
+        let deadline = Date().addingTimeInterval(3)
+        while explicitListener.isRunning && Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+        }
+        XCTAssertFalse(explicitListener.isRunning)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        XCTAssertTrue(debugListener.isRunning, "reporter unexpectedly broadcast to debug socket")
+        let line = explicitOutput.fileHandleForReading.readDataToEndOfFile()
+        XCTAssertEqual(AgentBridge.decodeHookLine(line)?["session"], "session-explicit")
+    }
+}


### PR DESCRIPTION
## Summary

Restore Codex working, tool, permission, completion, and failure status updates in the sidebar for recent Codex CLI versions.

## Root cause

Recent Codex versions execute hooks from a long-lived shared `codex app-server` process. That process does not inherit the terminal pane's `GLINT_PANE_ID` or `GLINT_AGENT_SOCK`, so Glint's existing reporter cannot identify the originating pane.

The reporter also exited before consuming hook stdin when the route was missing, which could surface as a broken-pipe hook error.

## Changes

- Keep the configured Codex hook command stable so its trust hash does not vary between panes.
- Extract only `session_id` and `cwd` routing metadata from Codex hook stdin.
- Prefer the inherited Glint socket when available and only probe production
  and debug sockets as a shared app-server fallback.
- Bind each Codex session to the pane that submitted its first prompt.
- Route subsequent tool, permission, stop, and failure events through that session mapping.
- Bound the session route cache with a 12-hour TTL and a 256-entry cap.
- Revalidate mappings when a session is resumed from another pane.
- Exclude permission-approval Return presses and stale shell state from prompt routing candidates.
- Preserve the existing direct pane-addressed path for Claude and other agents.
- Avoid retaining prompt or tool payload contents.

## Validation

- Built and ad-hoc signed a Release app.
- Manually verified the fix against a local production-style Codex session.
- Added direct and shared hook envelope decoding tests.
- Added an end-to-end Unix socket reporter test.
- Added regression coverage that an explicit socket prevents debug/release broadcasting.
- Added regression coverage for stale foreground process routing.
- `AgentHookRoutingTests`: 8 passed.

The full local suite has one pre-existing locale-sensitive assertion: it expects `Disabled` while a Chinese test host returns `已停用`.
