### PR TITLE
fix(theme): English source strings + zh-Hans catalog for theme UI / 主题设置英文源串 + zh-Hans 翻译

### DIFF
--- a/Glint/Chrome/GlintTheme.swift
+++ b/Glint/Chrome/GlintTheme.swift
@@ -113,7 +113,7 @@ extension GlintTheme {
     /// 无法派生,follow 态的 chrome 策略留到第 3/4 步定。
     static let followGhostty = GlintTheme(
         id: "follow-ghostty",
-        name: "跟随 Ghostty 配置",
+        name: "Follow Ghostty Config",
         isDark: true,
         background: glintDark.background,
         foreground: glintDark.foreground,

--- a/Glint/Chrome/SettingsView.swift
+++ b/Glint/Chrome/SettingsView.swift
@@ -487,7 +487,7 @@ private struct AppearancePane: View {
     var body: some View {
         SettingsCard("Theme") {
             VStack(alignment: .leading, spacing: 8) {
-                Text("终端与界面共用一套配色,一键换肤。")
+                Text("Terminal and interface share one palette — recolor both at once.")
                     .font(.system(size: 11))
                     .foregroundStyle(Theme.text3)
                 LazyVGrid(
@@ -507,7 +507,7 @@ private struct AppearancePane: View {
                     HStack(spacing: 6) {
                         Image(systemName: "square.grid.2x2")
                             .font(.system(size: 11, weight: .medium))
-                        Text("浏览全部 \(ThemeRegistry.catalog.count + ThemeRegistry.featured.count) 套主题")
+                        Text("Browse all \(ThemeRegistry.catalog.count + ThemeRegistry.featured.count) themes")
                             .font(.system(size: 12, weight: .medium))
                         Image(systemName: "chevron.right")
                             .font(.system(size: 9, weight: .semibold))
@@ -565,17 +565,17 @@ private struct AppearancePane: View {
             }
         }
 
-        SettingsCard("透明度与模糊",
-                     footer: "让桌面从背后透出 —— 终端区与侧栏/工具栏可分开调。背景模糊把透出的桌面磨砂虚化,终端文字更易读。注:macOS 原生全屏下系统会禁用窗口透明。") {
-            SettingsRow("终端透明度") {
+        SettingsCard("Opacity & blur",
+                     footer: "Let the desktop show through — the terminal area and the sidebar/toolbar can be tuned separately. Background blur frosts the desktop behind the window so terminal text stays readable. Note: macOS native fullscreen disables window transparency.") {
+            SettingsRow("Terminal opacity") {
                 OpacityControl(value: $store.terminalOpacity)
             }
             SettingsDivider()
-            SettingsRow("界面透明度", subtitle: "侧栏与工具栏") {
+            SettingsRow("Interface opacity", subtitle: "Sidebar and toolbar") {
                 OpacityControl(value: $store.chromeOpacity)
             }
             SettingsDivider()
-            SettingsRow("背景模糊") {
+            SettingsRow("Background blur") {
                 HStack(spacing: 10) {
                     Slider(value: $store.backgroundBlur, in: 0...60)
                         .frame(width: 150)
@@ -587,8 +587,8 @@ private struct AppearancePane: View {
             }
         }
 
-        SettingsCard("应用图标",
-                     footer: "切换程序坞（Dock）中的图标。「默认」在 macOS 26 上保留 Liquid Glass 玻璃图标；其余配色为静态图标。") {
+        SettingsCard("App icon",
+                     footer: "Switch the Dock icon. \"Default\" keeps the Liquid Glass icon on macOS 26; the other accents are static icons.") {
             LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 10), count: 5), spacing: 14) {
                 ForEach(AppIconPreset.allCases) { preset in
                     VStack(spacing: 5) {
@@ -748,7 +748,7 @@ private struct ThemeBrowserSheet: View {
             Image(systemName: "magnifyingglass")
                 .font(.system(size: 13, weight: .medium))
                 .foregroundStyle(Theme.text3)
-            TextField("搜索主题…", text: $query)
+            TextField("Search themes…", text: $query)
                 .textFieldStyle(.plain)
                 .font(.system(size: 14))
                 .foregroundStyle(Theme.text1)
@@ -797,7 +797,7 @@ private struct ThemeBrowserSheet: View {
     private var footer: some View {
         HStack(spacing: 10) {
             Spacer()
-            Button("取消") { dismiss() }       // applied 仍为 false → onDisappear 还原
+            Button("Cancel") { dismiss() }       // applied 仍为 false → onDisappear 还原
                 .buttonStyle(.plain)
                 .font(.system(size: 13, weight: .medium))
                 .foregroundStyle(Theme.text2)
@@ -808,7 +808,7 @@ private struct ThemeBrowserSheet: View {
                         .fill(Theme.overlay(0.05))
                 )
 
-            Button("应用") { apply() }
+            Button("Apply") { apply() }
                 .buttonStyle(.plain)
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundStyle(dirty ? .white : Theme.text4)
@@ -874,7 +874,7 @@ private struct ThemeBrowserRow: View {
                             .foregroundStyle(Theme.text1)
                             .lineLimit(1)
                         if isCurrent {
-                            Text("当前")
+                            Text("Current")
                                 .font(.system(size: 9, weight: .semibold))
                                 .foregroundStyle(accent)
                                 .padding(.horizontal, 5)

--- a/Glint/Resources/Localizable.xcstrings
+++ b/Glint/Resources/Localizable.xcstrings
@@ -1,6 +1,149 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "App icon": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用图标"
+          }
+        }
+      }
+    },
+    "Apply": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用"
+          }
+        }
+      }
+    },
+    "Background blur": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "背景模糊"
+          }
+        }
+      }
+    },
+    "Browse all %lld themes": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "浏览全部 %lld 套主题"
+          }
+        }
+      }
+    },
+    "Current": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前"
+          }
+        }
+      }
+    },
+    "Interface opacity": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "界面透明度"
+          }
+        }
+      }
+    },
+    "Let the desktop show through — the terminal area and the sidebar/toolbar can be tuned separately. Background blur frosts the desktop behind the window so terminal text stays readable. Note: macOS native fullscreen disables window transparency.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "让桌面从背后透出 —— 终端区与侧栏/工具栏可分开调。背景模糊把透出的桌面磨砂虚化,终端文字更易读。注:macOS 原生全屏下系统会禁用窗口透明。"
+          }
+        }
+      }
+    },
+    "Opacity & blur": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "透明度与模糊"
+          }
+        }
+      }
+    },
+    "Search themes…": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索主题…"
+          }
+        }
+      }
+    },
+    "Sidebar and toolbar": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "侧栏与工具栏"
+          }
+        }
+      }
+    },
+    "Switch the Dock icon. \"Default\" keeps the Liquid Glass icon on macOS 26; the other accents are static icons.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换程序坞（Dock）中的图标。「默认」在 macOS 26 上保留 Liquid Glass 玻璃图标；其余配色为静态图标。"
+          }
+        }
+      }
+    },
+    "Terminal and interface share one palette — recolor both at once.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "终端与界面共用一套配色,一键换肤。"
+          }
+        }
+      }
+    },
+    "Terminal opacity": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "终端透明度"
+          }
+        }
+      }
+    },
     "External control": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
## What / 问题

The theme settings section (`Opacity & blur`, `App icon`, `Terminal/Interface opacity`, `Background blur`, theme-browser buttons/labels, etc.) used **Chinese source literals with no `Localizable.xcstrings` entries**. Because `sourceLanguage = en`, English-locale users saw Chinese.

主题设置区(`Opacity & blur`、`App icon`、终端/界面透明度、背景模糊、主题浏览器按钮/标签等)用的是**中文源串,且 `Localizable.xcstrings` 里没有对应条目**。因为 `sourceLanguage = en`,英文环境用户看到的是中文。

## Why it's a bug / 为什么是 bug

`SettingsCard`/`SettingsRow` 在 body 里把 `title`/`footer`/`subtitle` 经 `Text(LocalizedStringKey(...))` 重新包装,目录里缺条目就渲染原始 key。中文 key + 没有 `zh-Hans` 条目 → 字符串目录无法解析 → 英文用户看到中文,且这些串不可翻译。

## Fix / 修复

- 13 处主题区 UI 字面量改为**英文源**。
- 在 `Localizable.xcstrings` 补它们的 **`zh-Hans` 翻译**(`extractionState: manual`)。
- `"跟随 Ghostty 配置"` 主题名 → `"Follow Ghostty Config"`,与其它英文主题名(`Catppuccin Mocha`、`glint-dark`)一致;主题名是目录数据,经 `Text(theme.name)` verbatim 渲染,无需目录条目。

## Verification / 验证

- arm64 Debug 构建通过。
- `xcstrings` JSON 合法(395 keys),13 个新 key 全部解析到 `zh-Hans`。
- `SettingsView.swift` 残留中文 UI 字面量 = 0(`中文（简体）` 是语言选择器里的语言本名,按惯例保留)。
- Dev 构建切英文实测:主题区现在显示英文。