### PR TITLE
fix(persistence): keep saving after a transient repair-write failure / 修复写失败后整会话停持久化

### DIFF
--- a/Glint/Workspace/Persistence.swift
+++ b/Glint/Workspace/Persistence.swift
@@ -93,11 +93,18 @@ enum Persistence {
                 do {
                     try repaired.write(to: url, options: [.atomic])
                 } catch {
-                    // Couldn't persist the repair (disk full/permissions).
-                    // Guard the original so the next autosave doesn't
-                    // overwrite the only copy with the stripped state.
-                    corruptUnmovablePath = url.path
-                    NSLog("[glint] couldn't persist repaired \(fileName); refusing to overwrite — original kept at \(url.path)")
+                    // Couldn't persist the repair (disk full/permissions) — but
+                    // the repaired state decoded fine and is now the in-memory
+                    // truth, so DON'T block further saves. A later autosave
+                    // carries this good state plus any new work, and an atomic
+                    // write that fails leaves the original intact (no worse
+                    // corruption). Setting corruptUnmovablePath here would
+                    // permanently drop EVERY subsequent edit until relaunch —
+                    // a worse outcome than overwriting a corrupt original we
+                    // already recovered from. The "preserve the only copy"
+                    // guard belongs only to the unreadable-file path below,
+                    // where no repair could be decoded at all.
+                    NSLog("[glint] couldn't persist repaired \(fileName) (\(error)); will retry on next save — original kept at \(url.path)")
                 }
                 return state
             }


### PR DESCRIPTION
## Problem

When `load()` recovered a corrupt `state.json` (stripped a bad pane/workspace via `stripBadPanes`/`stripBadWorkspaces`) but the atomic write of the repaired copy failed (disk full / permissions), it set `corruptUnmovablePath`. That flag makes `save()` skip **for the rest of the session**.

But the repaired state was already the good in-memory truth, so every later autosave carried **repaired + NEW user work**. Skipping all of them lost that new work on next launch — only the pre-repair on-disk copy survived. A one-time, transient repair-write failure turned into session-wide data loss.

## Fix

Drop the `corruptUnmovablePath` assignment in the repair-write-failure path; log and let saves retry.

The \"preserve the only copy\" rationale only holds for the **sibling** path (line ~115) where the file is fully unreadable and couldn't be moved aside — no repair could be decoded there, so overwriting the only possibly-recoverable copy is wrong. Here a repair **was** decoded, so a later save overwriting the corrupt original with good state is strictly an improvement — and an atomic write that fails leaves the original intact anyway.

The sibling guard is left untouched.

---

## 问题

`load()` 修复损坏的 `state.json`(经 `stripBadPanes`/`stripBadWorkspaces` 剥离坏 pane/workspace)后,若回写修复副本的原子写失败(磁盘满/权限),会设置 `corruptUnmovablePath`。该标志使 `save()` **整个会话**跳过。

但修复后的状态已是内存中的正确值,后续每次 autosave 都携带**「修复 + 新工作」**。全部跳过 = 新工作在下次启动丢失,磁盘上只剩修复前的副本。一次性的、瞬态的修复写失败,演变成整会话的数据丢失。

## 修复

去掉修复写失败路径里的 `corruptUnmovablePath` 赋值,改为日志并让 save 继续重试。

「保留唯一副本」的理由只适用于**兄弟路径**(约 115 行)——那里文件完全不可读且无法移走,根本解不出修复,覆盖唯一可能恢复的副本才是错的。这里已经解出修复,后续 save 用好状态覆盖损坏原件纯属改善,且原子写失败时原件原封不动。

兄弟路径的守卫保持不变。