### PR TITLE
fix(palette): release key-event monitor in PaletteModel.deinit / 在 PaletteModel.deinit 中释放键盘事件监视器

### DIFF
--- a/Glint/Chrome/CommandPalette.swift
+++ b/Glint/Chrome/CommandPalette.swift
@@ -409,6 +409,14 @@ struct CommandPalette: View {
 private final class PaletteModel: ObservableObject {
     @Published var selectedIndex: Int = 0
     var keyMonitor: Any?
+
+    deinit {
+        // `.onDisappear` normally removes the monitor, but SwiftUI occasionally
+        // skips it (view replaced rather than removed). An NSEvent local monitor
+        // isn't auto-removed on dealloc, so a leaked one would silently swallow
+        // every arrow/Return/Escape in the app. Belt-and-suspenders cleanup.
+        if let m = keyMonitor { NSEvent.removeMonitor(m) }
+    }
 }
 
 // MARK: - Row + model


### PR DESCRIPTION
## What & why

The command palette installs an `NSEvent.addLocalMonitorForEvents(.keyDown)` on `onAppear` (to drive ↑/↓/⏎/⎋) and removes it on `onDisappear`. SwiftUI occasionally skips `onDisappear` — the view is replaced rather than torn down — and an `NSEvent` local monitor is **not** auto-removed on `dealloc` (only `removeMonitor` reclaims it). A leaked monitor then silently consumes every arrow / Return / Escape keypress app-wide. Spotted in a weekly code review.

## How

Add a `deinit` to `PaletteModel` — the reference type that already owns the `keyMonitor` token — that removes the monitor if it's still installed:

```swift
deinit {
    if let m = keyMonitor { NSEvent.removeMonitor(m) }
}
```

Belt-and-suspenders: the normal close path (`onDisappear` → `removeKeyMonitor`) is unchanged; this only fires when SwiftUI skips `onDisappear`.

## Testing / verification

`xcodegen generate` + `xcodebuild test -scheme Glint -destination 'platform=macOS,arch=arm64'` → build OK, 96 tests pass. No behavioral change on the normal open/close path.

Scope note: one of three follow-ups split out from a weekly review (sibling PRs: Codex hook i18n, review-diff parsing tests).

## 中文

### 问题
命令面板在 `onAppear` 装 `NSEvent.addLocalMonitorForEvents(.keyDown)`(驱动 ↑/↓/⏎/⎋),在 `onDisappear` 卸。但 SwiftUI 偶尔会跳过 `onDisappear`(视图被替换而非销毁),而 `NSEvent` 本地监视器**不会**在 `dealloc` 时自动移除(只有 `removeMonitor` 能回收)。泄漏的监视器会静默吞掉全 App 的方向键/Return/Esc。周评审发现。

### 做法
给已持有 `keyMonitor` token 的引用类型 `PaletteModel` 加 `deinit`,监视器还在就移除:
```swift
deinit {
    if let m = keyMonitor { NSEvent.removeMonitor(m) }
}
```
兜底:正常关闭路径(`onDisappear` → `removeKeyMonitor`)不变,仅当 SwiftUI 跳过 `onDisappear` 时生效。

### 验证
`xcodegen generate` + `xcodebuild test` → 构建通过,96 tests pass。正常开闭路径行为不变。

范围说明:周评审拆出的三个跟进 PR 之一(另两个:Codex 钩子 i18n、review diff 解析单测)。
