### PR TITLE
feat(review): root-or-cwd scope for Review/Reveal + fix subdir empty diff / Review 与 Reveal 支持「仓库根 vs 当前目录」并修复子目录 diff 为空

### DIFF
--- a/Glint.xcodeproj/project.pbxproj
+++ b/Glint.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		5157C5439862F21202BCC44D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E67CF5D8552AE1F51386161 /* AppDelegate.swift */; };
 		692D1A7D490E07D796535EAA /* UpdaterController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4408F9761E584DE2AB6630E2 /* UpdaterController.swift */; };
 		6D74FE6545631EB8193C82E1 /* PaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FC2FBC9E8729A5ECBF857C /* PaneView.swift */; };
+		7072B8575DB70B2367A7EE1D /* ReviewScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7F8C1899F93B387843907FF /* ReviewScopeTests.swift */; };
 		7D07A40DF6411A613624827A /* PaneSurfaceRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16137B405E48DBE262A15B6D /* PaneSurfaceRepresentable.swift */; };
 		7FC12666816053BEB64079CB /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 050E267AE14712D4D6633B4F /* Theme.swift */; };
 		81532B36FEC3039B8EAD9CB1 /* AgentKindResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EEF00CBEF45A9D60423A207 /* AgentKindResolutionTests.swift */; };
@@ -124,6 +125,7 @@
 		C0656F7C1D48AE0429C1888B /* VisualEffectBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualEffectBackground.swift; sourceTree = "<group>"; };
 		C11B3335E47DDAF77A883064 /* ModalOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalOverlay.swift; sourceTree = "<group>"; };
 		C9E2B9ADF809766CE4278047 /* SafeJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeJSON.swift; sourceTree = "<group>"; };
+		D7F8C1899F93B387843907FF /* ReviewScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewScopeTests.swift; sourceTree = "<group>"; };
 		DB20921E3CAC1006A8FBD3AE /* SettingsSafety.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSafety.swift; sourceTree = "<group>"; };
 		E298AD81B1615CBBFD69F48A /* GhosttySurfaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttySurfaceView.swift; sourceTree = "<group>"; };
 		E94AB23640CA1E6007F8B2B4 /* GlintTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GlintTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -186,6 +188,7 @@
 				797C4E86D052EF8A68DD9B39 /* PaneSessionIdMigrationTests.swift */,
 				51DE2D7740BD03498A936B62 /* PersistenceRecoveryTests.swift */,
 				2CFFB91CE5C44976A6961F1F /* ReviewDiffParsingTests.swift */,
+				D7F8C1899F93B387843907FF /* ReviewScopeTests.swift */,
 				83E4DF4C5180D50C381B4976 /* WorkspaceIconKindTests.swift */,
 			);
 			path = GlintTests;
@@ -426,6 +429,7 @@
 				3194A1545E36E400BC2C33E6 /* PaneSessionIdMigrationTests.swift in Sources */,
 				E80809A987A07731FF35D01D /* PersistenceRecoveryTests.swift in Sources */,
 				F5AE37B67B17DD61B652E5B6 /* ReviewDiffParsingTests.swift in Sources */,
+				7072B8575DB70B2367A7EE1D /* ReviewScopeTests.swift in Sources */,
 				C748DE21F23B49B2FFD73DC7 /* WorkspaceIconKindTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Glint/Chrome/SettingsView.swift
+++ b/Glint/Chrome/SettingsView.swift
@@ -409,6 +409,18 @@ private struct GeneralPane: View {
                 Toggle("", isOn: $store.sortCompletedFirst)
                     .toggleStyle(.switch).labelsHidden()
             }
+            SettingsDivider()
+            SettingsRow("Review Changes at repository root",
+                        subtitle: "For plain workspaces whose pane is inside a git repo, review the whole repository instead of just the current directory's subtree.") {
+                Toggle("", isOn: $store.reviewAtRepoRoot)
+                    .toggleStyle(.switch).labelsHidden()
+            }
+            SettingsDivider()
+            SettingsRow("Reveal in Finder at repository root",
+                        subtitle: "For plain workspaces whose pane is inside a git repo, reveal the repository root instead of the current directory.") {
+                Toggle("", isOn: $store.revealAtRepoRoot)
+                    .toggleStyle(.switch).labelsHidden()
+            }
         }
 
         SettingsCard("New terminals") {

--- a/Glint/Resources/Localizable.xcstrings
+++ b/Glint/Resources/Localizable.xcstrings
@@ -1799,6 +1799,50 @@
         }
       }
     },
+    "Review Changes at repository root": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在仓库根目录审查变更"
+          }
+        }
+      }
+    },
+    "For plain workspaces whose pane is inside a git repo, review the whole repository instead of just the current directory's subtree.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "对于面板位于 git 仓库内的普通工作区，审查整个仓库而非仅当前目录的子树。"
+          }
+        }
+      }
+    },
+    "Reveal in Finder at repository root": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在访达中显示仓库根目录"
+          }
+        }
+      }
+    },
+    "For plain workspaces whose pane is inside a git repo, reveal the repository root instead of the current directory.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "对于面板位于 git 仓库内的普通工作区，显示仓库根目录而非当前目录。"
+          }
+        }
+      }
+    },
     "Restore last workspace": {
       "extractionState": "stale",
       "localizations": {

--- a/Glint/Review/ReviewWindow.swift
+++ b/Glint/Review/ReviewWindow.swift
@@ -12,6 +12,9 @@ import AppKit
 final class ReviewModel: ObservableObject {
     let repo: String
     let title: String
+    /// Root-relative path to scope the file list to (current-directory review),
+    /// or nil for the whole repo. See `reload`'s prefix filter.
+    let subdir: String?
     let availableScopes: [DiffScope]
 
     @Published var scope: DiffScope { didSet { Task { await reload() } } }
@@ -32,9 +35,10 @@ final class ReviewModel: ObservableObject {
     private var fileLoadToken = 0   // guards against out-of-order file-list loads
     private var diffLoadToken = 0   // guards against out-of-order diff loads
 
-    init(repo: String, title: String, scopes: [DiffScope]) {
+    init(repo: String, title: String, subdir: String? = nil, scopes: [DiffScope]) {
         self.repo = repo
         self.title = title
+        self.subdir = subdir
         self.availableScopes = scopes.isEmpty ? [.workingTree] : scopes
         self.scope = scopes.first ?? .workingTree
     }
@@ -45,8 +49,18 @@ final class ReviewModel: ObservableObject {
         fileLoadToken += 1
         let token = fileLoadToken
         loadingFiles = true
-        let fs = await git.changedFiles(repo: repo, scope: scope)
+        var fs = await git.changedFiles(repo: repo, scope: scope)
         guard token == fileLoadToken else { return }
+        // Scope the file list to the focused pane's subtree when reviewing a
+        // subdirectory. Git reports root-relative paths, so a prefix filter
+        // (exact match for the dir itself, or "<subdir>/" for contents) is
+        // exact and covers tracked + untracked alike. Applied before tree/
+        // combined are built so all three list modes stay consistent. fileDiff
+        // is unaffected — it still runs root-relative paths from `repo` (the
+        // toplevel), which is what makes every diff resolve correctly.
+        if let sub = subdir {
+            fs = fs.filter { $0.path == sub || $0.path.hasPrefix(sub + "/") }
+        }
         loadingFiles = false
         files = fs
         tree = TreeNode.build(fs)
@@ -809,8 +823,8 @@ final class ReviewWindowController: NSObject, NSWindowDelegate {
     private var window: NSWindow?
     private var model: ReviewModel?   // strong ref for the window's lifetime
 
-    func present(repo: String, title: String, scopes: [DiffScope]) {
-        let model = ReviewModel(repo: repo, title: title, scopes: scopes)
+    func present(repo: String, title: String, subdir: String? = nil, scopes: [DiffScope]) {
+        let model = ReviewModel(repo: repo, title: title, subdir: subdir, scopes: scopes)
         self.model = model
         let root = ReviewView(model: model)
             .frame(minWidth: 780, minHeight: 480)

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -2513,15 +2513,17 @@ final class WorkspaceStore: ObservableObject {
         if let branchError { throw branchError }
     }
 
-    /// Open the workspace's bound root (worktree/repo) in Finder — dive INTO
-    /// the folder, unified with `revealCurrentInFinder`. Shared by every "Open
-    /// in Finder" entry point: the git popover button, the sidebar context
-    /// item, and the command palette.
+    /// Open the workspace's location in Finder — shared by every "Open in
+    /// Finder" entry point (git popover button, sidebar context item, command
+    /// palette). Mirrors the ⌘⇧F shortcut: the bound root (worktree/repo) when
+    /// `revealAtRepoRoot` is on, else the focused pane's cwd — and always dives
+    /// INTO the folder, so the button and the shortcut stay consistent.
     func revealWorktreeInFinder(_ id: UUID) {
         guard let ws = workspaces.first(where: { $0.id == id }),
-              let path = ws.source.worktreePath ?? ws.source.repoRoot ?? effectiveGitPath(for: ws)
+              let root = ws.source.worktreePath ?? ws.source.repoRoot ?? effectiveGitPath(for: ws)
         else { return }
-        Self.openInFinder(path)
+        let paneCwd = (ws.selectedTab?.focusedPane).flatMap { ws.panes[$0]?.workingDirectory }
+        Self.openInFinder((revealAtRepoRoot || paneCwd == nil) ? root : paneCwd!)
     }
 
     /// Reveal the focused pane's current directory in Finder — the global ⌘⇧F

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -905,6 +905,23 @@ final class WorkspaceStore: ObservableObject {
         }
     }
 
+    /// For a plain (non-git-bound) workspace whose focused pane sits inside a
+    /// git repo, review the whole repository from its root (on, default) or just
+    /// the focused pane's current-directory subtree (off). Git-bound workspaces
+    /// always review at the repo root — their gitPath is already root — so this
+    /// only selects the scope for plain workspaces. See `openReview`.
+    @Published var reviewAtRepoRoot: Bool = (UserDefaults.standard.object(forKey: "glint.reviewAtRepoRoot") as? Bool) ?? true {
+        didSet { UserDefaults.standard.set(reviewAtRepoRoot, forKey: "glint.reviewAtRepoRoot") }
+    }
+
+    /// Same choice, independent, for Reveal in Finder (⌘⇧F): reveal the repo
+    /// root (on, default) or the focused pane's cwd (off) for plain workspaces.
+    /// Git-bound workspaces always reveal their bound root. See
+    /// `revealCurrentInFinder`.
+    @Published var revealAtRepoRoot: Bool = (UserDefaults.standard.object(forKey: "glint.revealAtRepoRoot") as? Bool) ?? true {
+        didSet { UserDefaults.standard.set(revealAtRepoRoot, forKey: "glint.revealAtRepoRoot") }
+    }
+
     /// NSSound names for the three audio cues, persisted; the defaults are
     /// the original hardcoded chimes.
     @Published var soundPermissionName: String = UserDefaults.standard.string(forKey: "glint.soundPermissionName") ?? "Funk" {
@@ -2496,12 +2513,15 @@ final class WorkspaceStore: ObservableObject {
         if let branchError { throw branchError }
     }
 
+    /// Open the workspace's bound root (worktree/repo) in Finder — dive INTO
+    /// the folder, unified with `revealCurrentInFinder`. Shared by every "Open
+    /// in Finder" entry point: the git popover button, the sidebar context
+    /// item, and the command palette.
     func revealWorktreeInFinder(_ id: UUID) {
         guard let ws = workspaces.first(where: { $0.id == id }),
               let path = ws.source.worktreePath ?? ws.source.repoRoot ?? effectiveGitPath(for: ws)
         else { return }
-        NSWorkspace.shared.activateFileViewerSelecting(
-            [URL(fileURLWithPath: (path as NSString).expandingTildeInPath)])
+        Self.openInFinder(path)
     }
 
     /// Reveal the focused pane's current directory in Finder — the global ⌘⇧F
@@ -2514,24 +2534,36 @@ final class WorkspaceStore: ObservableObject {
             NSSound.beep()
             return
         }
-        let cwd = (ws.selectedTab?.focusedPane).flatMap { ws.panes[$0]?.workingDirectory }
-        guard let path = cwd
-            ?? ws.source.worktreePath
-            ?? ws.source.repoRoot
-            ?? effectiveGitPath(for: ws)
-        else {
+        let paneCwd = (ws.selectedTab?.focusedPane).flatMap { ws.panes[$0]?.workingDirectory }
+        // A bound workspace's gitPath is its root (worktree root for a worktree,
+        // repo root for Local Repo) — already known. A plain workspace resolves
+        // the toplevel async. Either way, dive INTO revealAtRepoRoot's target:
+        // the root (on, default) or the focused pane's current directory (off).
+        if let root = ws.source.gitPath {
+            let target = (revealAtRepoRoot || paneCwd == nil) ? root : paneCwd!
+            Self.openInFinder(target)
+            return
+        }
+        let base = paneCwd ?? ws.source.worktreePath ?? ws.source.repoRoot ?? effectiveGitPath(for: ws)
+        guard let base else {
             NSSound.beep()
             return
         }
-        NSWorkspace.shared.activateFileViewerSelecting(
-            [URL(fileURLWithPath: (path as NSString).expandingTildeInPath)])
+        if revealAtRepoRoot {
+            Task {
+                let root = await git.repoRoot(at: base) ?? base
+                await MainActor.run { Self.openInFinder(root) }
+            }
+        } else {
+            Self.openInFinder(base)
+        }
     }
 
     /// Open the read-only Review window for a workspace. Always offers the
     /// working-tree scope; for a worktree with a known base branch it also offers
     /// the whole-branch (`base...HEAD`) scope, so the segmented control appears.
     func openReview(for ws: Workspace) {
-        guard let repo = ws.source.gitPath ?? effectiveGitPath(for: ws) else {
+        guard let cwd = ws.source.gitPath ?? effectiveGitPath(for: ws) else {
             NSSound.beep()
             return
         }
@@ -2539,7 +2571,36 @@ final class WorkspaceStore: ObservableObject {
         if let base = ws.source.baseBranch, !base.isEmpty {
             scopes.append(.branch(base: base))
         }
-        ReviewWindowController.shared.present(repo: repo, title: ws.displayName, scopes: scopes)
+        // A bound workspace's gitPath is its root (worktree/repo) — known, no
+        // async. A plain workspace resolves the toplevel async. Either way
+        // honor reviewAtRepoRoot: whole root (on, default) or the focused pane's
+        // cwd subtree (off, filtered via `subdir`). `repo` is always the root so
+        // fileDiff's root-relative paths resolve — the empty-diff bug stays
+        // fixed by construction.
+        let scopeToRoot = reviewAtRepoRoot
+        if let root = ws.source.gitPath {
+            let subdir = scopeToRoot ? nil : Self.paneSubdir(for: ws, root: root)
+            // Keep the worktree's "repo · branch" identity and append the
+            // reviewed subdir when scoping to it (root mode shows just the
+            // identity), so the title reflects what's actually reviewed.
+            let title = subdir.map { "\(ws.displayName) · \($0)" } ?? ws.displayName
+            ReviewWindowController.shared.present(repo: root, title: title,
+                                                  subdir: subdir, scopes: scopes)
+            return
+        }
+        Task {
+            let root = await git.repoRoot(at: cwd) ?? cwd
+            let subdir = scopeToRoot ? nil : Self.paneSubdir(for: ws, root: root)
+            // Title reflects what's reviewed, not ws.displayName — which for a
+            // plain workspace can be a cwd-derived label that disagrees with the
+            // root Review actually opens.
+            let rootName = (root as NSString).lastPathComponent
+            let reviewTitle = subdir.map { "\(rootName)/\($0)" } ?? rootName
+            await MainActor.run {
+                ReviewWindowController.shared.present(repo: root, title: reviewTitle,
+                                                      subdir: subdir, scopes: scopes)
+            }
+        }
     }
 
     // MARK: - What's New (hand-authored per-version notes; see ReleaseNotes.swift)
@@ -2621,6 +2682,36 @@ final class WorkspaceStore: ObservableObject {
         if let p = ws.source.gitPath { return p }
         return (ws.selectedTab?.focusedPane).flatMap { ws.panes[$0]?.workingDirectory }
             ?? ws.panes.values.compactMap(\.workingDirectory).first
+    }
+
+    /// Root-relative path of `cwd` under `root`, or nil if `cwd` is the root
+    /// itself or not inside it. Both are normalized (symlinks resolved,
+    /// "."/".." collapsed) before the prefix drop, so a symlinked repo root or
+    /// a "."-laden shell cwd compare correctly. Used to scope Review's file
+    /// list to a subdirectory: e.g. root=/repo, cwd=/repo/src → "src".
+    /// Pure / no instance state, so Review can call it once at open time and
+    /// pass the result down as `subdir`.
+    nonisolated static func subdirPath(root: String, cwd: String) -> String? {
+        let r = URL(fileURLWithPath: root).resolvingSymlinksInPath().standardizedFileURL.path
+        let c = URL(fileURLWithPath: cwd).resolvingSymlinksInPath().standardizedFileURL.path
+        if c == r { return nil }
+        guard c.hasPrefix(r + "/") else { return nil }   // cwd not under root
+        let rel = String(c.dropFirst(r.count + 1))
+        return rel.isEmpty ? nil : rel
+    }
+
+    /// The focused pane's cwd as a root-relative subdir, or nil if the pane has
+    /// no cwd, is at the root, or is outside it. Shared by `openReview` (Review
+    /// subtree filter) for bound and plain workspaces alike.
+    nonisolated static func paneSubdir(for ws: Workspace, root: String) -> String? {
+        guard let paneCwd = (ws.selectedTab?.focusedPane).flatMap({ ws.panes[$0]?.workingDirectory }) else { return nil }
+        return subdirPath(root: root, cwd: paneCwd)
+    }
+
+    /// Open a folder in Finder by diving INTO it (not reveal-and-select in its
+    /// parent). Shared by every Reveal-in-Finder path.
+    static func openInFinder(_ path: String) {
+        NSWorkspace.shared.open(URL(fileURLWithPath: (path as NSString).expandingTildeInPath))
     }
 
     func gitStatus(for id: UUID) -> GitStatus? { gitStatuses[id] }

--- a/GlintTests/ReviewScopeTests.swift
+++ b/GlintTests/ReviewScopeTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import Glint
+
+/// Tests for the root-vs-current-directory scoping logic behind
+/// `reviewAtRepoRoot` / `revealAtRepoRoot`. `subdirPath` is the one piece of
+/// real logic (normalization + prefix drop); `paneSubdir` wires it to the
+/// focused pane's cwd. The Review/Reveal methods themselves depend on a live
+/// GitService + surfaces, so they're covered manually instead — these tests
+/// lock the path math that decides what "current directory" means.
+final class ReviewScopeTests: XCTestCase {
+
+    private func makeTmpDir(_ leaf: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("glint-review-scope-\(leaf)-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    // MARK: subdirPath
+
+    func testSubdirPathOneLevel() throws {
+        let root = try makeTmpDir("root")
+        let src = root.appendingPathComponent("src", isDirectory: true)
+        try FileManager.default.createDirectory(at: src, withIntermediateDirectories: true)
+        XCTAssertEqual(WorkspaceStore.subdirPath(root: root.path, cwd: src.path), "src")
+    }
+
+    func testSubdirPathNested() throws {
+        let root = try makeTmpDir("root")
+        let nested = root.appendingPathComponent("src/main/resources", isDirectory: true)
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+        XCTAssertEqual(WorkspaceStore.subdirPath(root: root.path, cwd: nested.path),
+                       "src/main/resources")
+    }
+
+    func testSubdirPathCwdIsRootReturnsNil() throws {
+        let root = try makeTmpDir("root")
+        // cwd exactly the root → whole repo, no subdir filter.
+        XCTAssertNil(WorkspaceStore.subdirPath(root: root.path, cwd: root.path))
+    }
+
+    func testSubdirPathCwdOutsideRootReturnsNil() throws {
+        let root = try makeTmpDir("root")
+        let elsewhere = try makeTmpDir("other")
+        // A cwd that isn't under the repo (e.g. the pane cd'd into another
+        // project) must not produce a filter — fall back to whole repo.
+        XCTAssertNil(WorkspaceStore.subdirPath(root: root.path, cwd: elsewhere.path))
+    }
+
+    func testSubdirPathResolvesSymlinkedRootAndCwd() throws {
+        // macOS symlinks /tmp → /private/tmp. A root expressed via /private/tmp
+        // and a cwd via /tmp (the same physical dir) must still match after
+        // resolvingSymlinksInPath — this is the exact mismatch shape that a
+        // pane cwd (shell-reported, often /tmp/…) vs a git toplevel
+        // (--show-toplevel, /private/tmp/…) would hit.
+        let name = "glint-symlink-\(UUID().uuidString)"
+        let rootViaPrivate = "/private/tmp/\(name)"
+        let cwdViaTmp = "/tmp/\(name)/src"
+        try FileManager.default.createDirectory(
+            atPath: rootViaPrivate + "/src", withIntermediateDirectories: true)
+        XCTAssertEqual(WorkspaceStore.subdirPath(root: rootViaPrivate, cwd: cwdViaTmp), "src")
+    }
+
+    func testSubdirPathStandardizesDotDot() throws {
+        let root = try makeTmpDir("root")
+        let src = root.appendingPathComponent("src", isDirectory: true)
+        try FileManager.default.createDirectory(at: src, withIntermediateDirectories: true)
+        // A cwd with a redundant ".." segment still collapses to the same
+        // normalized path, so the prefix drop is stable.
+        let cwdWithDot = root.appendingPathComponent("src/../src").path
+        XCTAssertEqual(WorkspaceStore.subdirPath(root: root.path, cwd: cwdWithDot), "src")
+    }
+
+    // MARK: paneSubdir
+
+    func testPaneSubdirReturnsFocusedPaneCwdRelativeToRoot() throws {
+        let root = try makeTmpDir("root")
+        let src = root.appendingPathComponent("src", isDirectory: true)
+        try FileManager.default.createDirectory(at: src, withIntermediateDirectories: true)
+        var ws = Workspace.fresh(name: "T", accentHex: "5E5CE6", symbol: "•")
+        ws.panes[PaneID(value: 0)]?.workingDirectory = src.path
+        XCTAssertEqual(WorkspaceStore.paneSubdir(for: ws, root: root.path), "src")
+    }
+
+    func testPaneSubdirNilWhenNoCwd() {
+        // A pane that hasn't reported a cwd yet (just launched, no OSC 7) →
+        // no subdir → Review falls back to the whole root.
+        var ws = Workspace.fresh(name: "T", accentHex: "5E5CE6", symbol: "•")
+        ws.panes[PaneID(value: 0)]?.workingDirectory = nil
+        XCTAssertNil(WorkspaceStore.paneSubdir(for: ws, root: "/tmp/anything"))
+    }
+
+    func testPaneSubdirNilWhenCwdIsRoot() throws {
+        let root = try makeTmpDir("root")
+        var ws = Workspace.fresh(name: "T", accentHex: "5E5CE6", symbol: "•")
+        ws.panes[PaneID(value: 0)]?.workingDirectory = root.path
+        XCTAssertNil(WorkspaceStore.paneSubdir(for: ws, root: root.path))
+    }
+
+    func testPaneSubdirNilWhenCwdOutsideRoot() throws {
+        let root = try makeTmpDir("root")
+        let elsewhere = try makeTmpDir("other")
+        var ws = Workspace.fresh(name: "T", accentHex: "5E5CE6", symbol: "•")
+        ws.panes[PaneID(value: 0)]?.workingDirectory = elsewhere.path
+        XCTAssertNil(WorkspaceStore.paneSubdir(for: ws, root: root.path))
+    }
+}


### PR DESCRIPTION
## English

Fixes a bug + adds a setting, all in the Review / Reveal-in-Finder area.

**Bug** — a plain workspace whose focused pane sits in a repo *subdirectory* showed "No diff for this file" for every file in Review. `effectiveGitPath` returns the pane cwd; `changedFiles` reports root-relative paths, but `fileDiff`'s `git diff HEAD -- <path>` resolves `<path>` against that cwd → a root-rel path read from `src/` becomes `src/src/...` → empty.

**Fix** — Review/Reveal always root at the git toplevel and run git with root-relative paths; the empty-diff bug is gone by construction. "Current directory" mode is a pure client-side file-list filter, never a different cwd/pathspec, so the path bug can't recur.

**Two settings** (Settings ▸ General ▸ Workspace, default = root):
- `reviewAtRepoRoot` — Review the whole repo (on) or the focused pane's cwd subtree (off).
- `revealAtRepoRoot` — Reveal the repo root (on) or the cwd (off).

Both apply uniformly to plain AND git-bound (worktree / Local Repo) workspaces.

**Unified dive-in** — every "Open/Reveal in Finder" action now dives INTO the folder (`NSWorkspace.open`) instead of reveal-and-select in the parent: ⌘⇧F + the git-popover / sidebar / command-palette buttons, and the buttons honor the same toggle as the shortcut. **Folds in / supersedes #48.**

**Review title** reflects the reviewed location (repo name, or `repo/subdir`; worktree keeps `repo · branch` and appends the subdir).

**Tests** — `ReviewScopeTests` covers `subdirPath` / `paneSubdir` (root==cwd, outside, nested, `/tmp`↔`/private/tmp` symlink, `..`, no-cwd).

## 中文

修复一个 bug 并加一个设置，都在 Review / 在访达中显示这块。

**Bug** — 普通工作区的面板若位于仓库*子目录*，Review 里每个文件都显示 "No diff for this file"。根因：`effectiveGitPath` 返回面板 cwd，`changedFiles` 报的是相对仓库根的路径，但 `fileDiff` 的 `git diff HEAD -- <path>` 把 `<path>` 按当前 cwd 解析 → 在 `src/` 下读 `src/...` 变成 `src/src/...` → 空。

**修复** — Review/Reveal 一律以 git 仓库根为根、用相对根的路径跑 git，bug 从结构上消除。「当前目录」模式只是客户端文件列表过滤，不换 cwd、不用 pathspec，所以路径 bug 不会再出现。

**两个设置**（设置 ▸ 通用 ▸ 工作区，默认 = 仓库根）：
- `reviewAtRepoRoot` — 审查整个仓库（开）或面板当前目录子树（关）。
- `revealAtRepoRoot` — 显示仓库根（开）或当前目录（关）。

对普通工作区和 git-bound（worktree / 本地仓库）统一生效。

**统一为 dive-in** — 所有「在访达中打开/显示」动作都改为直接进入文件夹（`NSWorkspace.open`）而非在父目录中选中：⌘⇧F + git 弹层 / 侧栏 / 命令面板按钮，且按钮与快捷键遵循同一开关。**合并 / 取代 #48。**

**Review 标题** 反映被审查位置（仓库名 或 仓库/子目录；worktree 保留 `仓库 · 分支` 并追加子目录）。

**测试** — `ReviewScopeTests` 覆盖 `subdirPath` / `paneSubdir`（根==cwd、仓库外、嵌套、`/tmp`↔`/private/tmp` 符号链接、`..`、无 cwd）。

---

Closes #48 — its `revealCurrentInFinder` rewrite and `GlintApp` async button are superseded here (this PR keeps the call sync, honors the new setting, and handles worktree cwd); its `revealWorktreeInFinder` dive-in is folded in.
