### PR TITLE
refactor(codex): route all CodexHome reads through one store accessor / CodexHome 读取合并到单一访问器

### DIFF
--- a/Glint/Agent/AgentHookInstaller.swift
+++ b/Glint/Agent/AgentHookInstaller.swift
@@ -408,7 +408,7 @@ enum CodexHookInstaller {
     ]
 
     static func isInstalled() -> Bool {
-        configuredHomes().contains { isInstalled(in: $0.resolvedURL) }
+        CodexHomeStore.configuredHomes().contains { isInstalled(in: $0.resolvedURL) }
     }
 
     static func isInstalled(in codexHome: URL) -> Bool {
@@ -449,7 +449,7 @@ enum CodexHookInstaller {
 
     static func installIfNeeded(socketPath: String) {
         guard let scriptPath = AgentHookInstaller.ensureReporterScript() else { return }
-        for home in configuredHomes().filter(\.isEnabled) {
+        for home in CodexHomeStore.configuredHomes().filter(\.isEnabled) {
             do {
                 try mergeCodexHooks(scriptPath: scriptPath, codexHome: home.resolvedURL)
             } catch {
@@ -470,7 +470,7 @@ enum CodexHookInstaller {
     /// itself is shared with Claude, so we only delete it when neither agent
     /// still references it.
     static func uninstall() {
-        for home in configuredHomes() {
+        for home in CodexHomeStore.configuredHomes() {
             try? uninstall(from: home.resolvedURL)
         }
         removeReporterIfUnused()
@@ -607,14 +607,6 @@ enum CodexHookInstaller {
         } catch {
             throw CodexHookInstallerError.writeFailed(error.localizedDescription)
         }
-    }
-
-    private static func configuredHomes(defaults: UserDefaults = .standard) -> [CodexHome] {
-        guard let data = defaults.data(forKey: CodexHomeStore.storageKey),
-              let homes = try? JSONDecoder().decode([CodexHome].self, from: data),
-              !homes.isEmpty else { return [.default] }
-        var seen = Set<URL>()
-        return homes.filter { seen.insert($0.resolvedURL).inserted }
     }
 
     private static func equalsJSON(_ a: Any?, _ b: Any) -> Bool {

--- a/Glint/Agent/CodexHome.swift
+++ b/Glint/Agent/CodexHome.swift
@@ -77,13 +77,20 @@ final class CodexHomeStore: ObservableObject {
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
-        if let data = defaults.data(forKey: Self.storageKey),
-           let decoded = try? JSONDecoder().decode([CodexHome].self, from: data),
-           !decoded.isEmpty {
-            homes = Self.deduplicated(decoded)
-        } else {
-            homes = [.default]
-        }
+        homes = Self.configuredHomes(defaults: defaults)
+    }
+
+    /// Read the configured Codex homes straight from `defaults`: decode,
+    /// dedupe by resolved URL, fall back to `[.default]`. The single source
+    /// of this read shape — `init`, `UsageStore`, and `AgentHookInstaller`
+    /// all go through here so the three can't drift (one applying a
+    /// normalization the others miss). `nonisolated`: touches only `defaults`
+    /// and a pure decode.
+    nonisolated static func configuredHomes(defaults: UserDefaults = .standard) -> [CodexHome] {
+        guard let data = defaults.data(forKey: storageKey),
+              let decoded = try? JSONDecoder().decode([CodexHome].self, from: data),
+              !decoded.isEmpty else { return [.default] }
+        return Self.deduplicated(decoded)
     }
 
     var enabledHomes: [CodexHome] {
@@ -140,7 +147,7 @@ final class CodexHomeStore: ObservableObject {
         defaults.set(data, forKey: Self.storageKey)
     }
 
-    private static func deduplicated(_ homes: [CodexHome]) -> [CodexHome] {
+    nonisolated private static func deduplicated(_ homes: [CodexHome]) -> [CodexHome] {
         var seen = Set<URL>()
         return homes.filter { seen.insert($0.resolvedURL).inserted }
     }

--- a/Glint/Agent/UsageStore.swift
+++ b/Glint/Agent/UsageStore.swift
@@ -122,7 +122,7 @@ final class UsageStore: ObservableObject {
         CodexQuotaPresentation.sidebarItems(
             from: codexHomeStatuses,
             fallback: codex,
-            hasEnabledHomes: Self.configuredCodexHomes().contains(where: \.isEnabled)
+            hasEnabledHomes: CodexHomeStore.configuredHomes().contains(where: \.isEnabled)
         )
     }
 
@@ -196,7 +196,7 @@ final class UsageStore: ObservableObject {
         if codexEnabled {
             let generation = codexRefreshCoordinator.begin()
             Task { [weak self] in
-                let homes = Self.configuredCodexHomes().filter(\.isEnabled)
+                let homes = CodexHomeStore.configuredHomes().filter(\.isEnabled)
                 await MainActor.run {
                     guard let self,
                           self.codexRefreshCoordinator.accepts(generation) else { return }
@@ -258,14 +258,6 @@ final class UsageStore: ObservableObject {
             return quota
         }.first
         apply(quota, to: .codex)
-    }
-
-    nonisolated private static func configuredCodexHomes() -> [CodexHome] {
-        guard let data = UserDefaults.standard.data(forKey: CodexHomeStore.storageKey),
-              let homes = try? JSONDecoder().decode([CodexHome].self, from: data),
-              !homes.isEmpty else { return [.default] }
-        var seen = Set<URL>()
-        return homes.filter { seen.insert($0.resolvedURL).inserted }
     }
 
     /// Publish and persist a fresh snapshot. A `nil` result (transient network


### PR DESCRIPTION
## Problem

The UserDefaults decode + dedupe-by-resolved-URL + `[.default]` fallback was implemented **three times**:

- `CodexHomeStore.init`
- `UsageStore.configuredCodexHomes`
- `AgentHookInstaller.configuredHomes` (byte-for-byte identical to UsageStore's)

Any change to the read shape — dedup rule, default-home suppression, schema migration — had to land in all three or they'd silently drift: the store could apply a normalization the two off-store readers bypass.

## Fix

Hoist the read into one `nonisolated static func CodexHomeStore.configuredHomes(defaults:)`. `init` uses it; the two off-store copies are **deleted**, and their 5 call sites call the store directly. Also drops `AgentHookInstaller.configuredHomes`'s dead `defaults:` param (no caller ever overrode it).

Net: one source of truth, ~9 fewer lines, no behavior change. Codex test suites (19 tests) pass unchanged.

---

## 问题

「读 UserDefaults + 按 resolved-URL 去重 + `[.default]` 兜底」实现了**三份**:

- `CodexHomeStore.init`
- `UsageStore.configuredCodexHomes`
- `AgentHookInstaller.configuredHomes`(与 UsageStore 的逐字节相同)

读取形状任何一处变化(去重规则、默认 Home 抑制、schema 迁移)都得在三处同步改,否则静默漂移:store 做的规范化,两处旁路读取会绕过。

## 修复

把读取上提到单个 `nonisolated static func CodexHomeStore.configuredHomes(defaults:)`。`init` 复用;两份旁路副本**删除**,5 个调用点改为直接调 store。同时去掉 `AgentHookInstaller.configuredHomes` 从未被覆盖的 `defaults:` 死参数。

净效果:单一真相源、少约 9 行、行为不变。Codex 相关测试套件(19 条)不变全部通过。