### PR TITLE
refactor(review): classify diff lines by marker, drop unrecognized meta / 简化 diff parse 的 meta 行识别

### DIFF
--- a/Glint/Review/ReviewWindow.swift
+++ b/Glint/Review/ReviewWindow.swift
@@ -644,15 +644,14 @@ struct DiffDocument: Sendable {
                 out.append(DiffLine(id: id, kind: .hunk, text: line, oldNum: nil, newNum: nil)); id += 1
                 continue
             }
-            if line.hasPrefix("+++") || line.hasPrefix("---")
-                || line.hasPrefix("diff ") || line.hasPrefix("index ")
-                || line.hasPrefix("new file") || line.hasPrefix("deleted file")
-                || line.hasPrefix("old mode") || line.hasPrefix("new mode")
-                || line.hasPrefix("rename ") || line.hasPrefix("similarity")
-                || line.hasPrefix("copy ") || line.hasPrefix("Binary files")
-                || line.hasPrefix("\\ ") {       // "\ No newline at end of file"
-                continue
-            }
+            if line.hasPrefix("+++") || line.hasPrefix("---") { continue }
+            // Unified-diff content is marked by a leading char: '+', '-', or
+            // ' ' (context). File headers (+++/---, handled above) and every
+            // git meta line (diff/index/old mode/rename/similarity/…/ "\ No
+            // newline") start with something else — so classify by marker and
+            // skip anything unrecognized, rather than maintain an allow-list
+            // of meta prefixes that leaks a new header (e.g. "similarity
+            // index") through as a tinted context line.
             // Strip the leading marker char so code columns align and the +/-
             // gutter clutter is gone — add/delete is shown via tint, not text.
             let body = String(line.dropFirst())
@@ -662,10 +661,11 @@ struct DiffDocument: Sendable {
             } else if line.hasPrefix("-") {
                 out.append(DiffLine(id: id, kind: .del, text: body, oldNum: oldLine, newNum: nil)); id += 1
                 oldLine += 1
-            } else {
+            } else if line.hasPrefix(" ") {
                 out.append(DiffLine(id: id, kind: .context, text: body, oldNum: oldLine, newNum: newLine)); id += 1
                 oldLine += 1; newLine += 1
             }
+            // else: a meta line (diff/index/mode/rename/…/\ No newline) — skip.
         }
         return out
     }

--- a/GlintTests/ReviewDiffParsingTests.swift
+++ b/GlintTests/ReviewDiffParsingTests.swift
@@ -103,6 +103,33 @@ index 000..111
         XCTAssertEqual(lines[1].newNum, 1)
     }
 
+    /// Meta headers NOT on the old allow-list (e.g. "dissimilarity index",
+    /// "GIT binary patch") must be skipped, not leaked through as a tinted
+    /// context line. Classification is by leading marker now, so any
+    /// unrecognized git header drops instead of rendering as content.
+    func testParseSkipsUnrecognizedMetaHeaders() {
+        let diff = """
+diff --git a/o b/n
+dissimilarity index 60%
+rename from o
+rename to n
+--- a/o
++++ b/n
+@@ -1,1 +1,1 @@
+-x
++y
+"""
+        let lines = DiffDocument.parse(diff)
+        // hunk + 1 del + 1 add; every meta header (diff / "dissimilarity
+        // index" / rename from / rename to / --- / +++) drops entirely.
+        XCTAssertEqual(lines.count, 3)
+        XCTAssertEqual(lines[0].kind, .hunk)
+        XCTAssertEqual(lines[1].kind, .del)
+        XCTAssertEqual(lines[1].text, "x")
+        XCTAssertEqual(lines[2].kind, .add)
+        XCTAssertEqual(lines[2].text, "y")
+    }
+
     func testParseEmptyYieldsEmpty() {
         XCTAssertTrue(DiffDocument.parse("").isEmpty)
     }


### PR DESCRIPTION
## Problem

`DiffDocument.parse` used a 13-prefix `hasPrefix` OR-chain to recognize git meta lines (`diff`/`index`/`+++`/`---`/`new file`/`deleted file`/`old mode`/`new mode`/`rename`/`similarity`/`copy`/`Binary files`/`\\ `) and a final `else → context` fallback. A meta header **not** on the list — e.g. `dissimilarity index`, `GIT binary patch` — fell through to the `else` and rendered as a tinted context line.

## Fix

Invert the classification: recognize **content** by its leading marker — `+` add, `-` del, ` ` context (`@@` already handled separately), keep `+++`/`---` explicit so the file headers don't match `+`/`-`, and skip anything unrecognized. New git headers now drop instead of leaking as content, and the OR-chain is gone.

Added a test pinning that `dissimilarity index` (not on the old list) is skipped, not rendered. All existing parse tests still pass (9 total).

---

## 问题

`DiffDocument.parse` 用 13 个 `hasPrefix` 的 OR 链识别 git meta 行,末尾 `else → context` 兜底。**不在**列表里的 meta 头(如 `dissimilarity index`、`GIT binary patch`)会落到 else,被当成着色的 context 行渲染。

## 修复

反转分类:按前导 marker 识别**内容** —— `+` 增、`-` 删、` ` 上下文(`@@` 已单独处理),显式保留 `+++`/`---`(否则文件头会匹配 `+`/`-`),其余未识别的一律跳过。新的 git 头现在直接丢弃而非漏成内容,OR 链移除。

新增测试固定 `dissimilarity index`(旧列表里没有)被跳过而非渲染。既有 parse 测试全部通过(共 9 条)。