### PR TITLE
feat: add ⌘⇧F Reveal in Finder shortcut / 新增 ⌘⇧F「在访达中显示」快捷键

### DIFF
--- a/Glint/App/GlintApp.swift
+++ b/Glint/App/GlintApp.swift
@@ -131,6 +131,12 @@ struct GlintApp: App {
                 .disabled(workspaceStore.selectedWorkspace.flatMap {
                     workspaceStore.effectiveGitPath(for: $0)
                 } == nil)
+                // Reveal the focused pane's cwd in Finder from anywhere — even
+                // outside a git repo (unlike Review Changes). Never disabled.
+                Button("Reveal in Finder") {
+                    workspaceStore.revealCurrentInFinder()
+                }
+                .keyboardShortcut("f", modifiers: [.command, .shift])
             }
             // Hijack the App menu's Settings… so ⌘, opens our in-window
             // sheet instead of trying to summon a separate scene.

--- a/Glint/Chrome/SettingsView.swift
+++ b/Glint/Chrome/SettingsView.swift
@@ -274,12 +274,12 @@ struct SettingsCard<Content: View>: View {
 }
 
 struct SettingsRow<Trailing: View>: View {
-    let title: String
+    let title: LocalizedStringKey
     let subtitle: String?
     let wip: Bool
     @ViewBuilder var trailing: () -> Trailing
 
-    init(_ title: String, subtitle: String? = nil, wip: Bool = false,
+    init(_ title: LocalizedStringKey, subtitle: String? = nil, wip: Bool = false,
          @ViewBuilder trailing: @escaping () -> Trailing) {
         self.title = title
         self.subtitle = subtitle
@@ -291,7 +291,7 @@ struct SettingsRow<Trailing: View>: View {
         HStack(spacing: 16) {
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 6) {
-                    Text(LocalizedStringKey(title))
+                    Text(title)
                         .font(.system(size: 13, weight: .medium))
                         .foregroundStyle(Theme.text1)
                     if wip {
@@ -1861,6 +1861,8 @@ private struct ShortcutsPane: View {
             SettingsDivider()
             shortcutRow("Find in Sidebar", keys: ["⌥", "⌘", "F"])
             SettingsDivider()
+            shortcutRow("Reveal in Finder", keys: ["⌘", "⇧", "F"])
+            SettingsDivider()
             shortcutRow("Settings", keys: ["⌘", ","])
             SettingsDivider()
             shortcutRow("Minimize", keys: ["⌘", "M"])
@@ -1881,7 +1883,7 @@ private struct ShortcutsPane: View {
         }
     }
 
-    private func shortcutRow(_ name: String, keys: [String]) -> some View {
+    private func shortcutRow(_ name: LocalizedStringKey, keys: [String]) -> some View {
         SettingsRow(name, subtitle: nil) {
             HStack(spacing: 4) {
                 ForEach(Array(keys.enumerated()), id: \.offset) { _, k in

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -2638,6 +2638,29 @@ final class WorkspaceStore: ObservableObject {
             [URL(fileURLWithPath: (path as NSString).expandingTildeInPath)])
     }
 
+    /// Reveal the focused pane's current directory in Finder — the global ⌘⇧F
+    /// shortcut. Cwd-first so it works anywhere (even outside a git repo),
+    /// falling back to the same worktree/repo-root/effective-git chain as
+    /// `revealWorktreeInFinder` when no cwd has been reported yet. Nothing
+    /// resolves ⇒ beep, mirroring `openReview`'s no-op.
+    func revealCurrentInFinder() {
+        guard let ws = selectedWorkspace else {
+            NSSound.beep()
+            return
+        }
+        let cwd = (ws.selectedTab?.focusedPane).flatMap { ws.panes[$0]?.workingDirectory }
+        guard let path = cwd
+            ?? ws.source.worktreePath
+            ?? ws.source.repoRoot
+            ?? effectiveGitPath(for: ws)
+        else {
+            NSSound.beep()
+            return
+        }
+        NSWorkspace.shared.activateFileViewerSelecting(
+            [URL(fileURLWithPath: (path as NSString).expandingTildeInPath)])
+    }
+
     /// Open the read-only Review window for a workspace. Always offers the
     /// working-tree scope; for a worktree with a known base branch it also offers
     /// the whole-branch (`base...HEAD`) scope, so the segmented control appears.


### PR DESCRIPTION
## Summary

Adds a global **⌘⇧F → Reveal in Finder** shortcut. The existing Review Changes (⌘⇧R) shortcut is left **unchanged**.

### ⌘⇧F — Reveal in Finder
- Reveals the **focused terminal pane's current directory** in Finder — works anywhere, including workspaces that are **not** git repositories.
- Resolution: pane cwd → `worktreePath` → `repoRoot` → `effectiveGitPath`. A fresh pane (no cwd yet) falls back to the repo path; if nothing resolves, it beeps (mirrors `openReview`).
- Inside a worktree it reveals the **cwd, not the repo root**.
- A menu-command shortcut, so it's dispatched by the menu system and **not** passed through to the terminal (same as ⌘⇧P).
- Listed in **Settings ▸ Shortcuts** (Window card).

## Files
- `WorkspaceStore.revealCurrentInFinder()` — cwd-first reveal.
- `GlintApp` — `Reveal in Finder` menu button (`⌘⇧F`).
- `SettingsView` — `Reveal in Finder` row in the Window card; `shortcutRow` / `SettingsRow` title widened to `LocalizedStringKey` so the row localizes.

---

## 概述

新增全局快捷键 **⌘⇧F → 在访达中显示**。已有的「审阅改动」(⌘⇧R)快捷键**保持不变**。

### ⌘⇧F — 在访达中显示
- 在访达中定位到**当前终端面板的工作目录**,任何地方都能用,包括**非 git** 工作区。
- 解析顺序:面板 cwd → `worktreePath` → `repoRoot` → `effectiveGitPath`。新开面板(还没上报 cwd)会回退到仓库路径;都拿不到时蜂鸣提示(与 `openReview` 一致)。
- 在 worktree 内 reveal 的是 **cwd 而非仓库根**。
- 作为菜单快捷键由菜单系统派发,**不会**透传给终端(与 ⌘⇧P 一致)。
- 已收录在 **设置 ▸ 快捷键**(Window 卡)。

## 文件
- `WorkspaceStore.revealCurrentInFinder()` —— cwd 优先的 reveal。
- `GlintApp` —— `Reveal in Finder` 菜单按钮(`⌘⇧F`)。
- `SettingsView` —— Window 卡里的 `Reveal in Finder` 行;`shortcutRow` / `SettingsRow` 标题改为 `LocalizedStringKey` 以便本地化。