### PR TITLE
fix(rename): commit on click-away, not just Enter / 点击空白处即可确认重命名(不再只能按回车)

### DIFF
--- a/Glint/Chrome/ContentView.swift
+++ b/Glint/Chrome/ContentView.swift
@@ -15,6 +15,14 @@ struct ContentView: View {
     /// search). Captured in the false→true transition below.
     @State private var prePaletteResponder: NSResponder?
     @State private var appActive = NSApp.isActive
+    /// Window-local left-click monitor that commits an in-flight rename when
+    /// the click lands outside its field. macOS keeps a focused TextField as
+    /// first responder on outside clicks, so the rename field's blur-to-commit
+    /// path (`onChange(nameFieldFocused)` → `commitRename()`) can't otherwise
+    /// fire — only Return would. Gated on `store.isRenaming` (see below) so it
+    /// acts *only* during a rename; the sidebar search and other fields are
+    /// untouched.
+    @State private var fieldDismissMonitor: Any?
 
     var body: some View {
         HStack(spacing: 0) {
@@ -74,6 +82,8 @@ struct ContentView: View {
             }
         }
         .ignoresSafeArea()
+        .onAppear { installFieldDismissMonitor() }
+        .onDisappear { removeFieldDismissMonitor() }
         // Root stays clear so the sidebar and terminal each own their backing
         // layer — that's what lets the two opacity sliders act independently
         // (a single opaque root fill would block the terminal from showing the
@@ -254,6 +264,39 @@ struct ContentView: View {
             return owner
         }
         return responder
+    }
+
+    /// Installs the rename click-away monitor (see `fieldDismissMonitor`). The
+    /// `store.isRenaming` gate is the whole point of the narrowing: without it
+    /// the monitor would resign *any* focused text field (sidebar search, etc.)
+    /// on every outside click. Resolve `store` once at install time and capture
+    /// the reference — the monitor outlives any single view update, so we must
+    /// not reach back into `self`/the environment at event time.
+    private func installFieldDismissMonitor() {
+        guard fieldDismissMonitor == nil else { return }
+        let store = self.store
+        fieldDismissMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { event in
+            guard store.isRenaming,
+                  let window = event.window ?? NSApp.keyWindow,
+                  let editor = window.firstResponder as? NSTextView,
+                  let superview = editor.superview else {
+                return event
+            }
+            let fieldRect = superview.convert(editor.frame, to: nil)
+            // Small tolerance so clicks on the field's padding still edit.
+            if fieldRect.insetBy(dx: -3, dy: -3).contains(event.locationInWindow) {
+                return event
+            }
+            window.makeFirstResponder(nil)
+            return event
+        }
+    }
+
+    private func removeFieldDismissMonitor() {
+        if let monitor = fieldDismissMonitor {
+            NSEvent.removeMonitor(monitor)
+            fieldDismissMonitor = nil
+        }
     }
 
     /// Sidebar 表面:暗色沿用主题平铺,亮色用 Codex 的中性白磨砂玻璃。
@@ -729,6 +772,7 @@ private struct TabChip: View {
                         DispatchQueue.main.async { nameFieldFocused = true }
                     }
                     .onChange(of: nameFieldFocused) { _, focused in
+                        store.isRenaming = focused
                         if !focused && isEditing { commitRename() }
                     }
             } else {
@@ -827,10 +871,12 @@ private struct TabChip: View {
     private func commitRename() {
         store.renameTab(tab.id, to: draftName)
         isEditing = false
+        store.isRenaming = false
     }
 
     private func cancelRename() {
         isEditing = false
+        store.isRenaming = false
     }
 
     /// Same condition as TabBar.glassCluster — chips restyle as segments

--- a/Glint/Chrome/SidebarView.swift
+++ b/Glint/Chrome/SidebarView.swift
@@ -649,6 +649,7 @@ private struct WorkspaceCard: View {
                             DispatchQueue.main.async { nameFieldFocused = true }
                         }
                         .onChange(of: nameFieldFocused) { _, focused in
+                            store.isRenaming = focused
                             if !focused && isEditing { commitRename() }
                         }
                 } else {
@@ -793,10 +794,12 @@ private struct WorkspaceCard: View {
     private func commitRename() {
         store.renameWorkspace(ws.id, to: draftName)
         isEditing = false
+        store.isRenaming = false
     }
 
     private func cancelRename() {
         isEditing = false
+        store.isRenaming = false
     }
 
     private func workspaceIcon(active: Bool, status: PaneAgentStatus?) -> some View {

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -522,6 +522,12 @@ final class WorkspaceStore: ObservableObject {
     /// of-the-OS.
     @Published var settingsOpen: Bool = false
 
+    /// True while a workspace (sidebar) or tab (tab bar) rename field is the
+    /// focused first responder. Gates the click-away dismissal monitor in
+    /// `ContentView` so it resigns *only* during an actual rename — the sidebar
+    /// search and other text fields stay on macOS's default focus behavior.
+    @Published var isRenaming: Bool = false
+
     /// Hand-authored "What's New" notes to show in the centered card overlay.
     /// Non-empty ⇒ the card is up (one entry on manual open, possibly several
     /// when catching up across skipped versions). See `ReleaseNotes.swift`.


### PR DESCRIPTION
## What & why

Renaming a workspace (sidebar) or a tab (tab bar) could only be confirmed with **Return** — clicking elsewhere did nothing. macOS keeps a focused `TextField` as first responder on outside clicks, so the rename field's existing blur-to-commit path (`onChange(of: nameFieldFocused)` → `commitRename()`) never fired. Users expect click-away to confirm, as in most macOS apps.

## How — rename-only scope

A single window-level `NSEvent` local monitor at the `ContentView` root (`onAppear` install / `onDisappear` remove). On `leftMouseDown`, **only while a rename is in progress** (`store.isRenaming`), if an `NSTextView` field editor is focused and the click lands outside its bounds, it calls `window.makeFirstResponder(nil)` — resigning the field and tripping the existing `onChange(nameFieldFocused)` commit path. Clicks inside the field pass through (±3pt tolerance) so cursor positioning still works.

`store.isRenaming` is a new `@Published` flag on `WorkspaceStore`, mirrored from the two rename fields' `@FocusState` (in `onChange`) and reset on commit/cancel. **It gates the monitor so only rename fields are affected** — the sidebar search and other text fields keep their default focus behavior. This is the narrowing requested in review: the monitor no longer resigns arbitrary focused text fields.

## Testing

`xcodebuild -scheme Glint -configuration Debug -sdk macosx -arch arm64` builds clean. Manually verified:
- Rename a workspace → type → click blank area / another card / the terminal → commits immediately.
- Tab rename → same.
- Click inside the field to reposition the cursor → stays in edit mode.
- Return still confirms; Esc still cancels.
- Sidebar search: focus + type + click away → keeps focus (default macOS behavior, intentionally **not** force-blurred).

## 中文

**问题**:重命名工作区(侧栏)或标签(标签栏)时只能按**回车**确认,点击其它地方没反应。macOS 在点击外部时不会让聚焦的 `TextField` 失去 first responder,所以重命名已有的「失焦即提交」逻辑(`onChange(nameFieldFocused)` → `commitRename()`)始终不触发。

**做法(仅作用于重命名)**:在 `ContentView` 根视图加一个窗口级 `NSEvent` 本地监听。收到 `leftMouseDown` 时,**仅当处于重命名态**(`store.isRenaming`)、且 first responder 是某个 `NSTextView` 字段编辑器、点击落在其 bounds 之外,才 `window.makeFirstResponder(nil)`,触发已有的 `onChange` 提交路径。点在字段内放行(±3pt 容差),不影响光标定位。

`store.isRenaming` 是 `WorkspaceStore` 上新增的 `@Published` 标志,由两处重命名字段的 `@FocusState` 经 `onChange` 镜像、并在 commit/cancel 时复位。**它把监听限定到重命名字段**——侧栏搜索等其它文本框保持默认聚焦行为。这正是 review 里要求的收窄:监听不再对任意聚焦的文本框生效。

**验证**:`xcodebuild ... -arch arm64` 构建通过。手测:重命名工作区/标签 → 输入 → 点空白 / 其它卡片 / 终端 → 立即提交;点字段内移动光标 → 仍处编辑态;回车仍确认,Esc 仍取消;侧栏搜索:聚焦输入再点别处 → 保持焦点(默认行为,刻意不强制失焦)。