### PR TITLE
feat(workspace): macOS notification on agent attention / 后台 agent 需要关注时弹出 macOS 通知

### DIFF
--- a/Glint/App/AppDelegate.swift
+++ b/Glint/App/AppDelegate.swift
@@ -1,4 +1,5 @@
 import AppKit
+import UserNotifications
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
@@ -12,6 +13,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.regular)
+        // 通知点击由我们自己接:激活现有窗口 + 切到对应 pane,
+        // 否则系统默认会再 launch 一个窗口。
+        UNUserNotificationCenter.current().delegate = self
         DispatchQueue.main.async {
             self.configureMainWindow()
             self.patchMainMenu()
@@ -82,6 +86,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // high-water mark — a setting changed this session can still crash the
         // next launch (issue #15), so it must stay rollback-eligible.
         SettingsSafety.shared.markCleanExit()
+        // Drop our delivered banners so they don't outlive the process. A
+        // notification whose owner is gone is a dead link: clicking it
+        // cold-launches a fresh instance instead of activating the running one.
+        // These banners are transient attention cues, not anything to keep.
+        UNUserNotificationCenter.current().removeAllDeliveredNotifications()
     }
 
     private func configureMainWindow() {
@@ -199,5 +208,28 @@ private final class CloseGuardWindowDelegate: NSObject, NSWindowDelegate {
             return original.windowShouldClose?(sender) ?? true
         }
         return true
+    }
+}
+
+extension AppDelegate: UNUserNotificationCenterDelegate {
+    /// 点击通知:激活 app 并把主窗前置;若通知带了 workspace+pane,再切过去。
+    /// 设了 delegate 后系统不再走默认的「再开一个窗口」行为。
+    /// `nonisolated` + 切主 actor:协议回调不保证在 main actor,而 AppDelegate 是
+    /// @MainActor,直接 conformance 会跨隔离(Swift 6 会变错)。
+    nonisolated func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                            didReceive response: UNNotificationResponse,
+                                            withCompletionHandler completionHandler: @escaping () -> Void) {
+        Task { @MainActor in
+            let info = response.notification.request.content.userInfo
+            NSApp.activate(ignoringOtherApps: true)
+            mainWindow?.makeKeyAndOrderFront(nil)
+            if let wsStr = info["workspace"] as? String,
+               let ws = UUID(uuidString: wsStr),
+               let paneStr = info["pane"] as? String,
+               let paneSeq = UInt32(paneStr) {
+                WorkspaceStore.current?.revealPane(workspace: ws, pane: PaneID(value: paneSeq))
+            }
+            completionHandler()
+        }
     }
 }

--- a/Glint/App/GlintApp.swift
+++ b/Glint/App/GlintApp.swift
@@ -44,7 +44,14 @@ struct GlintApp: App {
     }
 
     var body: some Scene {
-        WindowGroup {
+        // Single-instance `Window` scene: it can never spawn a second window,
+        // so any external activation (a clicked macOS notification, a reopen)
+        // lands on the existing window instead of creating a new one. The
+        // UNUserNotificationCenterDelegate handles the pane switch.
+        // NB: `handlesExternalEvents` does NOT help here — it only routes
+        // URL-scheme / NSUserActivity events, and a local-notification click
+        // produces neither. WindowGroup would open a fresh window on reopen.
+        Window("Glint", id: "glint-main") {
             ContentView()
                 .environmentObject(workspaceStore)
                 .environmentObject(updater)

--- a/Glint/Chrome/SettingsView.swift
+++ b/Glint/Chrome/SettingsView.swift
@@ -1275,6 +1275,12 @@ private struct AgentsPane: View {
                     .toggleStyle(.switch).labelsHidden()
             }
             SettingsDivider()
+            SettingsRow("Show macOS notification for agent attention",
+                        subtitle: "Pop a banner in Notification Center when a background agent needs approval, finishes, or fails. Silent — the chime stays the audio cue.") {
+                Toggle("", isOn: $store.systemNotificationOnAgentAttention)
+                    .toggleStyle(.switch).labelsHidden()
+            }
+            SettingsDivider()
             SettingsRow("Sound on permission request",
                         subtitle: "Play a chime when an agent is waiting for your approval in a background workspace.") {
                 HStack(spacing: 10) {

--- a/Glint/Resources/Localizable.xcstrings
+++ b/Glint/Resources/Localizable.xcstrings
@@ -4348,6 +4348,61 @@
           }
         }
       }
+    },
+    "Show macOS notification for agent attention": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "后台 agent 需要关注时弹出 macOS 通知"
+          }
+        }
+      }
+    },
+    "Pop a banner in Notification Center when a background agent needs approval, finishes, or fails. Silent — the chime stays the audio cue.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "后台 agent 需要批准、完成或出错时,在通知中心弹出横幅。静默——声音仍由提示音负责。"
+          }
+        }
+      }
+    },
+    "Waiting for your approval": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "等待你的批准"
+          }
+        }
+      }
+    },
+    "Agent finished its turn": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "任务已完成"
+          }
+        }
+      }
+    },
+    "Agent's turn ended in an error": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行出错"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import Combine
 import AppKit
 import Darwin
+import UserNotifications
 
 // MARK: - Domain types
 
@@ -894,6 +895,21 @@ final class WorkspaceStore: ObservableObject {
         didSet { UserDefaults.standard.set(soundOnError, forKey: "glint.soundOnError") }
     }
 
+    /// 在后台 agent 需要关注时(权限请求 / 完成 / 出错),除了 chime 之外再弹一个
+    /// 静默的 macOS 通知横幅。一个总开关覆盖三种状态。默认 off:横幅比 chime 更
+    /// 打扰、且需要系统授权,让用户主动开启。
+    @Published var systemNotificationOnAgentAttention: Bool =
+        (UserDefaults.standard.object(forKey: "glint.systemNotificationOnAgentAttention") as? Bool) ?? false {
+        didSet {
+            UserDefaults.standard.set(systemNotificationOnAgentAttention,
+                                      forKey: "glint.systemNotificationOnAgentAttention")
+            if systemNotificationOnAgentAttention {
+                // 用户首次开启时请求授权;系统级已拒绝则为空操作。
+                Task { try? await UNUserNotificationCenter.current().requestAuthorization(options: [.alert]) }
+            }
+        }
+    }
+
     /// Show a Dock badge count for background agent states that need a look.
     /// Unlike notification banners this stays quiet and carries no prompt or
     /// transcript text. Defaults to on because it is non-interruptive.
@@ -1606,6 +1622,11 @@ final class WorkspaceStore: ObservableObject {
                 break
             }
         }
+        // 通知比 chime 门更严:仅在整个 Glint 处于后台时弹(前台切到别的 workspace
+        // 不弹——横幅不该盖在用户正用的 app 上)。chime 走上面的 `!userIsWatching` 宽门。
+        if systemNotificationOnAgentAttention && !NSApp.isActive && oldStatus != state.status {
+            postAttentionNotification(status: state.status, key: key)
+        }
         syncDockBadge(for: key, oldStatus: oldStatus, newStatus: state.status, userIsWatching: userIsWatching)
     }
 
@@ -1680,6 +1701,34 @@ final class WorkspaceStore: ObservableObject {
         case .idle, .thinking, .tool, .compacting:
             return false
         }
+    }
+
+    /// 与 chime 镜像的静默横幅。title 用 workspace 名(数据、不翻译),body 走本地化。
+    /// userInfo 带定位(workspace + pane),点击通知时据此呼出 app 并切到该 pane。
+    private func postAttentionNotification(status: PaneAgentStatus, key: WorkspacePaneKey) {
+        let body: String
+        switch status {
+        case .needsPermission: body = String(localized: "Waiting for your approval")
+        case .justCompleted:   body = String(localized: "Agent finished its turn")
+        case .failed:          body = String(localized: "Agent's turn ended in an error")
+        default: return
+        }
+        let title = workspaces.first { $0.id == key.workspace }?.displayName
+            ?? String(localized: "Glint")
+        let c = UNMutableNotificationContent()
+        c.title = title
+        c.body = body
+        // 不设 soundName — chime 已覆盖声音,横幅只负责视觉。
+        c.userInfo = [
+            "workspace": key.workspace.uuidString,
+            "pane": String(key.pane.value),
+        ]
+        // Stable id per pane: a fresh banner replaces the stale one instead of
+        // stacking up in Notification Center, where — once the process exits —
+        // they become dead links that cold-launch a new instance on click.
+        let id = "glint.attention.\(key.workspace.uuidString).\(key.pane.value)"
+        let req = UNNotificationRequest(identifier: id, content: c, trigger: nil)
+        UNUserNotificationCenter.current().add(req)
     }
 
     private func syncDockBadge(for key: WorkspacePaneKey,
@@ -2010,6 +2059,21 @@ final class WorkspaceStore: ObservableObject {
         guard let i = currentIndex, let t = workspaces[i].selectedTabIndex else { return }
         workspaces[i].tabs[t].focusedPane = id
         refreshGitStatusNow(for: workspaces[i].id)
+    }
+
+    /// 点击系统通知时呼出:切到 workspace、选中含该 pane 的 tab 并聚焦,
+    /// 同时清掉它的未读(justCompleted/failed)状态与 Dock 角标。
+    func revealPane(workspace: UUID, pane: PaneID) {
+        guard let wi = workspaces.firstIndex(where: { $0.id == workspace }) else { return }
+        selectedWorkspaceID = workspace
+        if let ti = workspaces[wi].tabs.firstIndex(where: { $0.root.leaves.contains(pane) }) {
+            workspaces[wi].selectedTabID = workspaces[wi].tabs[ti].id
+            workspaces[wi].tabs[ti].focusedPane = pane
+        }
+        let key = WorkspacePaneKey(workspace: workspace, pane: pane)
+        clearDockBadge(for: key)
+        acknowledgeCompletionIfNeeded(for: workspace)
+        refreshGitStatusNow(for: workspace)
     }
 
     // MARK: - external control (control.sock)


### PR DESCRIPTION
## English

Adds an optional, silent macOS notification banner that fires alongside the existing chime when a background agent needs approval, finishes its turn, or fails. One master toggle (Settings ▸ Agents ▸ Notifications, default off).

- **Silent** — no sound; the chime stays the audio cue, the banner is just visual and lands in Notification Center for review.
- **Background-only** — gated on `!NSApp.isActive`, so it never overlays the window you're actively using.
- **Click-to-reveal** — clicking a banner activates the existing window and switches to the pane that triggered it.
- **No second window** — the scene moves from `WindowGroup` to a single-instance `Window`, so activating from a notification can never spawn a new window. (`handlesExternalEvents` doesn't route local-notification clicks — it only matches URL / `NSUserActivity` — so that modifier was a dead end here.)
- **No dead links** — banners use a stable per-pane id (fresh replaces stale) and are cleared on quit, so Notification Center never holds a banner whose owner process is gone — which would otherwise cold-launch a new instance on click.

Localized (en + zh-Hans).

## 中文

新增一个可选的、静默的 macOS 通知横幅:后台 agent 需要批准 / 完成这一轮 / 出错时,在原有 chime 之外再弹一条,进通知中心可回看。一个总开关(Settings ▸ Agents ▸ 通知,默认关)。

- **静默** —— 不响声音;声音仍由 chime 负责,横幅只做视觉提示。
- **仅后台触发** —— 只在 `!NSApp.isActive`(整个 Glint 不在前台)时弹,不会盖在你正在用的窗口上。
- **点击定位** —— 点横幅激活现有窗口并切到触发的 pane。
- **不另开窗口** —— scene 从 `WindowGroup` 换成单实例 `Window`,通知激活不会冒第二个窗口。(`handlesExternalEvents` 不路由本地通知点击 —— 它只匹配 URL / `NSUserActivity`,这条路上是死路。)
- **不留死链接** —— 横幅用稳定的 per-pane id(新的覆盖旧的),并在退出时清空,通知中心不会残留归属进程已死的横幅 —— 那种横幅点了会冷启动新实例。

已本地化(en + zh-Hans)。

### Test / 测试
1. 打开开关 → 授权通知。
2. dev 起 agent → ⌘Tab 切别的 app(别关窗口)→ agent 完成 / 出错 / 请求权限 → 收到横幅(只有视觉,无第二声)。
3. 点横幅 → 激活现有窗口 + 切到该 pane,不冒新窗口。
4. 关 dev → 通知中心该横幅消失(防死链接)。