### PR TITLE
fix(persistence): tolerate a single bad workspace + guard the repaired write / 容忍单个坏 workspace + 保护修复态写入

### DIFF
--- a/Glint.xcodeproj/project.pbxproj
+++ b/Glint.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		D1BDE1E5DE8D4FE1F96822D1 /* WorkspaceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8933F67B4B6EEA3FD4E603 /* WorkspaceStore.swift */; };
 		D3D6CF13B67D30E9DA557F83 /* UsageStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A1F24DAA7220AD4EE961E2 /* UsageStore.swift */; };
 		E464D0233508CD31C1235054 /* AgentBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05F2CA2243872C8111048EF2 /* AgentBridge.swift */; };
+		E80809A987A07731FF35D01D /* PersistenceRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DE2D7740BD03498A936B62 /* PersistenceRecoveryTests.swift */; };
 		ED46CD7A6E09551A775AD3B8 /* PaneAgentKindTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBCC04C19D745AA867D961FD /* PaneAgentKindTests.swift */; };
 		EF3ACBA990526130228FAD0B /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D3B64992BBD5A190DFE36D2 /* SettingsView.swift */; };
 		EF937781512647E835836F83 /* ControlBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21868C7211897C87A6CAD7C3 /* ControlBridge.swift */; };
@@ -93,6 +94,7 @@
 		4408F9761E584DE2AB6630E2 /* UpdaterController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdaterController.swift; sourceTree = "<group>"; };
 		4BE4DBC7E2579823474466E9 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		4EEF00CBEF45A9D60423A207 /* AgentKindResolutionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentKindResolutionTests.swift; sourceTree = "<group>"; };
+		51DE2D7740BD03498A936B62 /* PersistenceRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceRecoveryTests.swift; sourceTree = "<group>"; };
 		54663E213FE879B96C0D80E7 /* GitStatusPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusPopover.swift; sourceTree = "<group>"; };
 		5A8933F67B4B6EEA3FD4E603 /* WorkspaceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceStore.swift; sourceTree = "<group>"; };
 		6860F8F626EFDB9A289FC727 /* themes.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = themes.json; sourceTree = "<group>"; };
@@ -168,6 +170,7 @@
 				0F58E2127BAE2C9F5155CF07 /* DevinHookInstallerTests.swift */,
 				349714D49AE52D84995314FD /* MascotAssetTests.swift */,
 				EBCC04C19D745AA867D961FD /* PaneAgentKindTests.swift */,
+				51DE2D7740BD03498A936B62 /* PersistenceRecoveryTests.swift */,
 				83E4DF4C5180D50C381B4976 /* WorkspaceIconKindTests.swift */,
 			);
 			path = GlintTests;
@@ -401,6 +404,7 @@
 				34997DD4A4F9B64A754FE77F /* DevinHookInstallerTests.swift in Sources */,
 				04E75EAD5165E8D96C1C5517 /* MascotAssetTests.swift in Sources */,
 				ED46CD7A6E09551A775AD3B8 /* PaneAgentKindTests.swift in Sources */,
+				E80809A987A07731FF35D01D /* PersistenceRecoveryTests.swift in Sources */,
 				C748DE21F23B49B2FFD73DC7 /* WorkspaceIconKindTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Glint/Workspace/Persistence.swift
+++ b/Glint/Workspace/Persistence.swift
@@ -66,14 +66,30 @@ enum Persistence {
         do {
             return try JSONDecoder().decode(PersistedState.self, from: data)
         } catch {
-            // A single undecodable pane entry would otherwise quarantine the
-            // whole file and lose every workspace. PaneID isn't a String/Int
-            // key, so [PaneID: Pane] serializes as a flat alternating
-            // [key, value, ...] array; stripBadPanes drops just the bad pair.
-            if let repaired = Self.stripBadPanes(from: data),
+            // Progressive recovery before quarantining. Two stages, each
+            // feeding the next so a file with mixed damage still recovers the
+            // good workspaces:
+            //   1. stripBadPanes — drops a single undecodable pane entry.
+            //      PaneID isn't a String/Int key, so [PaneID: Pane] serializes
+            //      as a flat alternating [key, value, ...] array; we drop just
+            //      the bad pair, keeping the workspace.
+            //   2. stripBadWorkspaces — drops a whole undecodable workspace
+            //      (corruption in a workspace-level field like tabs/source/
+            //      accentHex, not a pane), keeping the rest.
+            let paneFixed = Self.stripBadPanes(from: data) ?? data
+            let repaired = Self.stripBadWorkspaces(from: paneFixed) ?? paneFixed
+            if repaired != data,
                let state = try? JSONDecoder().decode(PersistedState.self, from: repaired) {
-                NSLog("[glint] decoded \(fileName) after stripping undecodable pane(s); persisting the repaired copy")
-                try? repaired.write(to: url, options: [.atomic])
+                NSLog("[glint] decoded \(fileName) after stripping undecodable pane(s)/workspace(s); persisting the repaired copy")
+                do {
+                    try repaired.write(to: url, options: [.atomic])
+                } catch {
+                    // Couldn't persist the repair (disk full/permissions).
+                    // Guard the original so the next autosave doesn't
+                    // overwrite the only copy with the stripped state.
+                    corruptUnmovablePath = url.path
+                    NSLog("[glint] couldn't persist repaired \(fileName); refusing to overwrite — original kept at \(url.path)")
+                }
                 return state
             }
 
@@ -119,7 +135,7 @@ enum Persistence {
     /// nothing changed or the structure is unrecognizable (so the caller only
     /// retries when there's something to retry with). Lets one bad pane cost
     /// only that pane instead of the whole file.
-    private static func stripBadPanes(from data: Data) -> Data? {
+    static func stripBadPanes(from data: Data) -> Data? {
         guard var root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
               var workspaces = root["workspaces"] as? [[String: Any]] else { return nil }
         let pdecoder = JSONDecoder()
@@ -145,6 +161,35 @@ enum Persistence {
         }
         guard changed else { return nil }
         root["workspaces"] = workspaces
+        return SafeJSON.data(root)
+    }
+
+    /// Drop any top-level workspace that won't decode, keeping the rest.
+    /// Runs after stripBadPanes, so by the time this fires the damage is in a
+    /// workspace-level field (tabs, source, accentHex, …) rather than a pane —
+    /// letting one bad workspace cost only that workspace instead of the whole
+    /// file. Returns nil if nothing was dropped, if every workspace is bad
+    /// (abstaining lets the caller fall back to a fresh state and preserve the
+    /// original on disk), or if the structure is unrecognizable.
+    static func stripBadWorkspaces(from data: Data) -> Data? {
+        guard var root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+              let workspaces = root["workspaces"] as? [Any] else { return nil }
+        let wdecoder = JSONDecoder()
+        var kept: [Any] = []
+        var dropped = 0
+        for ws in workspaces {
+            // SafeJSON, not bare data(withJSONObject:): a stray non-JSON leaf
+            // or non-finite number throws an NSException (uncatchable by try?).
+            let blob = SafeJSON.data(ws) ?? Data()
+            if (try? wdecoder.decode(Workspace.self, from: blob)) != nil {
+                kept.append(ws)
+            } else {
+                dropped += 1
+            }
+        }
+        guard dropped > 0, !kept.isEmpty else { return nil }
+        root["workspaces"] = kept
+        NSLog("[glint] \(fileName): dropping \(dropped) undecodable workspace(s), keeping \(kept.count)")
         return SafeJSON.data(root)
     }
 }

--- a/GlintTests/PersistenceRecoveryTests.swift
+++ b/GlintTests/PersistenceRecoveryTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import Glint
+
+/// Recovery logic in `Persistence.load()` is the only thing standing between a
+/// half-written state.json and losing every workspace. `load()`/`save()` read a
+/// fixed Application Support path, so these tests exercise the pure
+/// `Data -> Data?` recovery helpers directly — pinning them so a future
+/// refactor can't quietly regress the "one bad entry costs only that entry"
+/// guarantee.
+final class PersistenceRecoveryTests: XCTestCase {
+
+    private func stateData(workspaces: [Workspace]) throws -> Data {
+        let state = PersistedState(workspaces: workspaces,
+                                   selectedWorkspaceID: nil,
+                                   sidebarCollapsed: false)
+        return try JSONEncoder().encode(state)
+    }
+
+    /// Two good workspaces, then one is replaced with a dict missing every
+    /// required Workspace field. stripBadWorkspaces must drop only the bad one
+    /// and leave the survivor decodable.
+    func testStripBadWorkspaces_dropsCorruptKeepsGood() throws {
+        let survivor = Workspace.fresh(name: "Survivor", accentHex: "5E5CE6", symbol: "S")
+        let clean = try stateData(workspaces: [
+            survivor,
+            Workspace.fresh(name: "Doomed", accentHex: "FF6482", symbol: "D")
+        ])
+        XCTAssertNotNil(try? JSONDecoder().decode(PersistedState.self, from: clean))
+
+        // Corrupt the second workspace with a garbage dict (missing id/name/…).
+        var root = try XCTUnwrap(JSONSerialization.jsonObject(with: clean) as? [String: Any])
+        var workspaces = try XCTUnwrap(root["workspaces"] as? [Any])
+        workspaces[1] = ["__corrupted": true]
+        root["workspaces"] = workspaces
+        let corrupted = try JSONSerialization.data(withJSONObject: root)
+
+        // Sanity: the corrupted blob no longer decodes as a whole.
+        XCTAssertNil(try? JSONDecoder().decode(PersistedState.self, from: corrupted))
+
+        let repaired = Persistence.stripBadWorkspaces(from: corrupted)
+        XCTAssertNotNil(repaired, "expected the bad workspace to be stripped")
+        let recovered = try JSONDecoder().decode(
+            PersistedState.self, from: try XCTUnwrap(repaired))
+        XCTAssertEqual(recovered.workspaces.count, 1)
+        XCTAssertEqual(recovered.workspaces.first?.name, "Survivor")
+    }
+
+    /// Undamaged data must return nil ("nothing to fix") so the caller doesn't
+    /// rewrite a healthy file.
+    func testStripBadWorkspaces_cleanDataReturnsNil() throws {
+        let clean = try stateData(workspaces: [
+            Workspace.fresh(name: "A", accentHex: "5E5CE6", symbol: "A")
+        ])
+        XCTAssertNil(Persistence.stripBadWorkspaces(from: clean))
+    }
+
+    /// If every workspace is bad we abstain (nil) rather than emitting an empty
+    /// state — the caller then preserves the original on disk and falls back to
+    /// a fresh start.
+    func testStripBadWorkspaces_allBadReturnsNil() throws {
+        let clean = try stateData(workspaces: [
+            Workspace.fresh(name: "A", accentHex: "5E5CE6", symbol: "A")
+        ])
+        var root = try XCTUnwrap(JSONSerialization.jsonObject(with: clean) as? [String: Any])
+        root["workspaces"] = [["__bad": 1], ["__bad": 2]]
+        let allBad = try JSONSerialization.data(withJSONObject: root)
+        XCTAssertNil(Persistence.stripBadWorkspaces(from: allBad))
+    }
+
+    /// A blob that isn't even PersistedState-shaped must not crash — returns nil.
+    func testStripBadWorkspaces_unrecognizableReturnsNil() throws {
+        let blob = try JSONSerialization.data(withJSONObject: ["not": "state"])
+        XCTAssertNil(Persistence.stripBadWorkspaces(from: blob))
+    }
+}


### PR DESCRIPTION
Two gaps in the `state.json` recovery path added in #21.
#21 引入的 `state.json` 恢复路径里有两个漏洞。

## 1. A single bad *workspace* still lost everything / 单个坏 workspace 仍会丢全部

`stripBadPanes` only surgically repaired a bad **pane**. If the undecodable field was at the workspace level (`tabs`, `source`, `accentHex`, …), the whole file was quarantined and **every workspace** was lost.

`stripBadPanes` 只能外科式修复单个坏 **pane**。坏的是 workspace 级字段(`tabs`、`source`、`accentHex`…)时,整个文件被 quarantine,**所有 workspace** 全丢。

**Fix / 修复:** 新增 `stripBadWorkspaces`,只丢坏的那个 workspace、保留其余。它在 `stripBadPanes` 之后跑(基于修过 pane 的数据),所以混合损坏也能救回好的 workspace。全部 workspace 都坏时返回 `nil`(放弃),让调用方保留原件、回落到 fresh。

## 2. The repaired write wasn't guarded / 修复态写入没保护

When recovery produced a repaired state, the persist step used `try?` and silently ignored failure. On a full disk the repair couldn't persist, but `corruptUnmovablePath` was never set — so the **next autosave overwrote the only copy of the original** with the stripped state.

恢复出修复态后,持久化用 `try?`,失败被静默吞掉。磁盘满时修复态写不进去,但 `corruptUnmovablePath` 没置位 → **下次 autosave 用剥掉的态覆盖了唯一的原件**。

**Fix / 修复:** 写入失败时置 `corruptUnmovablePath`,`save()` 拒绝覆盖原件(与 move-aside 分支一致)。内存里的修复态仍返回,用户本次会话仍能用好的 workspace。

## Tests / 测试

新增 `GlintTests/PersistenceRecoveryTests.swift`(4 例):坏的被剔好的保留、无损坏→`nil`、全坏→`nil`、不可识别→`nil`。两个恢复 helper 去掉 `private`,好让 `@testable` 能访问。

```
Executed 4 tests, with 0 failures
```

arm64 Debug 构建通过。健康文件行为不变。