### PR TITLE
fix(i18n): localize Codex hook error + auth status strings / 本地化 Codex 钩子错误与 auth 状态串

### DIFF
--- a/Glint/Agent/AgentHookInstaller.swift
+++ b/Glint/Agent/AgentHookInstaller.swift
@@ -462,7 +462,7 @@ enum CodexHookInstaller {
         guard FileManager.default.fileExists(atPath: url.path) else { return .notInstalled }
         guard let data = try? Data(contentsOf: url),
               (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) != nil else {
-            return .error("Invalid hooks.json")
+            return .error(String(localized: "Invalid hooks.json"))
         }
         return isInstalled(in: codexHome) ? .installed : .notInstalled
     }
@@ -664,12 +664,12 @@ enum CodexHookInstallerError: LocalizedError, Equatable {
 
     var errorDescription: String? {
         switch self {
-        case .reporterUnavailable: return "Could not create the Glint reporter script."
-        case .cannotCreateHome(let detail): return "Could not create the Codex Home directory: \(detail)"
-        case .invalidHooksJSON: return "Invalid hooks.json. The file was not modified."
-        case .invalidHookTree: return "The hook configuration cannot be encoded as JSON."
-        case .readFailed(let detail): return "Could not read hooks.json: \(detail)"
-        case .writeFailed(let detail): return "Could not write hooks.json: \(detail)"
+        case .reporterUnavailable: return String(localized: "Could not create the Glint reporter script.")
+        case .cannotCreateHome(let detail): return String(localized: "Could not create the Codex Home directory: \(detail)")
+        case .invalidHooksJSON: return String(localized: "Invalid hooks.json. The file was not modified.")
+        case .invalidHookTree: return String(localized: "The hook configuration cannot be encoded as JSON.")
+        case .readFailed(let detail): return String(localized: "Could not read hooks.json: \(detail)")
+        case .writeFailed(let detail): return String(localized: "Could not write hooks.json: \(detail)")
         }
     }
 }

--- a/Glint/Agent/UsageStore.swift
+++ b/Glint/Agent/UsageStore.swift
@@ -502,7 +502,7 @@ enum CodexLiveReader {
         guard FileManager.default.fileExists(atPath: path.path) else { return .missing }
         guard let data = try? Data(contentsOf: path),
               (try? JSONDecoder().decode(Auth.self, from: data)) != nil else {
-            return .invalid("Invalid auth.json")
+            return .invalid(String(localized: "Invalid auth.json"))
         }
         return .found
     }

--- a/Glint/Resources/Localizable.xcstrings
+++ b/Glint/Resources/Localizable.xcstrings
@@ -4216,6 +4216,94 @@
           }
         }
       }
+    },
+    "Invalid hooks.json": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hooks.json 无效"
+          }
+        }
+      }
+    },
+    "Invalid auth.json": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "auth.json 无效"
+          }
+        }
+      }
+    },
+    "Could not create the Glint reporter script.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法创建 Glint 上报脚本。"
+          }
+        }
+      }
+    },
+    "Could not create the Codex Home directory: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法创建 Codex Home 目录:%@"
+          }
+        }
+      }
+    },
+    "Invalid hooks.json. The file was not modified.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hooks.json 无效,文件未被修改。"
+          }
+        }
+      }
+    },
+    "The hook configuration cannot be encoded as JSON.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "钩子配置无法编码为 JSON。"
+          }
+        }
+      }
+    },
+    "Could not read hooks.json: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法读取 hooks.json:%@"
+          }
+        }
+      }
+    },
+    "Could not write hooks.json: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法写入 hooks.json:%@"
+          }
+        }
+      }
     }
   },
   "version": "1.0"


### PR DESCRIPTION
## What & why

Eight user-visible strings in the Codex Home settings row were raw English and never went through the string catalog, so under `zh-Hans` the failure states showed English while every sibling status string was translated. They surface two ways:

- `CodexHookInstaller.status(in:)` → `.error("Invalid hooks.json")` and `CodexLiveReader.authStatus` → `.invalid("Invalid auth.json")` (the `Hook` / `Auth` badges).
- `CodexHookInstallerError.errorDescription` (6 strings) → shown as the orange error text via `error.localizedDescription` → `Text(error)`.

## How

- Wrap all 8 in `String(localized:)` at the construction site (matches the existing `Disabled` / `Usage off` / `Quota unavailable` pattern). Interpolated ones keep `%@` in the key, matching `Removed from Glint, but hook cleanup failed: %@`.
- Add the 8 `zh-Hans` entries to `Localizable.xcstrings` (`extractionState: manual`). The catalog was edited by surgical text insertion so **no existing key is reformatted** (the file mixes `": "` / `" : "` separators; a full re-dump would have produced a 160-line noise diff).

Data (paths, `hooks.json`, `auth.json` filenames) stays verbatim — only the chrome is translated.

## Testing / verification

- `xcodegen generate` + `xcodebuild test -scheme Glint -destination 'platform=macOS,arch=arm64'` → 96 tests, 0 failures.
- The existing `CodexHookInstallerTests` (`hasPrefix("Could not read hooks.json:")`) and `CodexUsageReaderTests` (`== .invalid("Invalid auth.json")`) still pass — `String(localized:)` falls back to the source literal under the English test bundle, and the prefix check is robust to either fallback form.

Scope note (from the review request): this is one of three follow-ups split out from a weekly review — the other two are the command-palette key-monitor leak and the review-diff parsing unit tests.

## 中文

### 问题
Codex Home 设置行的 8 条可见串是裸英文、没进字符串目录,中文环境下失败态会露英文,而同行的其它状态串都已翻译。两条路径:`CodexHookInstaller.status` 的 `.error("Invalid hooks.json")`、`authStatus` 的 `.invalid("Invalid auth.json")`(Hook/Auth 徽标),以及 `CodexHookInstallerError.errorDescription` 的 6 条(经 `error.localizedDescription` → `Text(error)` 显示为橙色错误文)。

### 做法
- 在构造点把 8 条都包进 `String(localized:)`,与现有 `Disabled`/`Usage off`/`Quota unavailable` 一致;带插值的 key 保留 `%@`,与 `Removed from Glint, but hook cleanup failed: %@` 一致。
- 在 `Localizable.xcstrings` 补 8 条 `zh-Hans`(`extractionState: manual`)。采用**文本级精准插入**,不重排任何已有 key(该文件 `": "` / `" : "` 混用,整体重导会产生约 160 行噪声 diff)。

数据(路径、`hooks.json`/`auth.json` 文件名)保持 verbatim,只翻译 UI chrome。

### 验证
- `xcodegen generate` + `xcodebuild test -scheme Glint -destination 'platform=macOS,arch=arm64'` → 96 tests,0 failures。
- 现有 `CodexHookInstallerTests`(`hasPrefix("Could not read hooks.json:")`)与 `CodexUsageReaderTests`(`== .invalid("Invalid auth.json")`)仍通过——`String(localized:)` 在英文测试 bundle 下回退为源串,prefix 校验对两种回退形式都成立。

范围说明:这是周评审拆出的三个跟进 PR 之一(另两个:命令面板键盘监视器泄漏、review diff 解析单测)。
