### PR TITLE
fix(hooks): deliver events on mktemp failure + dedup removeReporterIfUnused / mktemp 失败不丢事件 + 合并 reporter 清理逻辑

### DIFF
--- a/Glint/Agent/AgentHookInstaller.swift
+++ b/Glint/Agent/AgentHookInstaller.swift
@@ -117,6 +117,28 @@ enum AgentHookInstaller {
             || AgentPresence.commandExists("claude")
     }
 
+    /// Installers whose hooks reference the shared `~/.glint/hooks/glint-report.sh`
+    /// reporter. The single source of truth consulted by
+    /// `removeReporterScriptIfUnused` — adding a new agent that adopts the
+    /// shared reporter is a one-line change here, not an edit to every
+    /// uninstall path.
+    private static let reporterSharingInstallers: [() -> Bool] = [
+        { AgentHookInstaller.isInstalled() },
+        { CodexHookInstaller.isInstalled() },
+        { DevinHookInstaller.isInstalled() },
+    ]
+
+    /// Delete the shared reporter script iff no installed agent still
+    /// references it. Callers that run under an injected (test) config path
+    /// must gate the call themselves so unit tests never delete the real
+    /// `~/.glint` reporter (see DevinHookInstaller.uninstall).
+    static func removeReporterScriptIfUnused() {
+        guard !reporterSharingInstallers.contains(where: { $0() }) else { return }
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let script = home.appendingPathComponent(".glint/hooks/glint-report.sh")
+        try? FileManager.default.removeItem(at: script)
+    }
+
     /// Strip Glint's hook entries from `~/.claude/settings.json` and delete
     /// the reporter script. Other tools' hook entries are preserved; empty
     /// buckets are removed; an empty `hooks` map is removed entirely.
@@ -162,11 +184,7 @@ enum AgentHookInstaller {
         }
         // Only nuke the shared reporter if no other installed agent still
         // references it (Codex and Devin share the same script).
-        if !AgentHookInstaller.isInstalled() && !CodexHookInstaller.isInstalled()
-            && !DevinHookInstaller.isInstalled() {
-            let script = home.appendingPathComponent(".glint/hooks/glint-report.sh")
-            try? FileManager.default.removeItem(at: script)
-        }
+        removeReporterScriptIfUnused()
     }
 
     static func installIfNeeded(socketPath: String) {
@@ -355,12 +373,22 @@ enum AgentHookInstaller {
     fi
 
     umask 077
-    TMP=$(/usr/bin/mktemp "${TMPDIR:-/tmp}/glint-hook.XXXXXX") || { cat >/dev/null 2>&1; exit 0; }
-    trap '/bin/rm -f "$TMP"' EXIT HUP INT TERM
-    cat >"$TMP"
-    SESSION=$(/usr/bin/plutil -extract session_id raw -o - "$TMP" 2>/dev/null || true)
-    /bin/rm -f "$TMP"
-    trap - EXIT HUP INT TERM
+    # The temp file is only needed to extract the OPTIONAL session_id (plutil
+    # reads a file). If mktemp fails (rare: TMPDIR gone / full), drain stdin
+    # but STILL deliver the event without a session id — the event drives pane
+    # state (idle/thinking/stop/permission), while the id only optimizes #45
+    # resume. Dropping the whole event (the old `exit 0`) stalled the pane
+    # silently until mktemp recovered.
+    SESSION=""
+    if TMP=$(/usr/bin/mktemp "${TMPDIR:-/tmp}/glint-hook.XXXXXX"); then
+      trap '/bin/rm -f "$TMP"' EXIT HUP INT TERM
+      cat >"$TMP"
+      SESSION=$(/usr/bin/plutil -extract session_id raw -o - "$TMP" 2>/dev/null || true)
+      /bin/rm -f "$TMP"
+      trap - EXIT HUP INT TERM
+    else
+      cat >/dev/null 2>&1
+    fi
 
     if [ -n "$SESSION" ]; then
       SESSION_B64=$(printf '%s' "$SESSION" | /usr/bin/base64 | /usr/bin/tr -d '\\r\\n')
@@ -473,7 +501,7 @@ enum CodexHookInstaller {
         for home in configuredHomes() {
             try? uninstall(from: home.resolvedURL)
         }
-        removeReporterIfUnused()
+        AgentHookInstaller.removeReporterScriptIfUnused()
     }
 
     static func uninstall(from codexHome: URL) throws {
@@ -524,15 +552,6 @@ enum CodexHookInstaller {
                 setPosixPermissions(mode, atPath: url.path)
             }
             NSLog("[glint] codex hooks removed from \(url.path)")
-        }
-    }
-
-    private static func removeReporterIfUnused() {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        if !AgentHookInstaller.isInstalled() && !CodexHookInstaller.isInstalled()
-            && !DevinHookInstaller.isInstalled() {
-            let script = home.appendingPathComponent(".glint/hooks/glint-report.sh")
-            try? FileManager.default.removeItem(at: script)
         }
     }
 
@@ -1175,13 +1194,8 @@ enum DevinHookInstaller {
         // Only nuke the shared reporter if no other agent still references it.
         // Skipped for an injected (test) config path so unit tests never touch
         // the real ~/.glint reporter script.
-        if url == DevinHookInstaller.defaultConfigURL(),
-           !AgentHookInstaller.isInstalled()
-            && !CodexHookInstaller.isInstalled()
-            && !DevinHookInstaller.isInstalled() {
-            let home = FileManager.default.homeDirectoryForCurrentUser
-            let script = home.appendingPathComponent(".glint/hooks/glint-report.sh")
-            try? FileManager.default.removeItem(at: script)
+        if url == DevinHookInstaller.defaultConfigURL() {
+            AgentHookInstaller.removeReporterScriptIfUnused()
         }
     }
 


### PR DESCRIPTION
## 1. Hook events dropped when mktemp fails

`scriptBody` uses `mktemp` only to feed the **optional** `session_id` extraction (`plutil` reads a file); the event JSON itself is built from env vars (`\$PANE` / `\$HOOK` / `\$AGENT`). On `mktemp` failure the old `|| { cat >/dev/null; exit 0; }` drained stdin and exited **without ever calling `nc`** — the whole hook event was dropped, so the pane stalled (no thinking / stop / permission cues) until `mktemp` recovered, with no log.

**Fix:** drain stdin but still send the event without a session id. Only the #45 resume optimization degrades; pane state still advances.

## 2. Dedup `removeReporterIfUnused`

The three-way \"is the shared reporter still referenced?\" check (`!AgentHookInstaller.isInstalled() && !CodexHookInstaller.isInstalled() && !DevinHookInstaller.isInstalled()`) was copy-pasted across `Agent.uninstall`, `CodexHookInstaller.removeReporterIfUnused`, and `Devin.uninstall` — each hardcoding the same agent list (and the copies had already drifted in comments).

**Fix:** one `AgentHookInstaller.removeReporterScriptIfUnused()` backed by a `reporterSharingInstallers: [() -> Bool]` list. Adding a 4th agent that adopts the shared reporter is now a one-line edit to the list, not an edit to every uninstall path. Devin keeps its `url == defaultConfigURL()` test-path gate; Codex's private helper is deleted.

Existing hook-installer tests (17) pass unchanged.

---

## 1. mktemp 失败时丢弃 hook 事件

`scriptBody` 用 `mktemp` 只是为了喂给**可选的** `session_id` 提取(plutil 读文件);事件 JSON 本身由环境变量(`\$PANE`/`\$HOOK`/`\$AGENT`)构造。`mktemp` 失败时旧的 `|| { cat >/dev/null; exit 0; }` 排空 stdin 后直接退出,**根本没调 `nc`** —— 整个 hook 事件被丢弃,pane 卡住(无 thinking/stop/permission 提示)直到 `mktemp` 恢复,且无日志。

**修复:** 排空 stdin 但仍发送事件(不带 session id)。只退化 #45 的 resume 优化,pane 状态照常推进。

## 2. 合并 removeReporterIfUnused

「共享 reporter 是否仍被引用」的三路判断(`!Agent && !Codex && !Devin`)在 `Agent.uninstall`、`CodexHookInstaller.removeReporterIfUnused`、`Devin.uninstall` 复制了三份,各自硬编码同一份 agent 列表(注释已漂移)。

**修复:** 单个 `AgentHookInstaller.removeReporterScriptIfUnused()`,由 `reporterSharingInstallers: [() -> Bool]` 列表驱动。新增共享 reporter 的第 4 个 agent 现在只改列表一处,而非每条 uninstall 路径都改。Devin 保留 `url == defaultConfigURL()` 测试路径守卫;删除 Codex 的私有 helper。

既有 hook-installer 测试(17 条)不变全部通过。