### PR TITLE
fix(focus): focus the terminal at launch, not the sidebar search / 启动后焦点落到右侧终端而非左侧搜索框

### DIFF
--- a/Glint/Chrome/ContentView.swift
+++ b/Glint/Chrome/ContentView.swift
@@ -164,7 +164,12 @@ struct ContentView: View {
                       onDismiss: { store.dismissWhatsNew() }) {
             WhatsNewView(notes: store.whatsNewNotes)
         }
-        .onAppear { store.evaluateWhatsNewOnLaunch() }
+        .onAppear {
+            // Put launch keyboard focus in the terminal instead of the sidebar
+            // search field (see `assertTerminalFocusOnLaunch`).
+            store.assertTerminalFocusOnLaunch()
+            store.evaluateWhatsNewOnLaunch()
+        }
         .sheet(isPresented: $store.settingsOpen) {
             GlintSettingsView()
                 .environmentObject(store)

--- a/Glint/Chrome/ContentView.swift
+++ b/Glint/Chrome/ContentView.swift
@@ -165,10 +165,14 @@ struct ContentView: View {
             WhatsNewView(notes: store.whatsNewNotes)
         }
         .onAppear {
-            // Put launch keyboard focus in the terminal instead of the sidebar
-            // search field (see `assertTerminalFocusOnLaunch`).
-            store.assertTerminalFocusOnLaunch()
+            // Order matters: evaluate Whats's New *before* the launch focus
+            // claim. `assertTerminalFocusOnLaunch`'s synchronous modal check
+            // reads `whatsNewNotes`, which `evaluateWhatsNewOnLaunch` populates
+            // — so it must run first, or a launch that opens the upgrade card
+            // would be misread as "no modal" on the sync frame and the focus
+            // claim could steal the card's focus. See PR #60 review.
             store.evaluateWhatsNewOnLaunch()
+            store.assertTerminalFocusOnLaunch()
         }
         .sheet(isPresented: $store.settingsOpen) {
             GlintSettingsView()

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -585,6 +585,68 @@ final class WorkspaceStore: ObservableObject {
         sidebarSearchFocusTick &+= 1
     }
 
+    /// One-shot: stays false until a launch focus claim actually succeeds, so
+    /// a claim that bailed (e.g. a modal was already up) isn't marked done.
+    /// The only call site is launch-time, so this flips at most once.
+    private var launchFocusClaimed = false
+
+    /// True while an in-window modal owns keyboard focus. These capture and
+    /// restore the first responder themselves, so the launch assertion must
+    /// not displace them.
+    private var modalOwnsFocus: Bool {
+        commandPaletteOpen || agentChooserIntent != nil
+            || !whatsNewNotes.isEmpty || settingsOpen || newWorkspaceSheetOpen
+    }
+
+    /// The already-minted surface for the focused pane of the selected
+    /// workspace, or nil if it hasn't been rendered yet. Non-minting — safe
+    /// to call from launch-time focus assertions that must NOT spawn a shell
+    /// as a side effect.
+    var currentFocusedSurfaceView: GhosttySurfaceView? {
+        guard let wsID = selectedWorkspaceID else { return nil }
+        return surfaceViews[WorkspacePaneKey(workspace: wsID, pane: currentFocusedPane)]
+    }
+
+    /// At launch, put keyboard focus in the focused pane's terminal instead of
+    /// the sidebar's search field. With no view explicitly claiming first
+    /// responder, AppKit's default key-view traversal hands the window's
+    /// initial focus to the sidebar search field (its field editor — an
+    /// `NSText` — becomes first responder). `PaneSurfaceRepresentable`'s ~1/s
+    /// focus sync then SKIPS, because it deliberately refuses to yank focus
+    /// away from an active text editor (so it can't steal focus from a search
+    /// box the user clicked), so the terminal never wins it back. This claims
+    /// the surface directly — bypassing that guard, which is safe because no
+    /// user clicked the search field at launch. Mirrors the command-palette's
+    /// focus-claim dance (#32).
+    ///
+    /// Launch-safety — this cannot break app launch:
+    ///  • It never touches launch-fragile singletons: the window comes from
+    ///    `surface.window` (held alive by the rendered pane), NOT
+    ///    `NSApp.keyWindow`, which can still be nil early in launch (the #43
+    ///    trap was the same shape of launch-time nil deref).
+    ///  • It runs only via `DispatchQueue.main.async` — strictly after the
+    ///    window is on screen and the run loop is turning, never inline in
+    ///    the launch path.
+    ///  • Every step is optional-guarded behind `[weak self]`; any nil or
+    ///    mid-teardown state degrades to a no-op rather than trapping.
+    ///  • Only first-responder APIs stable since macOS 10.0 are used (deploy
+    ///    target is 14.0), so there's no version-conditional behaviour.
+    /// No-ops once a modal that owns focus (palette, What's New, settings
+    /// sheet, …) is up.
+    func assertTerminalFocusOnLaunch() {
+        guard !launchFocusClaimed, !modalOwnsFocus else { return }
+        DispatchQueue.main.async { [weak self] in
+            guard let self,
+                  !self.launchFocusClaimed,
+                  let surface = self.currentFocusedSurfaceView,
+                  let window = surface.window,
+                  !self.modalOwnsFocus else { return }
+            if window.makeFirstResponder(surface) {
+                self.launchFocusClaimed = true
+            }
+        }
+    }
+
     /// Preferred UI language identifier. `"system"` follows the OS; any
     /// other value is a BCP-47 tag (e.g. `"en"`, `"zh-Hans"`). Persists
     /// across launches via UserDefaults so the choice survives quits.


### PR DESCRIPTION
## What & why

On launch, keyboard focus lands in the **sidebar search field** instead of the **terminal**. Root cause: with no view explicitly claiming first responder, AppKit's default key-view traversal hands the window's initial focus to the sidebar's search `TextField` — its field editor (an `NSText`) becomes first responder. `PaneSurfaceRepresentable`'s ~1/s focus sync then **skips**, because it deliberately refuses to yank focus away from an active text editor (so it can't steal focus from a search box the user clicked). Result: the terminal never wins focus back at launch.

## How

Add a one-shot `WorkspaceStore.assertTerminalFocusOnLaunch()` called from `ContentView.onAppear`. It resolves the focused pane's already-minted surface and calls `makeFirstResponder(surface)` directly — bypassing the text-editor guard, which is safe because no user clicked the search field at launch. This mirrors the focus-claim dance established for the command palette (#32).

```swift
func assertTerminalFocusOnLaunch() {
    guard !launchFocusClaimed, !modalOwnsFocus else { return }
    DispatchQueue.main.async { [weak self] in
        guard let self, !self.launchFocusClaimed,
              let surface = self.currentFocusedSurfaceView,
              let window = surface.window,
              !self.modalOwnsFocus else { return }
        if window.makeFirstResponder(surface) {
            self.launchFocusClaimed = true
        }
    }
}
```

**Launch-safety** (this touches the post-launch path, so it must be impossible to break startup):
- Resolves the window from `surface.window` (held alive by the rendered pane) — **never `NSApp.keyWindow`**, which can still be `nil` early in launch (the #43 trap was the same shape of launch-time nil deref).
- Runs only via `DispatchQueue.main.async` — strictly after the window is on screen and the run loop is turning, never inline in the launch path.
- Every step is optional-guarded behind `[weak self]`; any `nil` or mid-teardown state degrades to a no-op rather than trapping.
- Uses only first-responder APIs stable since macOS 10.0 (deploy target is 14.0) — no version-conditional behaviour.
- No-ops while a modal that owns focus (command palette, What's New, settings sheet, …) is up.

## Testing / verification

Built `Debug` (`arm64`, macOS 26.5 SDK). Ran the dev build with a temporary first-responder probe:
- Before the claim: `firstResponder = _SystemTextFieldFieldEditor` (the bug — sidebar search field editor).
- After the claim: `firstResponder = GhosttySurfaceView`, `makeFirstResponder` returned `true`.

Known limitation (not addressed here, to keep the launch-path change minimal and avoid racing `ModalOverlay`'s async focus restore): a launch that opens the **What's New** upgrade card leaves focus to that modal; this method no-ops while it's up. Normal launches (the reported case) are fixed.

## 中文

**问题**：启动后键盘焦点落在左侧搜索框，而不是右侧终端。根因：没有视图主动 claim first responder 时，AppKit 默认的 key-view 遍历把启动焦点给了左侧搜索框的 `TextField`——它的 field editor（`NSText`）成了 first responder。而 `PaneSurfaceRepresentable` 每秒一次的焦点同步会**跳过**这种情况（它故意不抢活动文本编辑器的焦点，避免抢走用户点中的搜索框），导致终端在启动时永远抢不回焦点。

**做法**：在 `ContentView.onAppear` 调用一次性的 `WorkspaceStore.assertTerminalFocusOnLaunch()`，取出当前焦点窗格已创建的 surface，直接 `makeFirstResponder(surface)`——绕过上述守卫（启动时没有用户点搜索框，所以安全）。复用命令面板（#32）的 focus-claim 模式。

**启动安全**（这是改启动后行为，必须确保不可能 break 启动）：
- 用 `surface.window` 取窗口（被渲染中的窗格持有），**绝不碰 `NSApp.keyWindow`**——后者在启动早期可能仍为 nil（#43 的 trap 就是同款启动期 nil 解包）。
- 仅经 `DispatchQueue.main.async` 执行——严格在窗口上屏、runloop 转动之后，不在启动路径内同步执行。
- 全程可选解包 + `[weak self]`；任何 nil / 析构中途状态都退化为 no-op，不会 trap。
- 只用 macOS 10.0 起稳定的 first-responder API（部署目标 14.0），无版本差异行为。
- 命令面板 / What's New / 设置等弹窗占用焦点时 no-op。

**验证**：`Debug`（`arm64`，macOS 26.5 SDK）构建；用临时 first-responder 探针跑了一遍 dev 构建：
- claim 前：`firstResponder = _SystemTextFieldFieldEditor`（复现 bug）。
- claim 后：`firstResponder = GhosttySurfaceView`，`makeFirstResponder` 返回 `true`。

已知局限（本次不做，以保持启动路径改动最小、避免与 `ModalOverlay` 的异步焦点恢复竞争）：首次启动弹出「更新内容」卡片时把焦点让给该弹窗（此方法在弹窗在台时 no-op）；普通启动（即本 issue 报告的场景）已修复。
