### PR TITLE
fix(workspace): guard New Workspace detect() against stale repo probes / 修复 detect() 陈旧探测竞态

### DIFF
--- a/Glint/Chrome/NewWorkspaceSheet.swift
+++ b/Glint/Chrome/NewWorkspaceSheet.swift
@@ -242,11 +242,20 @@ private struct WorktreePane: View {
         detecting = true
         Task {
             let root = await store.git.repoRoot(at: target)
-            await MainActor.run { repoRoot = root; detecting = false }
+            await MainActor.run {
+                // Ignore a probe that arrived after the field moved on to a
+                // different repo: a slow earlier detect() must not clobber a
+                // newer one's repoRoot (nor, below, its baseBranch/baseDirty).
+                // Same staleness guard branchChanged() uses for the branch name.
+                guard (repo as NSString).expandingTildeInPath == target else { return }
+                repoRoot = root
+                detecting = false
+            }
             if let root {
                 let cur = await store.git.currentBranch(at: root)
                 let st = try? await store.git.status(at: root)
                 await MainActor.run {
+                    guard (repo as NSString).expandingTildeInPath == target else { return }
                     if let cur { baseBranch = cur }
                     baseDirty = st?.dirtyCount ?? 0
                     if !pathEdited { recomputePath() }

--- a/Glint/Chrome/NewWorkspaceSheet.swift
+++ b/Glint/Chrome/NewWorkspaceSheet.swift
@@ -238,7 +238,11 @@ private struct WorktreePane: View {
 
     private func detect() {
         let target = (repo as NSString).expandingTildeInPath
-        guard !target.isEmpty else { repoRoot = nil; return }
+        // Reset detecting here too: a prior probe may still be in flight with
+        // detecting=true, and its stale MainActor block below is skipped by the
+        // guard (which also skips its `detecting = false`). Without this reset
+        // the spinner would stick after the field is cleared to empty.
+        guard !target.isEmpty else { repoRoot = nil; detecting = false; return }
         detecting = true
         Task {
             let root = await store.git.repoRoot(at: target)


### PR DESCRIPTION
## Problem

`detect()` spawns a `Task` whose two `MainActor.run` blocks write `repoRoot`, then `baseBranch` / `baseDirty`, with **no check that the repo field still holds the same value**. The sibling `branchChanged()` already guards its result against a stale branch name, but `detect()` didn't.

So typing `repoA` ⏎ then `repoB` ⏎ — with `repoB` resolving first — let `repoA`'s slower probe overwrite `repoB`'s `repoRoot` / `baseBranch` / `baseDirty`. The sheet then showed `repoB`'s path but `repoA`'s base, and `create()` could build the worktree off the wrong base.

## Fix

Capture `target` at `Task` start and ignore any result that arrives after the repo field moved on to a different path — the same staleness guard `branchChanged()` uses for the branch name. Applied to both `MainActor.run` blocks (a stale `repoRoot` is just as wrong as a stale `baseBranch`).

Not unit-tested: `detect()` is a private method on a SwiftUI view backed by `@EnvironmentObject` + a real git subprocess, and the existing suite has no New Workspace sheet tests. The guard mirrors the already-shipping `branchChanged()` guard.

---

## 问题

`detect()` 起的 `Task` 里两个 `MainActor.run` 块写入 `repoRoot`、然后 `baseBranch`/`baseDirty`,**没有检查 repo 字段是否还是同一个值**。兄弟方法 `branchChanged()` 已对陈旧分支名做了守卫,但 `detect()` 没有。

于是连续输入 `repoA` ⏎ 再 `repoB` ⏎ —— 若 `repoB` 先返回 —— `repoA` 的慢探测会覆盖 `repoB` 的 `repoRoot`/`baseBranch`/`baseDirty`。表单显示 `repoB` 的路径却用 `repoA` 的 base,`create()` 可能从错误的 base 开分支。

## 修复

在 `Task` 启动时捕获 `target`,丢弃字段已切换后到达的结果,与 `branchChanged()` 的守卫一致。两个 `MainActor.run` 块都加上(陈旧的 `repoRoot` 与陈旧的 `baseBranch` 一样错)。

未加单测:`detect()` 是 SwiftUI 视图的私有方法,依赖 `@EnvironmentObject` + 真实 git 子进程,既有测试套件没有 New Workspace 的测试。守卫直接复用已上线的 `branchChanged()` 守卫。