### PR TITLE
test(review): cover DiffDocument.parse + TreeNode.build / 补 DiffDocument.parse 与 TreeNode.build 单测

### DIFF
--- a/Glint.xcodeproj/project.pbxproj
+++ b/Glint.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		ED46CD7A6E09551A775AD3B8 /* PaneAgentKindTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBCC04C19D745AA867D961FD /* PaneAgentKindTests.swift */; };
 		EF3ACBA990526130228FAD0B /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D3B64992BBD5A190DFE36D2 /* SettingsView.swift */; };
 		EF937781512647E835836F83 /* ControlBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21868C7211897C87A6CAD7C3 /* ControlBridge.swift */; };
+		F5AE37B67B17DD61B652E5B6 /* ReviewDiffParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CFFB91CE5C44976A6961F1F /* ReviewDiffParsingTests.swift */; };
 		F6AFF715FCE5357CEB07683D /* SettingsSafety.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB20921E3CAC1006A8FBD3AE /* SettingsSafety.swift */; };
 		F7ABF70CD455143BF89B89B3 /* SafeJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E2B9ADF809766CE4278047 /* SafeJSON.swift */; };
 		FCB67525DF16A4DCF9B2AF7A /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 376568363043C189904E4E0A /* Localizable.xcstrings */; };
@@ -85,6 +86,7 @@
 		25DADCEBA9C483C729B69388 /* Glint.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Glint.entitlements; sourceTree = "<group>"; };
 		26141150D2DB4C0589558ECC /* CodexHookInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexHookInstallerTests.swift; sourceTree = "<group>"; };
 		265A192AC9BD06DB09346E90 /* AgentHookInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookInstaller.swift; sourceTree = "<group>"; };
+		2CFFB91CE5C44976A6961F1F /* ReviewDiffParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDiffParsingTests.swift; sourceTree = "<group>"; };
 		3023490E670A10EC38870B12 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		349714D49AE52D84995314FD /* MascotAssetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MascotAssetTests.swift; sourceTree = "<group>"; };
 		376568363043C189904E4E0A /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
@@ -174,6 +176,7 @@
 				349714D49AE52D84995314FD /* MascotAssetTests.swift */,
 				EBCC04C19D745AA867D961FD /* PaneAgentKindTests.swift */,
 				51DE2D7740BD03498A936B62 /* PersistenceRecoveryTests.swift */,
+				2CFFB91CE5C44976A6961F1F /* ReviewDiffParsingTests.swift */,
 				83E4DF4C5180D50C381B4976 /* WorkspaceIconKindTests.swift */,
 			);
 			path = GlintTests;
@@ -409,6 +412,7 @@
 				04E75EAD5165E8D96C1C5517 /* MascotAssetTests.swift in Sources */,
 				ED46CD7A6E09551A775AD3B8 /* PaneAgentKindTests.swift in Sources */,
 				E80809A987A07731FF35D01D /* PersistenceRecoveryTests.swift in Sources */,
+				F5AE37B67B17DD61B652E5B6 /* ReviewDiffParsingTests.swift in Sources */,
 				C748DE21F23B49B2FFD73DC7 /* WorkspaceIconKindTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/GlintTests/ReviewDiffParsingTests.swift
+++ b/GlintTests/ReviewDiffParsingTests.swift
@@ -1,0 +1,153 @@
+import XCTest
+@testable import Glint
+
+/// Pure-logic guards for the review diff pipeline in `ReviewWindow.swift`.
+/// `DiffDocument.parse` and `TreeNode.build` are plain string/JSON → tree
+/// transforms with no UI/AppKit surface, so they're unit-tested directly.
+///
+/// `DiffDocument.parse`'s CRLF normalization (PR #33) is the highest-value
+/// guard here: without it Swift treats "\r\n" as a single Character, so
+/// `split(separator: "\n")` never matches a CRLF-terminated line and a
+/// Windows-authored diff body parses as zero add/del lines — nothing tints.
+final class ReviewDiffParsingTests: XCTestCase {
+
+    private func file(_ path: String) -> GitFileChange {
+        GitFileChange(path: path, kind: .modified, additions: 1, deletions: 1, isBinary: false)
+    }
+
+    // MARK: DiffDocument.parse
+
+    private static let hunkDiff = """
+diff --git a/f.txt b/f.txt
+index 111..222 100644
+--- a/f.txt
++++ b/f.txt
+@@ -1,3 +1,3 @@
+ keep
+-old
++new
+"""
+
+    /// Hunk header seeds old/new line numbers; +/-/context get the right kind
+    /// and the body markers are stripped from the rendered text.
+    func testParseAssignsKindsAndLineNumbers() {
+        let lines = DiffDocument.parse(Self.hunkDiff)
+        // Meta (diff/index/---/+++) is dropped → hunk + 3 body lines.
+        XCTAssertEqual(lines.count, 4)
+        XCTAssertEqual(lines[0].kind, .hunk)
+        XCTAssertEqual(lines[1].kind, .context)
+        XCTAssertEqual(lines[1].text, "keep")
+        XCTAssertEqual(lines[1].oldNum, 1)
+        XCTAssertEqual(lines[1].newNum, 1)
+        XCTAssertEqual(lines[2].kind, .del)
+        XCTAssertEqual(lines[2].text, "old")
+        XCTAssertEqual(lines[2].oldNum, 2)
+        XCTAssertNil(lines[2].newNum)
+        XCTAssertEqual(lines[3].kind, .add)
+        XCTAssertEqual(lines[3].text, "new")
+        XCTAssertNil(lines[3].oldNum)
+        XCTAssertEqual(lines[3].newNum, 2)
+    }
+
+    /// CRLF regression guard (PR #33). A Windows-authored file keeps CRLF in
+    /// the diff body; it must parse exactly like the LF version. If the
+    /// normalization is removed, CRLF lines merge (or keep a trailing \r) and
+    /// these counts/texts break.
+    func testParseNormalizesCRLFBodyLikeLF() {
+        let crlf = Self.hunkDiff.replacingOccurrences(of: "\n", with: "\r\n")
+        let lines = DiffDocument.parse(crlf)
+        XCTAssertEqual(lines.count, 4)
+        XCTAssertEqual(lines[0].kind, .hunk)
+        XCTAssertEqual(lines[1].kind, .context)
+        XCTAssertEqual(lines[1].text, "keep")
+        XCTAssertEqual(lines[2].kind, .del)
+        XCTAssertEqual(lines[2].text, "old")
+        XCTAssertEqual(lines[3].kind, .add)
+        XCTAssertEqual(lines[3].text, "new")
+        XCTAssertEqual(lines[3].newNum, 2)
+    }
+
+    /// Lone CR (classic Mac) line endings must also normalize to LF.
+    func testParseNormalizesLoneCR() {
+        // "@@ ...@@" + CRLF-free body using lone CR as the line separator.
+        let diff = "@@ -1,1 +1,1 @@\r+a\r-b"
+        let lines = DiffDocument.parse(diff)
+        XCTAssertEqual(lines.count, 3)
+        XCTAssertEqual(lines[0].kind, .hunk)
+        XCTAssertEqual(lines[1].kind, .add)
+        XCTAssertEqual(lines[1].text, "a")
+        XCTAssertEqual(lines[1].newNum, 1)
+        XCTAssertEqual(lines[2].kind, .del)
+        XCTAssertEqual(lines[2].text, "b")
+        XCTAssertEqual(lines[2].oldNum, 1)
+    }
+
+    /// File-level meta lines and the "\ No newline at end of file" marker
+    /// produce no DiffLines; only the hunk + its body survive.
+    func testParseDropsMetaAndNoNewlineMarker() {
+        let diff = """
+diff --git a/f b/f
+new file mode 100644
+index 000..111
+--- /dev/null
++++ b/f
+@@ -0,0 +1,1 @@
++hello
+\\ No newline at end of file
+"""
+        let lines = DiffDocument.parse(diff)
+        XCTAssertEqual(lines.count, 2)
+        XCTAssertEqual(lines[0].kind, .hunk)
+        XCTAssertEqual(lines[1].kind, .add)
+        XCTAssertEqual(lines[1].text, "hello")
+        XCTAssertEqual(lines[1].newNum, 1)
+    }
+
+    func testParseEmptyYieldsEmpty() {
+        XCTAssertTrue(DiffDocument.parse("").isEmpty)
+    }
+
+    // MARK: TreeNode.build
+
+    /// Directories nest, folders sort before files at each level (case
+    /// insensitive), and only leaf nodes carry the `GitFileChange`.
+    func testBuildNestsAndSortsFoldersFirst() {
+        let nodes = TreeNode.build([
+            file("src/b.swift"),
+            file("src/a.swift"),
+            file("README.md"),
+            file("src/sub/c.swift"),
+        ])
+        XCTAssertEqual(nodes.map(\.name), ["src", "README.md"])   // folder first
+        XCTAssertTrue(nodes[0].isDir)
+        XCTAssertFalse(nodes[1].isDir)
+        XCTAssertNil(nodes[0].file)                                // dir carries no file
+        XCTAssertEqual(nodes[1].file?.path, "README.md")
+
+        let src = nodes[0].children
+        XCTAssertEqual(src.map(\.name), ["sub", "a.swift", "b.swift"])  // folder, then files
+        XCTAssertEqual(src[0].children.map(\.name), ["c.swift"])
+        XCTAssertEqual(src[1].file?.path, "src/a.swift")
+    }
+
+    /// Many files under one parent share that parent node — the O(1) path
+    /// lookup (PR #30). A flat dir with N files yields one shared dir with N
+    /// leaves; the old linear sibling scan made this O(N²) on reload().
+    func testBuildDedupesSharedParentAndScalesFlat() {
+        let paths = (0..<40).map { file("flat/f\($0).txt") }
+        let nodes = TreeNode.build(paths)
+        XCTAssertEqual(nodes.count, 1)
+        XCTAssertEqual(nodes[0].name, "flat")
+        XCTAssertTrue(nodes[0].isDir)
+        XCTAssertEqual(nodes[0].children.count, 40)
+        XCTAssertTrue(nodes[0].children.allSatisfy { !$0.isDir && $0.file != nil })
+    }
+
+    /// A path reported twice collapses to a single node (the path-keyed build
+    /// reuses the first) rather than creating a duplicate leaf.
+    func testBuildCollapsesDuplicatePath() {
+        let nodes = TreeNode.build([file("a.txt"), file("a.txt")])
+        XCTAssertEqual(nodes.count, 1)
+        XCTAssertEqual(nodes[0].name, "a.txt")
+    }
+}


### PR DESCRIPTION
## What & why

The review diff pipeline in `ReviewWindow.swift` had **zero** unit tests for its pure logic, even though two recent changes there were pure string/JSON → tree transforms worth guarding:

- `DiffDocument.parse` — the CRLF normalization added so a Windows-authored diff body still tints (PR #33). Without it Swift treats `"\r\n"` as one Character and `split(separator: "\n")` never matches, so every CRLF-terminated line merges into one blob and the file parses as zero adds/dels.
- `TreeNode.build` — the O(1) `byPath` lookup that took a flat directory from O(N²) → O(N) on `reload()` (PR #30). `reload()` runs on the main actor, so a large diff would hitch.

Both are pure functions with no UI/AppKit surface, so they're unit-tested directly. Spotted as the top test-coverage gap in a weekly code review.

## How

New `GlintTests/ReviewDiffParsingTests.swift` (8 tests), no production changes:

- `DiffDocument.parse`: hunk header seeds old/new line numbers + kinds; **CRLF body parses identically to LF** (the #33 regression guard); lone-CR normalization; meta lines + `\ No newline at end of file` dropped; empty input.
- `TreeNode.build`: nesting + folders-first case-insensitive sort + leaves carry the `GitFileChange`; shared-parent dedup at flat-dir scale (the #30 case); duplicate-path collapses to one node.

## Testing / verification

`xcodegen generate` + `xcodebuild test -scheme Glint -destination 'platform=macOS,arch=arm64' -only-testing:GlintTests/ReviewDiffParsingTests` → 8/8 pass, **TEST SUCCEEDED** (verified on top of `upstream/main`, which includes the recent `fix(review): stabilize pre-release diff loading` changes to `ReviewWindow.swift` / `GitDiff.swift`).

Scope note: one of three follow-ups split out from a weekly review (sibling PRs: Codex hook i18n, command-palette key-monitor leak). Trivially rebases — pure new test file + project regeneration.

## 中文

### 问题
`ReviewWindow.swift` 的 review diff 流水线对纯逻辑**零单测**,而其中两个最近的改动正是值得守护的纯 string/JSON → tree 变换:
- `DiffDocument.parse` —— 为让 Windows 源文件(其 diff body 保留 CRLF)仍能正确着色而加的 CRLF 归一化(PR #33)。没有它 Swift 把 `"\r\n"` 当一个 Character,`split(separator: "\n")` 永不匹配,每行 CRLF 终止的正文并成一坨,文件解析出 0 增删。
- `TreeNode.build` —— 把扁平目录从 O(N²) 降到 O(N) 的 `byPath` O(1) 查找(PR #30)。`reload()` 在主线程跑,大 diff 会卡顿。

二者都是无 UI/AppKit 的纯函数,直接单测。周评审中标记为最高优先测试缺口。

### 做法
新增 `GlintTests/ReviewDiffParsingTests.swift`(8 个测试),不改产物代码:
- `DiffDocument.parse`:hunk 头播种 old/new 行号 + kind;**CRLF body 与 LF 等价解析**(#33 回归守卫);lone-CR 归一化;meta 行与 `\ No newline at end of file` 丢弃;空输入。
- `TreeNode.build`:嵌套 + 文件夹优先(大小写不敏感)排序 + 叶子带 `GitFileChange`;共享父目录在扁平规模下的去重(#30 的场景);重复 path 折叠为一个节点。

### 验证
`xcodegen generate` + `xcodebuild test ... -only-testing:GlintTests/ReviewDiffParsingTests` → 8/8 通过,**TEST SUCCEEDED**(在 `upstream/main` 之上验证,含最近的 `fix(review): stabilize pre-release diff loading` 对 `ReviewWindow.swift`/`GitDiff.swift` 的改动)。

范围说明:周评审拆出的三个跟进 PR 之一(另两个:Codex 钩子 i18n、命令面板键盘监视器泄漏)。纯新增测试文件 + 工程重生成,可轻松 rebase。
