### PR TITLE
[codex] stabilize Codex usage and hook routing

### DIFF
--- a/Glint/Agent/CodexHome.swift
+++ b/Glint/Agent/CodexHome.swift
@@ -45,6 +45,20 @@ enum CodexQuotaStatus: Hashable {
     case unavailable(String)
     case loading
 
+    static func refreshing(previous: CodexQuotaStatus?) -> CodexQuotaStatus {
+        switch previous {
+        case .available(let quota): return .available(quota)
+        case .unavailable, .loading, .none: return .loading
+        }
+    }
+
+    static func refreshFailed(previous: CodexQuotaStatus?, message: String) -> CodexQuotaStatus {
+        switch previous {
+        case .available(let quota): return .available(quota)
+        case .unavailable, .loading, .none: return .unavailable(message)
+        }
+    }
+
     static func placeholder(isHomeEnabled: Bool, isUsageEnabled: Bool) -> CodexQuotaStatus {
         if !isHomeEnabled { return .unavailable(String(localized: "Disabled")) }
         return isUsageEnabled ? .loading : .unavailable(String(localized: "Usage off"))

--- a/Glint/Agent/UsageStore.swift
+++ b/Glint/Agent/UsageStore.swift
@@ -197,21 +197,28 @@ final class UsageStore: ObservableObject {
             let generation = codexRefreshCoordinator.begin()
             Task { [weak self] in
                 let homes = Self.configuredCodexHomes().filter(\.isEnabled)
-                await MainActor.run {
+                let previousStatusesByID = await MainActor.run { () -> [UUID: CodexQuotaStatus]? in
                     guard let self,
-                          self.codexRefreshCoordinator.accepts(generation) else { return }
+                          self.codexRefreshCoordinator.accepts(generation) else { return nil }
+                    let previousStatusesByID = Dictionary(
+                        self.codexHomeStatuses.map { ($0.id, $0.quotaStatus) },
+                        uniquingKeysWith: { first, _ in first }
+                    )
                     self.codexHomeStatuses = homes.map {
                         CodexHomeStatus(
                             home: $0,
                             resolvedURL: $0.resolvedURL,
                             hookStatus: CodexHookInstaller.status(in: $0.resolvedURL),
                             authStatus: CodexLiveReader.authStatus(from: $0.resolvedURL),
-                            quotaStatus: .loading
+                            quotaStatus: .refreshing(previous: previousStatusesByID[$0.id])
                         )
                     }
+                    return previousStatusesByID
                 }
+                guard let previousStatusesByID else { return }
                 let statuses = await withTaskGroup(of: CodexHomeStatus.self) { group in
                     for home in homes {
+                        let previousQuotaStatus = previousStatusesByID[home.id]
                         group.addTask {
                             let quota = await CodexUsageReader.readPreferLive(from: home.resolvedURL)
                             return CodexHomeStatus(
@@ -220,7 +227,10 @@ final class UsageStore: ObservableObject {
                                 hookStatus: CodexHookInstaller.status(in: home.resolvedURL),
                                 authStatus: CodexLiveReader.authStatus(from: home.resolvedURL),
                                 quotaStatus: quota.map(CodexQuotaStatus.available)
-                                    ?? .unavailable(String(localized: "Quota unavailable"))
+                                    ?? .refreshFailed(
+                                        previous: previousQuotaStatus,
+                                        message: String(localized: "Quota unavailable")
+                                    )
                             )
                         }
                     }

--- a/Glint/Resources/Localizable.xcstrings
+++ b/Glint/Resources/Localizable.xcstrings
@@ -243,10 +243,46 @@
         }
       }
     },
-    "—": {},
-    "· %@": {},
-    "%@": {},
-    "%@%%": {},
+    "—": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "—"
+          }
+        }
+      }
+    },
+    "· %@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "· %@"
+          }
+        }
+      }
+    },
+    "%@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
+          }
+        }
+      }
+    },
+    "%@%%": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@%%"
+          }
+        }
+      }
+    },
     "%d of its panes still have something running; everything in this workspace will be terminated.": {
       "extractionState": "stale",
       "localizations": {
@@ -269,10 +305,46 @@
         }
       }
     },
-    "+%@": {},
-    "~/.glint/hooks/glint-report.sh": {},
-    "⌘N": {},
-    "⌘T": {},
+    "+%@": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "+%@"
+          }
+        }
+      }
+    },
+    "~/.glint/hooks/glint-report.sh": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "~/.glint/hooks/glint-report.sh"
+          }
+        }
+      }
+    },
+    "⌘N": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "⌘N"
+          }
+        }
+      }
+    },
+    "⌘T": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "⌘T"
+          }
+        }
+      }
+    },
     "── session restored ──": {
       "extractionState": "manual",
       "localizations": {
@@ -1534,7 +1606,16 @@
         }
       }
     },
-    "No results": {},
+    "No results": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无结果"
+          }
+        }
+      }
+    },
     "Not installed": {
       "extractionState": "stale",
       "localizations": {
@@ -2545,7 +2626,16 @@
         }
       }
     },
-    "TABS": {},
+    "TABS": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "标签页"
+          }
+        }
+      }
+    },
     "Terminal": {
       "extractionState": "stale",
       "localizations": {

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -463,6 +463,7 @@ final class WorkspaceStore: ObservableObject {
     /// values forever.
     private var recentPaneReturns: [WorkspacePaneKey: Date] = [:]
     private static let recentPaneReturnTTL: TimeInterval = 60
+    private static let recentPaneReturnRoutingWindow: TimeInterval = 10
     /// Maximum staleness for a `.needsPermission` status before a fresh
     /// Return is treated as a real new-prompt submit again. Codex sometimes
     /// fails to clear permission state (client died mid-tool, hook lost),
@@ -1637,36 +1638,14 @@ final class WorkspaceStore: ObservableObject {
             )
             return kind == .codex ? key : nil
         }
-        // Panes already routing for another Codex session must not be reused
-        // for a new one — a subsequent Return in a cwd-bound pane would
-        // otherwise silently steal an unrelated session that submits within
-        // the 10-second window.
-        let alreadyBound = Set(codexSessionPanes.values.map { $0.pane })
-        let unboundPanes = codexPanes.filter { !alreadyBound.contains($0) }
-        let recentlySubmitted = unboundPanes.compactMap { key -> (WorkspacePaneKey, Date)? in
-            guard let date = recentPaneReturns[key],
-                  now.timeIntervalSince(date) >= 0,
-                  now.timeIntervalSince(date) <= 10 else { return nil }
-            return (key, date)
-        }
-        let key: WorkspacePaneKey?
-        if let latest = recentlySubmitted.max(by: { $0.1 < $1.1 }) {
-            key = latest.0
-        } else if let cwd = info["cwd"] as? String, !cwd.isEmpty {
-            let normalized = Self.canonicalizeCwd(cwd)
-            // Only compare against cwds the shell has actually reported via
-            // OSC 7. The pane's initial `workingDirectory` would misroute
-            // anyone who `cd`'d before launching codex (first prompt fires
-            // before OSC 7 has populated cachedCwd) — better to give up than
-            // bind the wrong pane.
-            let matches = unboundPanes.filter { candidate in
-                guard let known = surfaceViews[candidate]?.cachedCwd else { return false }
-                return Self.canonicalizeCwd(known) == normalized
-            }
-            key = matches.count == 1 ? matches[0] : nil
-        } else {
-            key = nil
-        }
+        let key = Self.selectCodexRoutingPane(
+            codexPanes: codexPanes,
+            boundPanes: Set(codexSessionPanes.values.map { $0.pane }),
+            recentPaneReturns: recentPaneReturns,
+            cwd: info["cwd"] as? String,
+            now: now,
+            cwdForPane: { surfaceViews[$0]?.cachedCwd }
+        )
         guard let key else {
             NSLog("[glint] agent: could not route Codex session \(session)")
             return nil
@@ -1679,9 +1658,61 @@ final class WorkspaceStore: ObservableObject {
             NSLog("[glint] agent: Codex session \(session) claimed by another Glint — skipping")
             return nil
         }
+        releaseCodexSessionRoutes(for: key, keeping: session)
         codexSessionPanes[session] = CodexSessionRoute(pane: key, lastSeen: now)
         recentPaneReturns.removeValue(forKey: key)
         return key
+    }
+
+    /// Pick the pane for a new shared Codex session. A recent Return is a
+    /// direct user action in that pane, so it may replace an older route on the
+    /// same Codex process (`/new`). Cwd-only fallback remains limited to
+    /// unbound panes, where it cannot steal an existing session.
+    static func selectCodexRoutingPane(
+        codexPanes: [WorkspacePaneKey],
+        boundPanes: Set<WorkspacePaneKey>,
+        recentPaneReturns: [WorkspacePaneKey: Date],
+        cwd: String?,
+        now: Date,
+        cwdForPane: (WorkspacePaneKey) -> String?
+    ) -> WorkspacePaneKey? {
+        let recentlySubmitted = codexPanes.compactMap { key -> (WorkspacePaneKey, Date)? in
+            guard let date = recentPaneReturns[key],
+                  now.timeIntervalSince(date) >= 0,
+                  now.timeIntervalSince(date) <= recentPaneReturnRoutingWindow else {
+                return nil
+            }
+            return (key, date)
+        }
+        if let latest = recentlySubmitted.max(by: { $0.1 < $1.1 }) {
+            return latest.0
+        }
+
+        // Panes already routing for another Codex session must not be reused
+        // by cwd alone — a cwd-bound pane could otherwise silently steal an
+        // unrelated session. Only the stronger Return signal above may rebind.
+        let unboundPanes = codexPanes.filter { !boundPanes.contains($0) }
+        guard let cwd, !cwd.isEmpty else { return nil }
+        let normalized = canonicalizeCwd(cwd)
+        // Only compare against cwds the shell has actually reported via OSC 7.
+        // The pane's initial `workingDirectory` would misroute anyone who
+        // `cd`'d before launching codex (first prompt fires before OSC 7 has
+        // populated cachedCwd) — better to give up than bind the wrong pane.
+        let matches = unboundPanes.filter { candidate in
+            guard let known = cwdForPane(candidate) else { return false }
+            return canonicalizeCwd(known) == normalized
+        }
+        return matches.count == 1 ? matches[0] : nil
+    }
+
+    private func releaseCodexSessionRoutes(for key: WorkspacePaneKey, keeping session: String) {
+        let replaced = codexSessionPanes.compactMap { existingSession, route -> String? in
+            existingSession != session && route.pane == key ? existingSession : nil
+        }
+        for existingSession in replaced {
+            codexSessionPanes.removeValue(forKey: existingSession)
+            Self.releaseCodexSessionClaim(existingSession)
+        }
     }
 
     private func pruneCodexSessionRoutes(now: Date) {

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -449,7 +449,7 @@ final class WorkspaceStore: ObservableObject {
     /// Codex 0.141+ runs hooks in a shared app-server, so hook processes no
     /// longer inherit GLINT_PANE_ID. Bind its stable session id after the first
     /// submitted prompt and use that route for the rest of the session.
-    private struct CodexSessionRoute {
+    struct CodexSessionRoute {
         var pane: WorkspacePaneKey
         var lastSeen: Date
     }
@@ -1221,16 +1221,24 @@ final class WorkspaceStore: ObservableObject {
         observerTokens.append(NotificationCenter.default.addObserver(
             forName: .glintPaneEscPressed,
             object: nil,
-            queue: .main
+            queue: nil
         ) { [weak self] note in
-            Task { @MainActor in self?.handlePaneEsc(note.userInfo) }
+            if Thread.isMainThread {
+                MainActor.assumeIsolated { self?.handlePaneEsc(note.userInfo) }
+            } else {
+                Task { @MainActor in self?.handlePaneEsc(note.userInfo) }
+            }
         })
         observerTokens.append(NotificationCenter.default.addObserver(
             forName: .glintPaneReturnPressed,
             object: nil,
-            queue: .main
+            queue: nil
         ) { [weak self] note in
-            Task { @MainActor in self?.handlePaneReturn(note.userInfo) }
+            if Thread.isMainThread {
+                MainActor.assumeIsolated { self?.handlePaneReturn(note.userInfo) }
+            } else {
+                Task { @MainActor in self?.handlePaneReturn(note.userInfo) }
+            }
         })
     }
 
@@ -1599,7 +1607,19 @@ final class WorkspaceStore: ObservableObject {
 
         pruneCodexSessionRoutes(now: now)
         pruneRecentPaneReturns(now: now)
+        let codexPanes = liveCodexRoutingPanes()
         if var route = codexSessionPanes[session] {
+            if hook == "UserPromptSubmit",
+               let key = Self.selectRecentCodexRoutingPane(
+                    codexPanes: codexPanes,
+                    recentPaneReturns: recentPaneReturns,
+                    now: now,
+                    preferredPane: route.pane
+               ) {
+                replaceCodexSessionRoute(session, pane: key, now: now)
+                recentPaneReturns.removeValue(forKey: key)
+                return key
+            }
             route.lastSeen = now
             codexSessionPanes[session] = route
             let key = route.pane
@@ -1626,18 +1646,6 @@ final class WorkspaceStore: ObservableObject {
         }
         guard hook == "UserPromptSubmit" else { return nil }
 
-        let codexPanes = surfaceViews.compactMap { key, view -> WorkspacePaneKey? in
-            guard view.hasLiveSurface else { return nil }
-            // A known foreground process is authoritative even when it is not
-            // an agent. Falling through from "zsh" to stale hook state would
-            // incorrectly keep an exited Codex pane in the routing candidates.
-            let kind = Self.codexRoutingCandidateKind(
-                foregroundProcessName: view.foregroundProcessName(),
-                polledProcessName: paneProcesses[key],
-                stateKind: paneAgentState[key]?.kind
-            )
-            return kind == .codex ? key : nil
-        }
         let key = Self.selectCodexRoutingPane(
             codexPanes: codexPanes,
             boundPanes: Set(codexSessionPanes.values.map { $0.pane }),
@@ -1658,10 +1666,24 @@ final class WorkspaceStore: ObservableObject {
             NSLog("[glint] agent: Codex session \(session) claimed by another Glint — skipping")
             return nil
         }
-        releaseCodexSessionRoutes(for: key, keeping: session)
-        codexSessionPanes[session] = CodexSessionRoute(pane: key, lastSeen: now)
+        replaceCodexSessionRoute(session, pane: key, now: now)
         recentPaneReturns.removeValue(forKey: key)
         return key
+    }
+
+    private func liveCodexRoutingPanes() -> [WorkspacePaneKey] {
+        surfaceViews.compactMap { key, view -> WorkspacePaneKey? in
+            guard view.hasLiveSurface else { return nil }
+            // A known foreground process is authoritative even when it is not
+            // an agent. Falling through from "zsh" to stale hook state would
+            // incorrectly keep an exited Codex pane in the routing candidates.
+            let kind = Self.codexRoutingCandidateKind(
+                foregroundProcessName: view.foregroundProcessName(),
+                polledProcessName: paneProcesses[key],
+                stateKind: paneAgentState[key]?.kind
+            )
+            return kind == .codex ? key : nil
+        }
     }
 
     /// Pick the pane for a new shared Codex session. A recent Return is a
@@ -1676,16 +1698,12 @@ final class WorkspaceStore: ObservableObject {
         now: Date,
         cwdForPane: (WorkspacePaneKey) -> String?
     ) -> WorkspacePaneKey? {
-        let recentlySubmitted = codexPanes.compactMap { key -> (WorkspacePaneKey, Date)? in
-            guard let date = recentPaneReturns[key],
-                  now.timeIntervalSince(date) >= 0,
-                  now.timeIntervalSince(date) <= recentPaneReturnRoutingWindow else {
-                return nil
-            }
-            return (key, date)
-        }
-        if let latest = recentlySubmitted.max(by: { $0.1 < $1.1 }) {
-            return latest.0
+        if let key = selectRecentCodexRoutingPane(
+            codexPanes: codexPanes,
+            recentPaneReturns: recentPaneReturns,
+            now: now
+        ) {
+            return key
         }
 
         // Panes already routing for another Codex session must not be reused
@@ -1705,14 +1723,52 @@ final class WorkspaceStore: ObservableObject {
         return matches.count == 1 ? matches[0] : nil
     }
 
-    private func releaseCodexSessionRoutes(for key: WorkspacePaneKey, keeping session: String) {
-        let replaced = codexSessionPanes.compactMap { existingSession, route -> String? in
+    static func selectRecentCodexRoutingPane(
+        codexPanes: [WorkspacePaneKey],
+        recentPaneReturns: [WorkspacePaneKey: Date],
+        now: Date,
+        preferredPane: WorkspacePaneKey? = nil
+    ) -> WorkspacePaneKey? {
+        let recentlySubmitted = codexPanes.compactMap { key -> (WorkspacePaneKey, Date)? in
+            guard let date = recentPaneReturns[key],
+                  now.timeIntervalSince(date) >= 0,
+                  now.timeIntervalSince(date) <= recentPaneReturnRoutingWindow else {
+                return nil
+            }
+            return (key, date)
+        }
+        if let preferredPane,
+           recentlySubmitted.contains(where: { $0.0 == preferredPane }) {
+            return preferredPane
+        }
+        return recentlySubmitted.max(by: { $0.1 < $1.1 })?.0
+    }
+
+    private func replaceCodexSessionRoute(_ session: String, pane key: WorkspacePaneKey, now: Date) {
+        Self.replaceCodexSessionRoute(
+            routes: &codexSessionPanes,
+            session: session,
+            pane: key,
+            now: now,
+            releaseClaim: Self.releaseCodexSessionClaim
+        )
+    }
+
+    static func replaceCodexSessionRoute(
+        routes: inout [String: CodexSessionRoute],
+        session: String,
+        pane key: WorkspacePaneKey,
+        now: Date,
+        releaseClaim: (String) -> Void
+    ) {
+        let replaced = routes.compactMap { existingSession, route -> String? in
             existingSession != session && route.pane == key ? existingSession : nil
         }
         for existingSession in replaced {
-            codexSessionPanes.removeValue(forKey: existingSession)
-            Self.releaseCodexSessionClaim(existingSession)
+            routes.removeValue(forKey: existingSession)
+            releaseClaim(existingSession)
         }
+        routes[session] = CodexSessionRoute(pane: key, lastSeen: now)
     }
 
     private func pruneCodexSessionRoutes(now: Date) {

--- a/GlintTests/AgentHookRoutingTests.swift
+++ b/GlintTests/AgentHookRoutingTests.swift
@@ -56,6 +56,64 @@ final class AgentHookRoutingTests: XCTestCase {
         ), .codex)
     }
 
+    @MainActor
+    func testRecentReturnCanRebindBoundCodexPaneForNewSession() {
+        let key = WorkspaceStore.WorkspacePaneKey(
+            workspace: UUID(),
+            pane: PaneID(value: 0)
+        )
+        let now = Date()
+
+        let routed = WorkspaceStore.selectCodexRoutingPane(
+            codexPanes: [key],
+            boundPanes: [key],
+            recentPaneReturns: [key: now.addingTimeInterval(-1)],
+            cwd: "/tmp",
+            now: now,
+            cwdForPane: { _ in "/tmp" }
+        )
+
+        XCTAssertEqual(routed, key)
+    }
+
+    @MainActor
+    func testCwdFallbackDoesNotStealAlreadyBoundCodexPane() {
+        let key = WorkspaceStore.WorkspacePaneKey(
+            workspace: UUID(),
+            pane: PaneID(value: 0)
+        )
+
+        let routed = WorkspaceStore.selectCodexRoutingPane(
+            codexPanes: [key],
+            boundPanes: [key],
+            recentPaneReturns: [:],
+            cwd: "/tmp",
+            now: Date(),
+            cwdForPane: { _ in "/tmp" }
+        )
+
+        XCTAssertNil(routed)
+    }
+
+    @MainActor
+    func testCwdFallbackStillRoutesUniqueUnboundCodexPane() {
+        let key = WorkspaceStore.WorkspacePaneKey(
+            workspace: UUID(),
+            pane: PaneID(value: 0)
+        )
+
+        let routed = WorkspaceStore.selectCodexRoutingPane(
+            codexPanes: [key],
+            boundPanes: [],
+            recentPaneReturns: [:],
+            cwd: "/tmp",
+            now: Date(),
+            cwdForPane: { _ in "/tmp" }
+        )
+
+        XCTAssertEqual(routed, key)
+    }
+
     func testReporterKeepsCodexCommandStableAndDrainsPayload() throws {
         let body = AgentHookInstaller.scriptBody
         XCTAssertTrue(body.contains("plutil -extract session_id"))

--- a/GlintTests/AgentHookRoutingTests.swift
+++ b/GlintTests/AgentHookRoutingTests.swift
@@ -77,6 +77,93 @@ final class AgentHookRoutingTests: XCTestCase {
     }
 
     @MainActor
+    func testLatestRecentReturnWinsAmongCodexPanes() {
+        let older = WorkspaceStore.WorkspacePaneKey(
+            workspace: UUID(),
+            pane: PaneID(value: 0)
+        )
+        let latest = WorkspaceStore.WorkspacePaneKey(
+            workspace: UUID(),
+            pane: PaneID(value: 1)
+        )
+        let now = Date()
+
+        let routed = WorkspaceStore.selectRecentCodexRoutingPane(
+            codexPanes: [older, latest],
+            recentPaneReturns: [
+                older: now.addingTimeInterval(-2),
+                latest: now.addingTimeInterval(-1),
+            ],
+            now: now
+        )
+
+        XCTAssertEqual(routed, latest)
+    }
+
+    @MainActor
+    func testPreferredRecentReturnWinsForExistingCodexRoute() {
+        let routePane = WorkspaceStore.WorkspacePaneKey(
+            workspace: UUID(),
+            pane: PaneID(value: 0)
+        )
+        let otherPane = WorkspaceStore.WorkspacePaneKey(
+            workspace: UUID(),
+            pane: PaneID(value: 1)
+        )
+        let now = Date()
+
+        let routed = WorkspaceStore.selectRecentCodexRoutingPane(
+            codexPanes: [routePane, otherPane],
+            recentPaneReturns: [
+                routePane: now.addingTimeInterval(-2),
+                otherPane: now.addingTimeInterval(-1),
+            ],
+            now: now,
+            preferredPane: routePane
+        )
+
+        XCTAssertEqual(routed, routePane)
+    }
+
+    @MainActor
+    func testRebindingCodexRouteReleasesDisplacedSessionForTargetPane() {
+        let pane1 = WorkspaceStore.WorkspacePaneKey(
+            workspace: UUID(),
+            pane: PaneID(value: 0)
+        )
+        let pane2 = WorkspaceStore.WorkspacePaneKey(
+            workspace: UUID(),
+            pane: PaneID(value: 1)
+        )
+        let now = Date()
+        var routes = [
+            "sessionA": WorkspaceStore.CodexSessionRoute(
+                pane: pane1,
+                lastSeen: now.addingTimeInterval(-10)
+            ),
+            "sessionB": WorkspaceStore.CodexSessionRoute(
+                pane: pane2,
+                lastSeen: now.addingTimeInterval(-5)
+            ),
+        ]
+        var releasedSessions: [String] = []
+
+        WorkspaceStore.replaceCodexSessionRoute(
+            routes: &routes,
+            session: "sessionB",
+            pane: pane1,
+            now: now,
+            releaseClaim: { releasedSessions.append($0) }
+        )
+
+        XCTAssertNil(routes["sessionA"])
+        XCTAssertEqual(routes["sessionB"]?.pane, pane1)
+        XCTAssertEqual(routes["sessionB"]?.lastSeen, now)
+        XCTAssertEqual(Set(routes.keys), Set(["sessionB"]))
+        XCTAssertEqual(releasedSessions, ["sessionA"])
+    }
+
+    @MainActor
     func testCwdFallbackDoesNotStealAlreadyBoundCodexPane() {
         let key = WorkspaceStore.WorkspacePaneKey(
             workspace: UUID(),

--- a/GlintTests/CodexUsageReaderTests.swift
+++ b/GlintTests/CodexUsageReaderTests.swift
@@ -33,7 +33,10 @@ final class CodexUsageReaderTests: XCTestCase {
 
         let authURL = home.appendingPathComponent("auth.json")
         try "invalid".write(to: authURL, atomically: true, encoding: .utf8)
-        XCTAssertEqual(CodexLiveReader.authStatus(from: home), .invalid("Invalid auth.json"))
+        XCTAssertEqual(
+            CodexLiveReader.authStatus(from: home),
+            .invalid(String(localized: "Invalid auth.json"))
+        )
 
         try #"{"tokens":{"access_token":"token","account_id":"account"}}"#
             .write(to: authURL, atomically: true, encoding: .utf8)
@@ -72,6 +75,98 @@ final class CodexUsageReaderTests: XCTestCase {
         XCTAssertEqual(items.count, 1)
         XCTAssertEqual(items[0].name, "Subscription")
         XCTAssertEqual(items[0].quota, quota)
+    }
+
+    func testSidebarKeepsAvailableHomeRowsVisibleWhileRefreshing() {
+        let primary = CodexHome(label: "Primary", path: "~/primary/.codex")
+        let secondary = CodexHome(label: "Secondary", path: "~/secondary/.codex")
+        let primaryQuota = AgentQuota(
+            sessionPercent: 21,
+            weeklyPercent: 35,
+            sessionResetsAt: nil,
+            weeklyResetsAt: nil,
+            planType: "plus"
+        )
+        let secondaryQuota = AgentQuota(
+            sessionPercent: 42,
+            weeklyPercent: 63,
+            sessionResetsAt: nil,
+            weeklyResetsAt: nil,
+            planType: "pro"
+        )
+        let refreshingStatuses = [
+            CodexHomeStatus(
+                home: primary,
+                resolvedURL: primary.resolvedURL,
+                hookStatus: .installed,
+                authStatus: .found,
+                quotaStatus: .refreshing(previous: .available(primaryQuota))
+            ),
+            CodexHomeStatus(
+                home: secondary,
+                resolvedURL: secondary.resolvedURL,
+                hookStatus: .installed,
+                authStatus: .found,
+                quotaStatus: .refreshing(previous: .available(secondaryQuota))
+            ),
+        ]
+
+        let items = CodexQuotaPresentation.sidebarItems(
+            from: refreshingStatuses,
+            fallback: primaryQuota
+        )
+
+        XCTAssertEqual(items.map(\.name), ["Primary", "Secondary"])
+        XCTAssertEqual(items.map(\.quota), [primaryQuota, secondaryQuota])
+    }
+
+    func testSidebarKeepsAvailableHomeRowsVisibleWhenRefreshFails() {
+        let primary = CodexHome(label: "Primary", path: "~/primary/.codex")
+        let secondary = CodexHome(label: "Secondary", path: "~/secondary/.codex")
+        let primaryQuota = AgentQuota(
+            sessionPercent: 21,
+            weeklyPercent: 35,
+            sessionResetsAt: nil,
+            weeklyResetsAt: nil,
+            planType: "plus"
+        )
+        let secondaryQuota = AgentQuota(
+            sessionPercent: 42,
+            weeklyPercent: 63,
+            sessionResetsAt: nil,
+            weeklyResetsAt: nil,
+            planType: "pro"
+        )
+        let failedStatuses = [
+            CodexHomeStatus(
+                home: primary,
+                resolvedURL: primary.resolvedURL,
+                hookStatus: .installed,
+                authStatus: .found,
+                quotaStatus: .refreshFailed(
+                    previous: .available(primaryQuota),
+                    message: "Quota unavailable"
+                )
+            ),
+            CodexHomeStatus(
+                home: secondary,
+                resolvedURL: secondary.resolvedURL,
+                hookStatus: .installed,
+                authStatus: .found,
+                quotaStatus: .refreshFailed(
+                    previous: .available(secondaryQuota),
+                    message: "Quota unavailable"
+                )
+            ),
+        ]
+
+        let items = CodexQuotaPresentation.sidebarItems(
+            from: failedStatuses,
+            fallback: primaryQuota
+        )
+
+        XCTAssertEqual(items.map(\.name), ["Primary", "Secondary"])
+        XCTAssertEqual(items.map(\.quota), [primaryQuota, secondaryQuota])
     }
 
     func testSidebarHidesFallbackWhenEveryHomeIsDisabled() {


### PR DESCRIPTION
## Summary
- rebind reused Codex sessions to the pane that submitted the prompt, covering `/new` and restarting Codex after exit
- keep Codex hook status routed to the current pane when multiple Codex tabs are open
- keep multi-home Codex usage rows visible during refreshes and transient quota read failures
- fill missing zh-Hans localized strings for the affected UI text

## Root Cause
Codex shared app-server hooks do not always carry `GLINT_PANE_ID`, so Glint has to infer the pane from session/cwd metadata and recent Return events. The previous routing could keep stale session bindings or process the Return marker after the hook, which made status updates appear on another tab. The usage sidebar also replaced available per-home quota rows with loading/unavailable states during refresh, causing rows to blink or collapse to a fallback Codex row.

## Validation
- `git diff --check`
- `xcodebuild test -project Glint.xcodeproj -scheme Glint -destination 'platform=macOS' -only-testing:GlintTests/AgentHookRoutingTests`
- `xcodebuild test -project Glint.xcodeproj -scheme Glint -destination 'platform=macOS' -only-testing:GlintTests/CodexUsageReaderTests`