### PR TITLE
fix(codex): persist Codex Home per pane so non-default homes survive restart / 持久化每窗格 Codex Home，修复非默认 Home 重启后 resume 失效

### DIFF
--- a/Glint/Agent/AgentChoice.swift
+++ b/Glint/Agent/AgentChoice.swift
@@ -64,6 +64,11 @@ struct AgentLaunchItem: Identifiable, Hashable {
     /// Resolved shell command typed into the new pane, nil = bare shell. For a
     /// non-default Codex Home this carries a `CODEX_HOME=…` prefix.
     let command: String?
+    /// Resolved CODEX_HOME path for a non-default Codex Home, else nil.
+    /// Persisted on the pane so a restart can re-prefix `codex resume …` with
+    /// the same home — otherwise a non-default-home pane resumes against
+    /// `~/.codex` and loses its session (#45 regression for multi-home).
+    let codexHome: String?
 
     var brandAsset: String? { choice.brandAsset }
 }
@@ -79,7 +84,8 @@ extension AgentLaunchItem {
 
     private static func single(_ choice: AgentChoice) -> AgentLaunchItem {
         AgentLaunchItem(id: choice.id, choice: choice,
-                        title: choice.displayName, subtitle: nil, tag: nil, command: choice.command)
+                        title: choice.displayName, subtitle: nil, tag: nil,
+                        command: choice.command, codexHome: nil)
     }
 
     private static func codexItems(_ homes: [CodexHome]) -> [AgentLaunchItem] {
@@ -106,7 +112,11 @@ extension AgentLaunchItem {
             title: AgentChoice.codex.displayName,
             subtitle: home.path,
             tag: isDefault ? nil : (home.label ?? home.resolvedURL.lastPathComponent),
-            command: codexCommand(for: home)
+            command: codexCommand(for: home),
+            // The default home launches bare (no CODEX_HOME), so there's
+            // nothing to persist; only a non-default home needs to survive a
+            // restart to re-prefix the resume command.
+            codexHome: isDefault ? nil : home.resolvedURL.path
         )
     }
 

--- a/Glint/Agent/PaneAgentState.swift
+++ b/Glint/Agent/PaneAgentState.swift
@@ -52,7 +52,14 @@ enum PaneAgentKind: String, Codable {
     /// downgraded to the fallback form rather than being interpolated into
     /// the TTY string. This keeps the function safe even if a future caller
     /// forgets the outer validation step (the value lands on a real shell).
-    func restoreCommand(sessionId: String?) -> String {
+    ///
+    /// `codexHome` carries the resolved `CODEX_HOME` path a non-default-home
+    /// Codex pane was launched under, so the restart re-prefixes the resume
+    /// command with it. Without this a pane started under e.g. `~/codex-test`
+    /// resumes against the default `~/.codex`, where its session doesn't
+    /// exist (#45 regression for the multi-home feature). nil/default ⇒ no
+    /// prefix. Ignored by every kind other than `.codex`.
+    func restoreCommand(sessionId: String?, codexHome: String? = nil) -> String {
         let validated: String? = sessionId.flatMap {
             PaneAgentKind.isValid(sessionId: $0) ? $0 : nil
         }
@@ -60,12 +67,22 @@ enum PaneAgentKind: String, Codable {
         case .claude:
             return validated.map { "claude --resume \($0)\n" } ?? "claude --continue\n"
         case .codex:
-            return validated.map { "codex resume \($0)\n" } ?? "codex resume --last\n"
+            let prefix = codexHome.map { "CODEX_HOME=\(Self.shellQuoted($0)) " } ?? ""
+            return validated.map { "\(prefix)codex resume \($0)\n" }
+                ?? "\(prefix)codex resume --last\n"
         case .opencode:
             return validated.map { "opencode --session \($0)\n" } ?? "opencode --continue\n"
         case .devin:
             return validated.map { "devin --resume \($0)\n" } ?? "devin --continue\n"
         }
+    }
+
+    /// Single-quote a path for shell assignment. Matches the launch-side
+    /// quoting in `AgentLaunchItem.codexCommand`, so the persisted home
+    /// round-trips byte-for-byte into the resume command.
+    private static func shellQuoted(_ path: String) -> String {
+        if !path.contains("'") { return "'\(path)'" }
+        return "'\(path.replacingOccurrences(of: "'", with: "'\\''"))'"
     }
 }
 

--- a/Glint/Chrome/NewWorkspaceSheet.swift
+++ b/Glint/Chrome/NewWorkspaceSheet.swift
@@ -302,14 +302,16 @@ private struct WorktreePane: View {
         let path = worktreePath
         let base = baseBranch
         let items = AgentLaunchItem.all(codexHomes: codexHomes.homes)
-        let cmd = (items.first { $0.id == agentID } ?? items.first)?.command
+        let picked = items.first { $0.id == agentID } ?? items.first
+        let cmd = picked?.command
+        let home = picked?.codexHome
         let carry = carryDirty
         Task {
             do {
                 try await store.createWorktreeWorkspace(
                     repoRoot: root, baseBranch: base, branch: b,
                     worktreePath: path, createBranch: true,
-                    carryUncommitted: carry, agentCommand: cmd)
+                    carryUncommitted: carry, agentCommand: cmd, codexHome: home)
                 await MainActor.run { creating = false; store.newWorkspaceSheetOpen = false }
             } catch {
                 await MainActor.run { creating = false; errorText = error.localizedDescription }

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -1441,11 +1441,18 @@ final class WorkspaceStore: ObservableObject {
                         }
                     }
                     // codexHome is only meaningful while Codex is the
-                    // foreground; drop it the moment it isn't, so a later
-                    // default-Codex launch on this pane can't inherit a stale
-                    // non-default home and resume the wrong session.
+                    // foreground. Clear it ONLY when the pane is back at a
+                    // benign shell — i.e. the user actually exited Codex — not
+                    // when a Codex tool subprocess (git/npm/vim/…) briefly takes
+                    // the foreground pid. Unlike sessionIds (re-stashed by every
+                    // UserPromptSubmit hook above), codexHome has no writer but
+                    // launch, so a premature clear permanently breaks the
+                    // non-default-home resume (#45 multi-home regression) until
+                    // the pane is relaunched. A stale home can't leak anyway:
+                    // the next launch always rewrites codexHome via
+                    // queueInitialInput.
                     if workspaces[i].panes[paneID]?.codexHome != nil,
-                       agentToken != PaneAgentKind.codex.rawValue {
+                       Self.isBenignShellProcessName(name) {
                         workspaces[i].panes[paneID]?.codexHome = nil
                     }
                 }

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -137,9 +137,15 @@ struct Pane: Identifiable, Codable {
     /// agent stops matching the entry's key, so a stale id can't leak
     /// across an exit/relaunch.
     var sessionIds: [String: String]
+    /// Resolved `CODEX_HOME` path a non-default-home Codex pane was launched
+    /// under, so restart can re-prefix `codex resume …` with it (#45 for the
+    /// multi-home feature). nil for default-home / non-codex panes. Cleared in
+    /// `captureCwdsFromLiveSurfaces` once the foreground stops being Codex, so
+    /// a later default-Codex launch on the same pane can't inherit a stale home.
+    var codexHome: String?
 
     private enum CodingKeys: String, CodingKey {
-        case id, title, workingDirectory, lastAgent, sessionIds
+        case id, title, workingDirectory, lastAgent, sessionIds, codexHome
     }
 
     /// Field shape from the first cut of #45 (one Optional per agent). Read
@@ -158,6 +164,7 @@ struct Pane: Identifiable, Codable {
         self.workingDirectory = workingDirectory
         self.lastAgent = lastAgent
         self.sessionIds = [:]
+        self.codexHome = nil
     }
 
     init(from decoder: Decoder) throws {
@@ -166,6 +173,7 @@ struct Pane: Identifiable, Codable {
         self.title = try c.decode(String.self, forKey: .title)
         self.workingDirectory = try c.decodeIfPresent(String.self, forKey: .workingDirectory)
         self.lastAgent = try c.decodeIfPresent(String.self, forKey: .lastAgent)
+        self.codexHome = try c.decodeIfPresent(String.self, forKey: .codexHome)
         if let map = try c.decodeIfPresent([String: String].self, forKey: .sessionIds) {
             self.sessionIds = map
         } else {
@@ -193,6 +201,7 @@ struct Pane: Identifiable, Codable {
         try c.encode(title, forKey: .title)
         try c.encodeIfPresent(workingDirectory, forKey: .workingDirectory)
         try c.encodeIfPresent(lastAgent, forKey: .lastAgent)
+        try c.encodeIfPresent(codexHome, forKey: .codexHome)
         // Skip the key entirely when there's nothing to remember — most
         // panes never see an agent, and an empty `{}` on every pane would
         // be persistent noise in the autosave file.
@@ -1340,7 +1349,7 @@ final class WorkspaceStore: ObservableObject {
                   restoreEnabled(for: kind) else { return nil }
             let sid = pane.sessionIds[kind.rawValue]
                 .flatMap { Self.isValidSessionId($0) ? $0 : nil }
-            return kind.restoreCommand(sessionId: sid)
+            return kind.restoreCommand(sessionId: sid, codexHome: pane.codexHome)
         }()
         let v = GhosttySurfaceView(
             frame: .zero,
@@ -1430,6 +1439,14 @@ final class WorkspaceStore: ObservableObject {
                         if kept.count != existing.count {
                             workspaces[i].panes[paneID]?.sessionIds = kept
                         }
+                    }
+                    // codexHome is only meaningful while Codex is the
+                    // foreground; drop it the moment it isn't, so a later
+                    // default-Codex launch on this pane can't inherit a stale
+                    // non-default home and resume the wrong session.
+                    if workspaces[i].panes[paneID]?.codexHome != nil,
+                       agentToken != PaneAgentKind.codex.rawValue {
+                        workspaces[i].panes[paneID]?.codexHome = nil
                     }
                 }
             }
@@ -1804,10 +1821,19 @@ final class WorkspaceStore: ObservableObject {
     /// (`pendingInitialInput` → `GhosttySurfaceView.initialInput`); a nil/empty
     /// command leaves the pane a bare shell. Call right after creating the pane,
     /// before its surface is built, so the lookup finds the entry.
-    private func queueInitialInput(_ command: String?, workspace: UUID, pane: PaneID) {
+    private func queueInitialInput(_ command: String?, codexHome: String? = nil,
+                                   workspace: UUID, pane: PaneID) {
         guard let cmd = command, !cmd.isEmpty else { return }
         let key = WorkspacePaneKey(workspace: workspace, pane: pane)
         pendingInitialInput[key] = cmd.hasSuffix("\n") ? cmd : cmd + "\n"
+        // Persist a non-default Codex home on the pane so a restart can
+        // re-prefix `codex resume …` with the same CODEX_HOME (see
+        // `Pane.codexHome`). The pane was just created above us, so the
+        // subscript hits.
+        if let home = codexHome,
+           let wi = workspaces.firstIndex(where: { $0.id == workspace }) {
+            workspaces[wi].panes[pane]?.codexHome = home
+        }
     }
 
     // MARK: new-terminal entry points (honor the "ask which agent" setting)
@@ -1837,15 +1863,16 @@ final class WorkspaceStore: ObservableObject {
         agentChooserIntent = nil
         guard let item else { return }
         let cmd = item.command
+        let home = item.codexHome
         switch intent {
-        case .tab:        newTab(agentCommand: cmd)
-        case .splitRight: splitFocused(.horizontal, agentCommand: cmd)
-        case .splitDown:  splitFocused(.vertical, agentCommand: cmd)
-        case .workspace:  addWorkspace(agentCommand: cmd)
+        case .tab:        newTab(agentCommand: cmd, codexHome: home)
+        case .splitRight: splitFocused(.horizontal, agentCommand: cmd, codexHome: home)
+        case .splitDown:  splitFocused(.vertical, agentCommand: cmd, codexHome: home)
+        case .workspace:  addWorkspace(agentCommand: cmd, codexHome: home)
         }
     }
 
-    func splitFocused(_ direction: SplitDirection, agentCommand: String? = nil) {
+    func splitFocused(_ direction: SplitDirection, agentCommand: String? = nil, codexHome: String? = nil) {
         guard let i = currentIndex, let t = workspaces[i].selectedTabIndex else { return }
         let new = PaneID(value: workspaces[i].nextPaneSeq)
         workspaces[i].nextPaneSeq += 1
@@ -1857,7 +1884,7 @@ final class WorkspaceStore: ObservableObject {
             newID: new
         ) ?? workspaces[i].tabs[t].root
         workspaces[i].tabs[t].focusedPane = new
-        queueInitialInput(agentCommand, workspace: workspaces[i].id, pane: new)
+        queueInitialInput(agentCommand, codexHome: codexHome, workspace: workspaces[i].id, pane: new)
     }
 
     /// Shells whose presence as the foreground process means "nothing of
@@ -2122,7 +2149,7 @@ final class WorkspaceStore: ObservableObject {
     /// Open a new tab in the current workspace, inheriting the focused pane's
     /// cwd (terminal convention: a new tab opens "here"). Inserts it right
     /// after the current tab and selects it.
-    func newTab(agentCommand: String? = nil) {
+    func newTab(agentCommand: String? = nil, codexHome: String? = nil) {
         guard let i = currentIndex else { return }
         let inheritedCwd = (workspaces[i].selectedTab?.focusedPane)
             .flatMap { workspaces[i].panes[$0]?.workingDirectory }
@@ -2138,7 +2165,7 @@ final class WorkspaceStore: ObservableObject {
             workspaces[i].tabs.append(tab)
         }
         workspaces[i].selectedTabID = tab.id
-        queueInitialInput(agentCommand, workspace: workspaces[i].id, pane: pane)
+        queueInitialInput(agentCommand, codexHome: codexHome, workspace: workspaces[i].id, pane: pane)
     }
 
     /// Close a tab and every pane it holds, cleaning up each pane's surface,
@@ -2376,7 +2403,7 @@ final class WorkspaceStore: ObservableObject {
         workspaces.move(fromOffsets: IndexSet(integer: source), toOffset: offset)
     }
 
-    func addWorkspace(agentCommand: String? = nil) {
+    func addWorkspace(agentCommand: String? = nil, codexHome: String? = nil) {
         let palette = [
             ("5E5CE6", "•"), ("FF6582", "•"), ("30D158", "•"),
             ("FF9F0A", "•"), ("64D2FF", "•"), ("BF5AF2", "•"),
@@ -2387,7 +2414,7 @@ final class WorkspaceStore: ObservableObject {
         workspaces.append(ws)
         selectedWorkspaceID = ws.id
         // Workspace.fresh seeds a single pane at PaneID 0.
-        queueInitialInput(agentCommand, workspace: ws.id, pane: PaneID(value: 0))
+        queueInitialInput(agentCommand, codexHome: codexHome, workspace: ws.id, pane: PaneID(value: 0))
     }
 
     /// Open a workspace anchored at `directory` (the "Local Repo" source). The
@@ -2430,7 +2457,7 @@ final class WorkspaceStore: ObservableObject {
     func createWorktreeWorkspace(repoRoot: String, baseBranch: String, branch: String,
                                  worktreePath: String, createBranch: Bool = true,
                                  carryUncommitted: Bool = false,
-                                 agentCommand: String?) async throws -> UUID {
+                                 agentCommand: String?, codexHome: String? = nil) async throws -> UUID {
         let expanded = (worktreePath as NSString).expandingTildeInPath
         try await git.addWorktree(repo: repoRoot, path: expanded,
                                   newBranch: createBranch ? branch : nil,
@@ -2447,7 +2474,8 @@ final class WorkspaceStore: ObservableObject {
         }
 
         let first = PaneID(value: 0)
-        let pane = Pane(id: first, title: "zsh", workingDirectory: expanded)
+        var pane = Pane(id: first, title: "zsh", workingDirectory: expanded)
+        pane.codexHome = codexHome
         let tab = WorkspaceTab(id: TabID(value: 0), name: nil, root: .leaf(first), focusedPane: first)
         let ws = Workspace(
             id: UUID(), name: "New workspace", userNamed: false,

--- a/GlintTests/PaneAgentKindTests.swift
+++ b/GlintTests/PaneAgentKindTests.swift
@@ -106,6 +106,28 @@ final class PaneAgentKindTests: XCTestCase {
                        "codex resume --last\n")
     }
 
+    // MARK: restoreCommand — non-default Codex Home prefix
+
+    func testRestoreCommandCodexHomePrefixesResume() {
+        // A non-default-home Codex pane must re-prefix its resume command with
+        // the same CODEX_HOME it launched under, or restart resumes against
+        // ~/.codex where the session doesn't exist (#45 for multi-home).
+        let home = "/Users/test/codex-secondary"
+        XCTAssertEqual(PaneAgentKind.codex.restoreCommand(sessionId: "abc-123", codexHome: home),
+                       "CODEX_HOME='\(home)' codex resume abc-123\n")
+        // Fallback form (--last) carries the prefix too.
+        XCTAssertEqual(PaneAgentKind.codex.restoreCommand(sessionId: nil, codexHome: home),
+                       "CODEX_HOME='\(home)' codex resume --last\n")
+    }
+
+    func testRestoreCommandCodexHomeIgnoredForDefaultAndOtherKinds() {
+        // Default home (nil) ⇒ no prefix; other agents ignore the home entirely.
+        XCTAssertEqual(PaneAgentKind.codex.restoreCommand(sessionId: "abc-123", codexHome: nil),
+                       "codex resume abc-123\n")
+        XCTAssertEqual(PaneAgentKind.claude.restoreCommand(sessionId: "abc-123", codexHome: "/x"),
+                       "claude --resume abc-123\n")
+    }
+
     // MARK: helpers
 
     /// WorkspaceIconKind isn't Equatable, so compare by matching the expected


### PR DESCRIPTION
## Problem

A pane launched under a **non-default Codex Home** (`CODEX_HOME=~/codex-test`) lost its home across restart. The chosen home lived only in the in-memory `pendingInitialInput` map (consumed once at surface mint); `Pane` had no field for it. On restart, `surfaceView` rebuilt the boot command via `PaneAgentKind.codex.restoreCommand`, which emitted a bare `codex resume <id>` against the default `~/.codex` — where the session doesn't exist — so **#45 per-pane session resume silently broke for every non-default-home pane** (the exact scenario the multi-home feature #34 is about).

## Fix

Persist the resolved `CODEX_HOME` path on `Pane` and reconstruct the prefix at restore:

- `Pane.codexHome: String?` (Codable, `decodeIfPresent` for back-compat) — the resolved home path, set only for non-default Codex panes.
- `AgentLaunchItem.codexHome` — carries the resolved path from the chooser; threaded through `newTab` / `splitFocused` / `addWorkspace` / `createWorktreeWorkspace` → `queueInitialInput`, which writes it onto the pane.
- `PaneAgentKind.restoreCommand(sessionId:codexHome:)` — re-prefixes `CODEX_HOME='…' ` for `.codex` when set; ignored by other kinds and the default home.
- `captureCwdsFromLiveSurfaces` clears `codexHome` once the foreground stops being Codex, so a later default-Codex launch on the same pane can't inherit a stale home (symmetric with the existing `sessionIds` clearing).

Default-home and non-codex panes are unaffected. New tests cover the prefix form, the `--last` fallback, and that the home is ignored for the default home / other agents.

---

## 问题

通过**非默认 Codex Home**(`CODEX_HOME=~/codex-test`)启动的 pane,重启后丢失了其 Home。选中的 Home 只存在于内存中的 `pendingInitialInput`(在 surface mint 时消费一次),`Pane` 没有对应字段。重启后 `surfaceView` 通过 `PaneAgentKind.codex.restoreCommand` 重建启动命令,直接吐出裸 `codex resume <id>`,打到默认的 `~/.codex` —— 那里没有该 session —— 于是 **#45 的每窗格会话恢复对所有非默认 Home 的 pane 全部静默失效**(正是多 Home 功能 #34 的核心场景)。

## 修复

把解析后的 `CODEX_HOME` 路径持久化到 `Pane`,并在恢复时重建前缀:

- `Pane.codexHome: String?`(Cododable,`decodeIfPresent` 向后兼容)—— 解析后的 Home 路径,仅非默认 Codex pane 设置。
- `AgentLaunchItem.codexHome` —— 从选择器携带解析后的路径,贯穿 `newTab` / `splitFocused` / `addWorkspace` / `createWorktreeWorkspace` → `queueInitialInput`,由后者写到 pane 上。
- `PaneAgentKind.restoreCommand(sessionId:codexHome:)` —— `.codex` 在设置时重新加上 `CODEX_HOME='…' ` 前缀;其他 kind 与默认 Home 忽略。
- `captureCwdsFromLiveSurfaces` 在前台不再是 Codex 时清掉 `codexHome`,避免后续默认 Codex 启动继承陈旧 Home(与既有 `sessionIds` 清理对称)。

默认 Home 与非 Codex 的 pane 不受影响。新增测试覆盖了带前缀的形式、`--last` 兜底,以及默认 Home / 其他 agent 忽略该字段。