### PR TITLE
fix(launch): guard applyAppIcon() against the NSApp launch race / applyAppIcon 补 #43 同源 NSApp 守卫

### DIFF
--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -784,10 +784,16 @@ final class WorkspaceStore: ObservableObject {
     /// presets are pre-rendered with their own padding and corner.
     /// Must run on the main thread; `didSet` and the launch restore both do.
     func applyAppIcon() {
+        // `NSApp` is `NSApplication!` (IUO). Touching it during @StateObject
+        // boxing at launch traps (#43), so guard like the dock-tile paths.
+        // Today's callers (the `appIconPreset` didSet and AppDelegate's
+        // main.async-deferred launch restore) land after NSApp is set, but a
+        // future init-time caller would otherwise hit the same trap.
+        guard let app = NSApp else { return }
         if let asset = appIconPreset.assetName {
-            NSApp.applicationIconImage = NSImage(named: asset)
+            app.applicationIconImage = NSImage(named: asset)
         } else {
-            NSApp.applicationIconImage = nil
+            app.applicationIconImage = nil
         }
     }
 


### PR DESCRIPTION
## Problem

#43 added `guard let app = NSApp else { return }` to the dock-tile paths (`updateDockBadge` / `clearDockBadge`) because `NSApp` is `NSApplication!` (IUO) and dereferencing it during `@StateObject` boxing at launch traps with `brk #0x1`.

The sibling `applyAppIcon()` dereferences the same IUO (`NSApp.applicationIconImage`) **without** the guard. It's safe today only because both callers — the `appIconPreset` `didSet` and AppDelegate's `main.async`-deferred launch restore — happen to land after `NSApp` is set. A future init-time caller (e.g. restoring the preset from UserDefaults inside `WorkspaceStore.init`) would trap identically, and the #43 fix's reputation would hide it — readers assume all `NSApp` access here was already guarded.

## Fix

Add the same one-line guard the dock-tile paths use.

---

## 问题

#43 给 dock-tile 路径(`updateDockBadge`/`clearDockBadge`)加了 `guard let app = NSApp else { return }`,因为 `NSApp` 是 `NSApplication!`(IUO),在 `@StateObject` boxing 期间解引用会触发 `brk #0x1`。

兄弟方法 `applyAppIcon()` 裸解同一个 IUO(`NSApp.applicationIconImage`),**却没有**这个守卫。当前安全纯属偶然——两个调用点(`appIconPreset` 的 `didSet` 与 AppDelegate 的 `main.async` 延迟恢复)都恰好在 `NSApp` 就绪之后。任何 init 阶段的新调用方(例如在 `WorkspaceStore.init` 里恢复预设)都会触发同样的 trap,而 #43 修复的声誉会掩盖它——读者会以为这里的 `NSApp` 访问都已加守卫。

## 修复

补上与 dock-tile 路径相同的一行守卫。