### PR TITLE
feat(reveal): open folder in Finder instead of reveal-in-parent / 在访达中打开目录而非在父目录中选中

### DIFF
--- a/Glint/App/GlintApp.swift
+++ b/Glint/App/GlintApp.swift
@@ -131,10 +131,11 @@ struct GlintApp: App {
                 .disabled(workspaceStore.selectedWorkspace.flatMap {
                     workspaceStore.effectiveGitPath(for: $0)
                 } == nil)
-                // Reveal the focused pane's cwd in Finder from anywhere — even
-                // outside a git repo (unlike Review Changes). Never disabled.
+                // Open the focused pane's location in Finder from anywhere —
+                // inside a repo it opens the repo root, outside it the cwd.
+                // Never disabled (unlike Review Changes).
                 Button("Reveal in Finder") {
-                    workspaceStore.revealCurrentInFinder()
+                    Task { await workspaceStore.revealCurrentInFinder() }
                 }
                 .keyboardShortcut("f", modifiers: [.command, .shift])
             }

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -2496,35 +2496,41 @@ final class WorkspaceStore: ObservableObject {
         if let branchError { throw branchError }
     }
 
+    /// Open the workspace's repo/worktree root in Finder — dive INTO the
+    /// folder, not reveal-and-select it in its parent. Shared by every "open
+    /// in Finder" entry point: the ⌘⇧F shortcut's repo branch, the git popover
+    /// button, the sidebar context item, and the command palette — one action.
     func revealWorktreeInFinder(_ id: UUID) {
         guard let ws = workspaces.first(where: { $0.id == id }),
               let path = ws.source.worktreePath ?? ws.source.repoRoot ?? effectiveGitPath(for: ws)
         else { return }
-        NSWorkspace.shared.activateFileViewerSelecting(
-            [URL(fileURLWithPath: (path as NSString).expandingTildeInPath)])
+        NSWorkspace.shared.open(URL(fileURLWithPath: (path as NSString).expandingTildeInPath))
     }
 
-    /// Reveal the focused pane's current directory in Finder — the global ⌘⇧F
-    /// shortcut. Cwd-first so it works anywhere (even outside a git repo),
-    /// falling back to the same worktree/repo-root/effective-git chain as
-    /// `revealWorktreeInFinder` when no cwd has been reported yet. Nothing
-    /// resolves ⇒ beep, mirroring `openReview`'s no-op.
-    func revealCurrentInFinder() {
+    /// Open the focused pane's location in Finder — the global ⌘⇧F shortcut.
+    /// A bound repo/worktree workspace reuses `revealWorktreeInFinder` (open
+    /// the bound root). A plain workspace resolves the focused pane's cwd to
+    /// its git toplevel if it's inside a repo, else the cwd — so cd'ing into
+    /// a repo subfolder still opens the repo root. Always dives INTO the
+    /// folder, not reveal-and-select in the parent. Nothing resolves ⇒ beep.
+    func revealCurrentInFinder() async {
         guard let ws = selectedWorkspace else {
             NSSound.beep()
             return
         }
-        let cwd = (ws.selectedTab?.focusedPane).flatMap { ws.panes[$0]?.workingDirectory }
-        guard let path = cwd
-            ?? ws.source.worktreePath
-            ?? ws.source.repoRoot
-            ?? effectiveGitPath(for: ws)
-        else {
+        // Bound repo/worktree → same action as the git popover button.
+        if ws.source.gitPath != nil {
+            revealWorktreeInFinder(ws.id)
+            return
+        }
+        // Plain workspace → repo root of the focused pane's cwd if it's inside
+        // a repo, else the cwd itself.
+        guard let cwd = (ws.selectedTab?.focusedPane).flatMap({ ws.panes[$0]?.workingDirectory }) else {
             NSSound.beep()
             return
         }
-        NSWorkspace.shared.activateFileViewerSelecting(
-            [URL(fileURLWithPath: (path as NSString).expandingTildeInPath)])
+        let target = await git.repoRoot(at: cwd) ?? cwd
+        NSWorkspace.shared.open(URL(fileURLWithPath: (target as NSString).expandingTildeInPath))
     }
 
     /// Open the read-only Review window for a workspace. Always offers the


### PR DESCRIPTION
## What & why

The ⌘⇧F shortcut and every other "Reveal in Finder" entry point (git popover button, sidebar context item, command palette) used `activateFileViewerSelecting`, which opens the target's **parent** folder and selects the target inside it. For a "jump to this folder" action that's the wrong default — you land one level too high. This switches them all to `NSWorkspace.open` so Finder dives **into** the folder itself.

It also fixes which folder gets opened: a plain workspace `cd`'d into a repo used to open the pane's cwd (because `effectiveGitPath` returns the cwd for a plain workspace — it's the seed for `git status`, not the repo root), so a pane in a subfolder opened that subfolder. Now it opens the repo root.

## How

- `revealWorktreeInFinder` (shared by all entry points): `activateFileViewerSelecting` → `NSWorkspace.open`.
- `revealCurrentInFinder` (the ⌘⇧F action) becomes `async`:
  - bound repo/worktree workspace → reuse `revealWorktreeInFinder` (open the bound root);
  - plain workspace → `await git.repoRoot(at: cwd) ?? cwd` — repo toplevel when the cwd is inside a repo, else the cwd.
- The button action wraps the now-async call in `Task { await … }`.

No new strings; button labels and the Settings ▸ Shortcuts row are unchanged.

## Testing / verification

- `xcodebuild build -scheme Glint -arch arm64` — clean (only a pre-existing `onChange` deprecation warning).
- Drove the dev build:
  - plain workspace, pane `cd` into a repo **subfolder** → ⌘⇧F opens the **repo root** (previously opened the subfolder);
  - plain workspace, cwd outside any repo → opens the cwd;
  - bound workspaces → opens the bound root (same as the git popover button).

## Follow-up (not in this PR)

Function names (`revealWorktreeInFinder` / `revealCurrentInFinder`) and button labels still say "Reveal in Finder" while the behavior is now "open". Renaming to "Open in Finder" (incl. `Localizable.xcstrings`) is left for a separate change to keep this diff focused.

---

## 中文

**做了什么 / 为什么**:「在访达中显示」各入口(⌘⇧F、git 浮层按钮、侧边栏右键、命令面板)之前用 `activateFileViewerSelecting`——在目标的**父目录**里选中它。对「跳到这个文件夹」的动作来说默认错了(会落到上一层)。全部改为 `NSWorkspace.open`,直接**进入**文件夹本身。

同时修正了打开哪个目录:普通工作区 `cd` 进仓库时,旧逻辑打开的是面板 cwd(`effectiveGitPath` 对普通工作区返回 cwd——它是 `git status` 的起点,不是仓库根),所以面板在子目录时打开的是子目录。现在打开仓库根。

**怎么做**:
- `revealWorktreeInFinder`(所有入口共用):`activateFileViewerSelecting` → `NSWorkspace.open`。
- `revealCurrentInFinder`(⌘⇧F 动作)改为 `async`:绑定工作区 → 复用 `revealWorktreeInFinder`(打开绑定根);普通工作区 → `await git.repoRoot(at: cwd) ?? cwd`(在仓库内→toplevel,否则 cwd)。
- 按钮动作用 `Task { await … }` 包裹。
- 不新增文案;按钮文案与「设置 ▸ 快捷键」行不变。

**测试**:`xcodebuild build -scheme Glint -arch arm64` 通过(仅一个既有的 `onChange` 弃用警告);dev build 手按验证:普通工作区 cd 进仓库**子目录** → ⌘⇧F 打开**仓库根**(旧行为:打开子目录);非仓库 cwd → 打开 cwd;绑定工作区 → 打开绑定根(与 git 浮层按钮一致)。

**后续(不在本 PR)**:函数名与按钮文案仍是 "Reveal in Finder"/「在访达中显示」,行为已变为「打开」。改名为 "Open in Finder"/「在访达中打开」(含 `Localizable.xcstrings`)留作单独改动,保持本 PR 聚焦。
