### PR TITLE
feat(review): review changes over SSH (auto-follow remote session) / 通过 SSH 审阅远程仓库改动(自动跟随远程会话)

### DIFF
--- a/Glint.xcodeproj/project.pbxproj
+++ b/Glint.xcodeproj/project.pbxproj
@@ -38,10 +38,12 @@
 		9F605AB2DC185A94ED28E6D4 /* AgentChoice.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3EB9A1E80F3CC4BCA468774 /* AgentChoice.swift */; };
 		A019A2AD685F1407D7E2A7E1 /* AgentHookRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0082D535969C315B8D75D7 /* AgentHookRoutingTests.swift */; };
 		A91EFEF0FEA392A0745724DE /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = 89B8883C4456681F07B6D662 /* AppIcon.icon */; };
+		AB3CF36FE1CF2E35AC6ADC26 /* RemoteTitleParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0B24E791FF6CEB30A9DDD5 /* RemoteTitleParserTests.swift */; };
 		AB89FA6EF5785EC4026F4402 /* VisualEffectBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0656F7C1D48AE0429C1888B /* VisualEffectBackground.swift */; };
 		ABFF3BCAC4AE8CCCAFF89CA0 /* NewWorkspaceSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D29C0D2447094B07854C193 /* NewWorkspaceSheet.swift */; };
 		B1DE20B081ACC4536DBD2089 /* GitStatusPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54663E213FE879B96C0D80E7 /* GitStatusPopover.swift */; };
 		B70CAFEBB2416E25B0FFED97 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = C48F9D3C512A0ABE8369D0F4 /* Sparkle */; };
+		BFF9A1736CA029241BB0622D /* SSHGitRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B8EDEAA2D0EAD42ED6F1915 /* SSHGitRunnerTests.swift */; };
 		C0E8D97C08BA3F0FA33F31E7 /* CommandPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 235E2D958A2244483CAA0812 /* CommandPalette.swift */; };
 		C11ED5034D6EF2BA539846AD /* FontCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = C753FB652599A4C7900F8AA4 /* FontCatalog.swift */; };
 		C41119D04864077E5B554F59 /* CodexHomeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AB338782EF6F22B7B381DA8 /* CodexHomeStoreTests.swift */; };
@@ -105,6 +107,8 @@
 		407B3A9D15F4B9E613DA1CF8 /* ReleaseNotes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseNotes.swift; sourceTree = "<group>"; };
 		41DDB9C7B5A277B7924270A3 /* PaneAgentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneAgentState.swift; sourceTree = "<group>"; };
 		4408F9761E584DE2AB6630E2 /* UpdaterController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdaterController.swift; sourceTree = "<group>"; };
+		4A0B24E791FF6CEB30A9DDD5 /* RemoteTitleParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTitleParserTests.swift; sourceTree = "<group>"; };
+		4B8EDEAA2D0EAD42ED6F1915 /* SSHGitRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHGitRunnerTests.swift; sourceTree = "<group>"; };
 		4BE4DBC7E2579823474466E9 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		4EEF00CBEF45A9D60423A207 /* AgentKindResolutionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentKindResolutionTests.swift; sourceTree = "<group>"; };
 		51DE2D7740BD03498A936B62 /* PersistenceRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceRecoveryTests.swift; sourceTree = "<group>"; };
@@ -193,8 +197,10 @@
 				EBCC04C19D745AA867D961FD /* PaneAgentKindTests.swift */,
 				797C4E86D052EF8A68DD9B39 /* PaneSessionIdMigrationTests.swift */,
 				51DE2D7740BD03498A936B62 /* PersistenceRecoveryTests.swift */,
+				4A0B24E791FF6CEB30A9DDD5 /* RemoteTitleParserTests.swift */,
 				2CFFB91CE5C44976A6961F1F /* ReviewDiffParsingTests.swift */,
 				D7F8C1899F93B387843907FF /* ReviewScopeTests.swift */,
+				4B8EDEAA2D0EAD42ED6F1915 /* SSHGitRunnerTests.swift */,
 				3FAD36B4BDB22AB47353C569 /* SyntaxHighlighterTests.swift */,
 				83E4DF4C5180D50C381B4976 /* WorkspaceIconKindTests.swift */,
 			);
@@ -437,8 +443,10 @@
 				ED46CD7A6E09551A775AD3B8 /* PaneAgentKindTests.swift in Sources */,
 				3194A1545E36E400BC2C33E6 /* PaneSessionIdMigrationTests.swift in Sources */,
 				E80809A987A07731FF35D01D /* PersistenceRecoveryTests.swift in Sources */,
+				AB3CF36FE1CF2E35AC6ADC26 /* RemoteTitleParserTests.swift in Sources */,
 				F5AE37B67B17DD61B652E5B6 /* ReviewDiffParsingTests.swift in Sources */,
 				7072B8575DB70B2367A7EE1D /* ReviewScopeTests.swift in Sources */,
+				BFF9A1736CA029241BB0622D /* SSHGitRunnerTests.swift in Sources */,
 				FAB0828152636BBBBC5989CD /* SyntaxHighlighterTests.swift in Sources */,
 				C748DE21F23B49B2FFD73DC7 /* WorkspaceIconKindTests.swift in Sources */,
 			);

--- a/Glint/Ghostty/GhosttyManager.swift
+++ b/Glint/Ghostty/GhosttyManager.swift
@@ -371,6 +371,19 @@ final class GhosttyManager {
                 }
             }
 
+        case GHOSTTY_ACTION_SET_TITLE:
+            // ghostty forwards the shell's OSC 0/2 title verbatim and — unlike
+            // OSC 7 — does NOT host-validate it, so a remote shell's
+            // `user@host:path` title survives an SSH session. We don't use it
+            // for window titling (Glint sets its own); we mine it for the
+            // remote cwd that drives Review-over-SSH. `updateRemoteFromTitle`
+            // is a no-op unless the foreground process is `ssh`, so local
+            // titles can't pollute remote state.
+            if let view, let cstr = action.action.set_title.title {
+                let title = String(cString: cstr)
+                DispatchQueue.main.async { view.updateRemoteFromTitle(title) }
+            }
+
         case GHOSTTY_ACTION_MOUSE_SHAPE:
             let shape = action.action.mouse_shape
             DispatchQueue.main.async { view?.mouseShape = shape }

--- a/Glint/Git/GitService.swift
+++ b/Glint/Git/GitService.swift
@@ -99,6 +99,126 @@ struct LocalGitRunner: GitRunner {
     }
 }
 
+/// Runs git over SSH against a captured destination, so `GitService`'s
+/// high-level methods work unchanged against a REMOTE repo — `cwd` is the
+/// remote path (a leading `~` is expanded against the remote `$HOME`). Reuses
+/// a per-target SSH `ControlMaster` so the status poll and the Review window
+/// don't each re-authenticate, and forces `BatchMode` so a missing key never
+/// hangs a background call (a host needing an interactive password degrades to
+/// empty results, same shape as a local non-repo). The remote title/host data
+/// that produces `target`/`cwd` is untrusted; this runner only ever runs
+/// read-only `git`, so the worst a spoofed title can do is query a repo on a
+/// host the user already SSHed to.
+struct SSHGitRunner: GitRunner {
+    let target: String
+    let port: Int?
+
+    /// Per-target ControlMaster socket so repeated calls share one authed
+    /// connection; `ControlPersist=10m` keeps it alive briefly after the last
+    /// call so a Review open right after a status poll reuses it.
+    private var controlPath: String {
+        var slug = target
+        if let port { slug += ":\(port)" }
+        let dash = Character("-")
+        let safe = String(slug.map { ($0.isLetter || $0.isNumber) ? $0 : dash })
+        return FileManager.default.temporaryDirectory
+            .appendingPathComponent("glint-ssh-\(safe).sock").path
+    }
+
+    func run(_ args: [String], cwd: String?) async throws -> GitResult {
+        let remoteCwd = try await resolveRemoteCwd(cwd)
+        let argv = Self.commandArgs(target: target, port: port,
+                                    controlPath: controlPath, cwd: remoteCwd, gitArgs: args)
+        return try await Self.spawn(argv)
+    }
+
+    /// Pure: the full `ssh … git -C <cwd> <args>` argv. Split out so the wire
+    /// format is unit-testable without spawning ssh.
+    static func commandArgs(target: String, port: Int?, controlPath: String,
+                            cwd: String?, gitArgs: [String]) -> [String] {
+        var a = ["-o", "BatchMode=yes",
+                 "-o", "ControlMaster=auto", "-o", "ControlPersist=10m",
+                 "-o", "ControlPath=\(controlPath)"]
+        if let port { a += ["-p", "\(port)"] }
+        a.append(target)
+        a.append("git")
+        if let cwd, !cwd.isEmpty { a += ["-C", cwd] }
+        a += gitArgs
+        return a
+    }
+
+    /// Expand a leading `~` against the remote `$HOME` (cached per target).
+    /// nil/empty cwd → nil (git runs in the remote login dir). Absolute paths
+    /// pass straight through.
+    private func resolveRemoteCwd(_ cwd: String?) async throws -> String? {
+        guard let cwd, !cwd.isEmpty else { return nil }
+        guard cwd.hasPrefix("~") else { return cwd }
+        let home = try await Self.remoteHome(target: target, port: port, controlPath: controlPath)
+        guard !home.isEmpty else { return cwd }   // couldn't resolve → best-effort passthrough
+        var rest = cwd
+        let leading: Set<Character> = ["~", "/"]
+        while let first = rest.first, leading.contains(first) { rest.removeFirst() }
+        return rest.isEmpty ? home : "\(home)/\(rest)"
+    }
+
+    // MARK: remote $HOME cache (serial-queue guarded: NSLock is unavailable in
+    // async contexts under Swift 6, and a blocking `.sync` read/write here is
+    // fine — the cache is tiny and the contention is one Review open at a time).
+    private static var homeCache: [String: String] = [:]
+    private static let homeQueue = DispatchQueue(label: "app.glint.git.sshhome")
+
+    private static func remoteHome(target: String, port: Int?, controlPath: String) async throws -> String {
+        let key = "\(target)#\(port.map(String.init) ?? "")"
+        if let cached = Self.homeQueue.sync(execute: { Self.homeCache[key] }) { return cached }
+        var a = ["-o", "BatchMode=yes", "-o", "ControlMaster=auto",
+                 "-o", "ControlPersist=10m", "-o", "ControlPath=\(controlPath)"]
+        if let port { a += ["-p", "\(port)"] }
+        // ssh runs this through the remote login shell, so `$HOME` expands
+        // remotely; printf gives the value with no trailing newline.
+        a += [target, "printf", "%s", "$HOME"]
+        let r = try await Self.spawn(a)
+        let home = r.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        Self.homeQueue.sync { Self.homeCache[key] = home }
+        return home
+    }
+
+    /// Spawn `/usr/bin/ssh <args>` and capture stdout/stderr — mirrors
+    /// `LocalGitRunner`'s concurrent-read layout so neither fixed pipe buffer
+    /// can deadlock on large diff output.
+    private static func spawn(_ sshArgs: [String]) async throws -> GitResult {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<GitResult, Error>) in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let proc = Process()
+                proc.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
+                proc.arguments = sshArgs
+                var env = ProcessInfo.processInfo.environment
+                env["GIT_TERMINAL_PROMPT"] = "0"
+                env["GIT_PAGER"] = "cat"
+                env["GIT_OPTIONAL_LOCKS"] = "0"
+                proc.environment = env
+                let outPipe = Pipe(), errPipe = Pipe()
+                proc.standardOutput = outPipe
+                proc.standardError = errPipe
+                do { try proc.run() } catch {
+                    cont.resume(throwing: GitError.launchFailed(error.localizedDescription))
+                    return
+                }
+                var outData = Data(), errData = Data()
+                let group = DispatchGroup()
+                let q = DispatchQueue(label: "app.glint.git.read", attributes: .concurrent)
+                q.async(group: group) { outData = outPipe.fileHandleForReading.readDataToEndOfFile() }
+                q.async(group: group) { errData = errPipe.fileHandleForReading.readDataToEndOfFile() }
+                group.wait()
+                proc.waitUntilExit()
+                cont.resume(returning: GitResult(
+                    exitCode: proc.terminationStatus,
+                    stdout: String(decoding: outData, as: UTF8.self),
+                    stderr: String(decoding: errData, as: UTF8.self)))
+            }
+        }
+    }
+}
+
 // MARK: - High-level git operations
 
 /// A single entry from `git worktree list --porcelain`.

--- a/Glint/Git/GitService.swift
+++ b/Glint/Git/GitService.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 // MARK: - Out-of-band git
@@ -116,11 +117,18 @@ struct SSHGitRunner: GitRunner {
     /// Per-target ControlMaster socket so repeated calls share one authed
     /// connection; `ControlPersist=10m` keeps it alive briefly after the last
     /// call so a Review open right after a status poll reuses it.
+    ///
+    /// Hashed (not sanitized) on purpose: a naive `[^A-Za-z0-9] → "-"` slug
+    /// collapses `deploy.prod.server` / `deploy-prod-server` / `deploy_prod_server`
+    /// into the same path, so two distinct destinations would share a mux and
+    /// the second ssh would tunnel through the first's connection — i.e. land
+    /// on the wrong host. Hashing is also short enough to fit comfortably under
+    /// macOS's 104-byte unix socket path limit even for long ssh aliases.
     private var controlPath: String {
         var slug = target
         if let port { slug += ":\(port)" }
-        let dash = Character("-")
-        let safe = String(slug.map { ($0.isLetter || $0.isNumber) ? $0 : dash })
+        let digest = SHA256.hash(data: Data(slug.utf8))
+        let safe = digest.prefix(8).map { String(format: "%02x", $0) }.joined()
         return FileManager.default.temporaryDirectory
             .appendingPathComponent("glint-ssh-\(safe).sock").path
     }

--- a/Glint/Pane/GhosttySurfaceView.swift
+++ b/Glint/Pane/GhosttySurfaceView.swift
@@ -43,6 +43,21 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
     /// proc_pidinfo polling because it's event-driven.
     var cachedCwd: String?
 
+    /// Remote host/path parsed from the terminal title while the pane is an
+    /// SSH session (the remote shell prints `user@host:path` at each prompt;
+    /// ghostty surfaces title changes via `GHOSTTY_ACTION_SET_TITLE`, which —
+    /// unlike OSC 7 — is NOT host-validated, so it survives an SSH session).
+    /// STRICTLY separate from `cachedCwd`: this is untrusted, remote-sourced
+    /// data used only by the SSH review runner. It must never feed ⌘-click
+    /// file-open, Reveal in Finder, or the proc_pidinfo fallback — those stay
+    /// local (see `resolveFilePath` / `currentCwd`).
+    ///
+    /// Transient: intentionally absent from `CodingKeys`, so they are never
+    /// persisted and always re-derived from the live terminal title after
+    /// restart. If you touch Pane's `CodingKeys`, do not add these.
+    var remoteHost: String?
+    var remotePath: String?
+
     private var scrollbackEnabled: Bool {
         (UserDefaults.standard.object(forKey: "glint.restoreTerminalScrollback") as? Bool) ?? true
     }
@@ -798,6 +813,73 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
             return (arg as NSString).lastPathComponent
         }
         return nil
+    }
+
+    // MARK: - Remote SSH context (Review-over-SSH)
+
+    /// Parse a `user@host:path` terminal title (bash's default `\u@\h:\w`)
+    /// into its parts. Returns nil for titles that carry no remote cwd — plain
+    /// zsh remotes, custom titles, full-screen apps that clear it — so Review
+    /// degrades to its no-path behavior instead of guessing. Static + internal
+    /// so the parser is directly unit-testable.
+    static func parseRemoteTitle(_ title: String) -> (user: String, host: String, path: String)? {
+        let t = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let at = t.firstIndex(of: "@") else { return nil }
+        let user = String(t[..<at])
+        guard !user.isEmpty, !user.contains(" ") else { return nil }
+        let rest = t[t.index(after: at)...]
+        guard let colon = rest.firstIndex(of: ":") else { return nil }
+        let host = String(rest[..<colon]).trimmingCharacters(in: .whitespaces)
+        let path = String(rest[rest.index(after: colon)...]).trimmingCharacters(in: .whitespaces)
+        guard !host.isEmpty,
+              host.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "." || $0 == "-" || $0 == "_" }),
+              !path.isEmpty else { return nil }
+        return (user, host, path)
+    }
+
+    /// Called from the `GHOSTTY_ACTION_SET_TITLE` handler. Records the remote
+    /// host/path only while the foreground process is `ssh`; clears them
+    /// otherwise so a finished SSH session can't leave stale remote data that
+    /// a later local Review would pick up.
+    func updateRemoteFromTitle(_ title: String?) {
+        guard foregroundProcessName() == "ssh",
+              let title, let parsed = Self.parseRemoteTitle(title) else {
+            if remoteHost != nil || remotePath != nil { remoteHost = nil; remotePath = nil }
+            return
+        }
+        remoteHost = parsed.host
+        remotePath = parsed.path
+    }
+
+    /// The ssh destination the user typed (`user@host`, plus `-p <port>` when
+    /// present), captured from the foreground ssh pid's argv. nil when the pane
+    /// isn't an SSH session or the argv can't be parsed — notably when ssh is
+    /// already running a one-shot remote command (a second non-flag token),
+    /// because appending `git` would then conflict with it.
+    func foregroundSshTarget() -> (target: String, port: Int?)? {
+        guard foregroundProcessName() == "ssh", let s = surface else { return nil }
+        let pid = ghostty_surface_foreground_pid(s)
+        guard pid > 0, let argv = Self.processArgv(pid: Int32(pid)), argv.count > 1 else { return nil }
+        var port: Int?
+        var destination: String?
+        var sawRemoteCommand = false
+        var i = 1   // skip argv[0] (the ssh binary path)
+        while i < argv.count {
+            let a = argv[i]
+            if a == "-p", i + 1 < argv.count { port = Int(argv[i + 1]); i += 2; continue }
+            if a.hasPrefix("-") { i += 1; continue }   // ignore -i/-l/-v/… best-effort
+            if destination == nil { destination = a } else { sawRemoteCommand = true }
+            i += 1
+        }
+        guard let destination, !sawRemoteCommand else { return nil }
+        return (destination, port)
+    }
+
+    /// Everything the SSH review runner needs, or nil when the focused pane
+    /// isn't a capturable SSH session with a known remote path.
+    var remoteReviewContext: (target: String, port: Int?, remotePath: String)? {
+        guard let ssh = foregroundSshTarget(), let path = remotePath, !path.isEmpty else { return nil }
+        return (ssh.target, ssh.port, path)
     }
 
     // MARK: - resize

--- a/Glint/Review/ReviewWindow.swift
+++ b/Glint/Review/ReviewWindow.swift
@@ -41,16 +41,18 @@ final class ReviewModel: ObservableObject {
     @Published var loadingFiles = false
     @Published var loadingDiff = false
 
-    private let git = GitService()
+    private let git: GitService
     private var fileLoadToken = 0   // guards against out-of-order file-list loads
     private var diffLoadToken = 0   // guards against out-of-order diff loads
 
-    init(repo: String, title: String, subdir: String? = nil, scopes: [DiffScope]) {
+    init(repo: String, title: String, subdir: String? = nil, scopes: [DiffScope],
+         runner: GitRunner = LocalGitRunner()) {
         self.repo = repo
         self.title = title
         self.subdir = subdir
         self.availableScopes = scopes.isEmpty ? [.workingTree] : scopes
         self.scope = scopes.first ?? .workingTree
+        self.git = GitService(runner: runner)
     }
 
     func reload() async {
@@ -1314,8 +1316,10 @@ final class ReviewWindowController: NSObject, NSWindowDelegate {
     /// resolving label colors against the open-time appearance.
     private var themeCancellable: AnyCancellable?
 
-    func present(repo: String, title: String, subdir: String? = nil, scopes: [DiffScope], store: WorkspaceStore) {
-        let model = ReviewModel(repo: repo, title: title, subdir: subdir, scopes: scopes)
+    func present(repo: String, title: String, subdir: String? = nil,
+                 scopes: [DiffScope], store: WorkspaceStore,
+                 runner: GitRunner = LocalGitRunner()) {
+        let model = ReviewModel(repo: repo, title: title, subdir: subdir, scopes: scopes, runner: runner)
         self.model = model
         let root = ReviewView(model: model)
             .frame(minWidth: 780, minHeight: 480)

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -129,6 +129,17 @@ struct Pane: Identifiable, Codable {
     /// `restoreClaudeSession` / `restoreCodexSession`. Reflects the CURRENT
     /// state, not sticky: an agent that quit back to the shell clears it.
     var lastAgent: String?
+    /// Remote SSH context for Review-over-SSH — the ssh destination the user
+    /// typed, its port, the remote host (display only), and the remote cwd
+    /// mined from the terminal title. Transient (NOT persisted): re-derived
+    /// from the live surface on the 1s capture poll, so it's nil until the
+    /// remote shell's title reports a cwd. Mirrors `workingDirectory`'s
+    /// snapshot-from-surface pattern. Optional → defaults nil, so the custom
+    /// Codable below ignores them without a CodingKeys/init/encode change.
+    var remoteTarget: String?
+    var remotePort: Int?
+    var remoteHost: String?
+    var remotePath: String?
     /// Per-agent session id captured from hook events, keyed by
     /// `PaneAgentKind.rawValue` ("claude"/"codex"/"opencode"/"devin"). When
     /// set, restore-on-launch issues the agent's `--resume <id>` /
@@ -1575,6 +1586,20 @@ final class WorkspaceStore: ObservableObject {
                    workspaces[i].panes[paneID]?.workingDirectory != cwd {
                     workspaces[i].panes[paneID]?.workingDirectory = cwd
                 }
+                // Snapshot the remote SSH context (Review-over-SSH). Same
+                // write-only-on-change discipline as cwd — an unconditional
+                // write would fire objectWillChange every tick.
+                let rctx = view.remoteReviewContext
+                let rhost = view.remoteHost
+                if workspaces[i].panes[paneID]?.remoteTarget != rctx?.target
+                    || workspaces[i].panes[paneID]?.remotePort != rctx?.port
+                    || workspaces[i].panes[paneID]?.remotePath != rctx?.remotePath
+                    || workspaces[i].panes[paneID]?.remoteHost != rhost {
+                    workspaces[i].panes[paneID]?.remoteTarget = rctx?.target
+                    workspaces[i].panes[paneID]?.remotePort = rctx?.port
+                    workspaces[i].panes[paneID]?.remotePath = rctx?.remotePath
+                    workspaces[i].panes[paneID]?.remoteHost = rhost
+                }
                 if let name = view.foregroundProcessName() {
                     newProcesses[key] = name
                     // Track CURRENT claude/codex/opencode foreground so the
@@ -2752,8 +2777,11 @@ final class WorkspaceStore: ObservableObject {
     /// `revealAtRepoRoot` is on, else the focused pane's cwd — and always dives
     /// INTO the folder, so the button and the shortcut stay consistent.
     func revealWorktreeInFinder(_ id: UUID) {
-        guard let ws = workspaces.first(where: { $0.id == id }),
-              let root = ws.source.worktreePath ?? ws.source.repoRoot ?? effectiveGitPath(for: ws)
+        guard let ws = workspaces.first(where: { $0.id == id }) else { return }
+        // Remote SSH pane: nothing local to reveal — beep and stop before the
+        // local-root chain runs against a bogus path.
+        if remoteContext(for: ws) != nil { NSSound.beep(); return }
+        guard let root = ws.source.worktreePath ?? ws.source.repoRoot ?? effectiveGitPath(for: ws)
         else { return }
         let paneCwd = (ws.selectedTab?.focusedPane).flatMap { ws.panes[$0]?.workingDirectory }
         Self.openInFinder((revealAtRepoRoot || paneCwd == nil) ? root : paneCwd!)
@@ -2769,6 +2797,9 @@ final class WorkspaceStore: ObservableObject {
             NSSound.beep()
             return
         }
+        // Remote SSH pane: there's no local directory to reveal — beep instead
+        // of diving into a bogus local path derived from the ssh process's cwd.
+        if remoteContext(for: ws) != nil { NSSound.beep(); return }
         let paneCwd = (ws.selectedTab?.focusedPane).flatMap { ws.panes[$0]?.workingDirectory }
         // A bound workspace's gitPath is its root (worktree root for a worktree,
         // repo root for Local Repo) — already known. A plain workspace resolves
@@ -2798,6 +2829,46 @@ final class WorkspaceStore: ObservableObject {
     /// working-tree scope; for a worktree with a known base branch it also offers
     /// the whole-branch (`base...HEAD`) scope, so the segmented control appears.
     func openReview(for ws: Workspace) {
+        // Remote SSH pane: review the remote repo over SSH by swapping the
+        // GitRunner. `git -C <remotePath>` works from anywhere inside the repo,
+        // so the remote cwd is passed straight through as `repo`; `--show-prefix`
+        // gives the root-relative subdir for the file-list scope (no tilde math
+        // — git resolves it remotely).
+        if let rctx = remoteContext(for: ws) {
+            let runner = SSHGitRunner(target: rctx.target, port: rctx.port)
+            let remoteGit = GitService(runner: runner)
+            Task {
+                // Resolve the remote repo root once; `--show-prefix` gives the
+                // cwd's root-relative subdir for the cwd-scope branch. Honor
+                // `reviewAtRepoRoot` — whole root (on) vs focused-cwd subtree
+                // (off) — mirroring the local Review path so the toggle behaves
+                // the same over SSH.
+                async let rootA = remoteGit.repoRoot(at: rctx.remotePath)
+                let prefixR = try? await remoteGit.git(
+                    ["rev-parse", "--show-prefix"], cwd: rctx.remotePath, allowFailure: true)
+                let root = await (rootA ?? rctx.remotePath)
+                var subdir: String? = nil
+                if !reviewAtRepoRoot,
+                   let pr = prefixR, pr.ok {
+                    // Trim the trailing newline git always emits, then any
+                    // slashes. Root → "" → nil; a non-nil subdir (even "") makes
+                    // ReviewModel.reload's prefix filter drop every file.
+                    let pre = pr.stdout
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                        .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+                    subdir = pre.isEmpty ? nil : pre
+                }
+                let rootName = (root as NSString).lastPathComponent
+                let label = subdir.map { "\(rootName)/\($0)" } ?? rootName
+                let title = rctx.host.map { "\($0) · \(label)" } ?? label
+                await MainActor.run {
+                    ReviewWindowController.shared.present(repo: root, title: title,
+                                                          subdir: subdir, scopes: [.workingTree],
+                                                          store: self, runner: runner)
+                }
+            }
+            return
+        }
         guard let cwd = ws.source.gitPath ?? effectiveGitPath(for: ws) else {
             NSSound.beep()
             return
@@ -2913,6 +2984,25 @@ final class WorkspaceStore: ObservableObject {
     /// what lets a *plain* workspace that's simply `cd`'d into a repo still
     /// surface git status and the tab's git button — no `.localWorktree` source
     /// required.
+    /// The focused pane's remote SSH context when it's a capturable SSH session
+    /// with a known remote path; else nil. The ssh `target` is authoritative
+    /// for transport (it's what the user typed — resolves `~/.ssh/config`
+    /// aliases/jumps via the user's own ssh); `remotePath` is mined from the
+    /// remote shell's terminal title; `host` is display-only. Resolved here
+    /// (not via `effectiveGitPath`) so the local status poll keeps ignoring
+    /// remote panes while Review still routes through SSH.
+    private func remoteContext(for ws: Workspace) -> (target: String, port: Int?, remotePath: String, host: String?)? {
+        guard let paneID = ws.selectedTab?.focusedPane else { return nil }
+        // Read the LIVE surface rather than the Pane snapshot. The snapshot
+        // (Pane.remotePath) lags up to the 1s capture poll, so pressing ⌘⇧R
+        // right after a remote `cd` would otherwise review the previous
+        // directory (e.g. `~` → "not a git repo" → empty Review). The surface's
+        // remotePath is updated immediately when the remote shell's title fires.
+        guard let view = surfaceViews[WorkspacePaneKey(workspace: ws.id, pane: paneID)],
+              let ctx = view.remoteReviewContext else { return nil }
+        return (ctx.target, ctx.port, ctx.remotePath, view.remoteHost)
+    }
+
     func effectiveGitPath(for ws: Workspace) -> String? {
         if let p = ws.source.gitPath { return p }
         return (ws.selectedTab?.focusedPane).flatMap { ws.panes[$0]?.workingDirectory }
@@ -2952,8 +3042,18 @@ final class WorkspaceStore: ObservableObject {
     func gitStatus(for id: UUID) -> GitStatus? { gitStatuses[id] }
 
     func refreshGitStatus(for id: UUID) async {
-        guard let ws = workspaces.first(where: { $0.id == id }),
-              let path = effectiveGitPath(for: ws) else {
+        guard let ws = workspaces.first(where: { $0.id == id }) else {
+            if gitStatuses[id] != nil { gitStatuses[id] = nil }
+            return
+        }
+        // Remote SSH pane: nothing local to poll, and remote status badges are
+        // out of scope for v1 (Review-over-SSH only). Skip before running local
+        // git against the ssh process's stale local cwd.
+        if remoteContext(for: ws) != nil {
+            if gitStatuses[id] != nil { gitStatuses[id] = nil }
+            return
+        }
+        guard let path = effectiveGitPath(for: ws) else {
             if gitStatuses[id] != nil { gitStatuses[id] = nil }
             return
         }

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -2869,6 +2869,16 @@ final class WorkspaceStore: ObservableObject {
             }
             return
         }
+        // ssh foreground but no parsed remote cwd yet (no title fired, or the
+        // remote shell's prompt doesn't print user@host:path). Beep instead of
+        // falling through to the local-cwd branch, which would silently Review
+        // the LOCAL directory the user happened to be in when they ran ssh.
+        if let paneID = ws.selectedTab?.focusedPane,
+           let view = surfaceViews[WorkspacePaneKey(workspace: ws.id, pane: paneID)],
+           view.foregroundSshTarget() != nil {
+            NSSound.beep()
+            return
+        }
         guard let cwd = ws.source.gitPath ?? effectiveGitPath(for: ws) else {
             NSSound.beep()
             return

--- a/GlintTests/RemoteTitleParserTests.swift
+++ b/GlintTests/RemoteTitleParserTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import Glint
+
+/// `GhosttySurfaceView.parseRemoteTitle` is the one piece of real logic behind
+/// Review-over-SSH's remote-cwd capture: it mines `user@host:path` out of the
+/// terminal title the remote shell prints at each prompt (bash default
+/// `\u@\h:\w`). Titles that carry no cwd must return nil so Review degrades
+/// gracefully instead of guessing. The surface/ghostty plumbing that delivers
+/// the title is covered manually; these tests lock the parser.
+final class RemoteTitleParserTests: XCTestCase {
+
+    func testBashDefaultTitle() {
+        let r = GhosttySurfaceView.parseRemoteTitle("deploy@prod-server:~/code/api")
+        XCTAssertEqual(r?.user, "deploy")
+        XCTAssertEqual(r?.host, "prod-server")
+        XCTAssertEqual(r?.path, "~/code/api")
+    }
+
+    func testAbsolutePath() {
+        let r = GhosttySurfaceView.parseRemoteTitle("root@1.2.3.4:/etc/nginx")
+        XCTAssertEqual(r?.user, "root")
+        XCTAssertEqual(r?.host, "1.2.3.4")
+        XCTAssertEqual(r?.path, "/etc/nginx")
+    }
+
+    func testFQDNHost() {
+        let r = GhosttySurfaceView.parseRemoteTitle("ci@build.example.com:/srv/app")
+        XCTAssertEqual(r?.host, "build.example.com")
+        XCTAssertEqual(r?.path, "/srv/app")
+    }
+
+    func testTrimsSurroundingWhitespace() {
+        let r = GhosttySurfaceView.parseRemoteTitle("  deploy@prod-server:~/x  ")
+        XCTAssertEqual(r?.user, "deploy")
+        XCTAssertEqual(r?.path, "~/x")
+    }
+
+    func testNoAtSignReturnsNil() {
+        // A local window title with a colon but no `user@host` must not parse.
+        XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("My Mac — zsh"))
+        XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("~/code/api"))
+    }
+
+    func testNoColonReturnsNil() {
+        XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("deploy@prod-server"))
+    }
+
+    func testEmptyPathReturnsNil() {
+        XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("deploy@prod-server:"))
+    }
+
+    func testUserWithSpaceReturnsNil() {
+        XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("a b@host:/x"))
+    }
+
+    func testHostWithInvalidCharsReturnsNil() {
+        // host must be letter/digit/.-/_ — a space in the host segment is not
+        // a real hostname, so reject rather than mis-parse.
+        XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@ho st:/x"))
+    }
+}

--- a/GlintTests/SSHGitRunnerTests.swift
+++ b/GlintTests/SSHGitRunnerTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import Glint
+
+/// `SSHGitRunner` runs git over a captured ssh destination. The runner itself
+/// shells out to `/usr/bin/ssh`, so it's covered manually — but the exact argv
+/// it assembles (transport, ControlMaster, `-C <remote-path>`, port) is pure
+/// and worth pinning: a wrong flag here means Review silently misses or hangs.
+final class SSHGitRunnerTests: XCTestCase {
+
+    func testBasicArgv() {
+        let a = SSHGitRunner.commandArgs(target: "deploy@prod-server", port: nil,
+                                         controlPath: "/tmp/x.sock",
+                                         cwd: "~/code/api", gitArgs: ["status"])
+        XCTAssertEqual(a, [
+            "-o", "BatchMode=yes",
+            "-o", "ControlMaster=auto", "-o", "ControlPersist=10m",
+            "-o", "ControlPath=/tmp/x.sock",
+            "deploy@prod-server",
+            "git", "-C", "~/code/api", "status"
+        ])
+    }
+
+    func testPortInserted() {
+        let a = SSHGitRunner.commandArgs(target: "host", port: 2222,
+                                         controlPath: "/tmp/x.sock",
+                                         cwd: "/srv/app", gitArgs: ["rev-parse", "--show-toplevel"])
+        let portIndex = a.firstIndex(of: "-p")
+        XCTAssertNotNil(portIndex)
+        XCTAssertEqual(a[portIndex! + 1], "2222")
+        // cwd present → `-C` lands right after `git`.
+        let gitIndex = a.firstIndex(of: "git")!
+        XCTAssertEqual(a[gitIndex + 1], "-C")
+        XCTAssertEqual(a[gitIndex + 2], "/srv/app")
+    }
+
+    func testNilCwdOmitsCFlag() {
+        let a = SSHGitRunner.commandArgs(target: "host", port: nil,
+                                         controlPath: "/tmp/x.sock",
+                                         cwd: nil, gitArgs: ["status"])
+        let gitIndex = a.firstIndex(of: "git")!
+        // Immediately after `git` come the git args, with no `-C` injected.
+        XCTAssertEqual(a[gitIndex + 1], "status")
+        XCTAssertFalse(a.contains("-C"))
+    }
+
+    func testAlwaysForcesBatchMode() {
+        // BatchMode=yes must always be present so a missing key never hangs a
+        // background Review/status call.
+        let a = SSHGitRunner.commandArgs(target: "h", port: nil,
+                                         controlPath: "/x", cwd: nil, gitArgs: [])
+        let idx = a.firstIndex(of: "BatchMode=yes")
+        XCTAssertNotNil(idx)
+        XCTAssertEqual(a[idx! - 1], "-o")
+    }
+}


### PR DESCRIPTION
> **Depends on #57** (root-or-cwd Review/Reveal scope). This branch is based on `fix/review-subdir-repo-root` because it reuses `reviewAtRepoRoot` + the `present(runner:)` plumbing added there. Once #57 merges, this PR's diff auto-collapses to just the SSH-review changes.

## What & why

When you SSH into a remote host from a Glint pane and `cd` into a remote repo, **Review Changes (⌘⇧R) was broken**: it ran `git` as a *local* subprocess, and the remote path never reached Glint (ghostty deliberately drops non-local OSC 7 for security; the proc fallback read the *local* ssh process's cwd). So Review came up empty or against the wrong local dir.

This makes Review follow you onto the remote host — `ssh user@host`, `cd` into a repo, ⌘⇧R, and you get the remote repo's diff — **with no pre-configuration and no ghostty rebuild**.

## How

Two signals, both required:
- **Transport** ← the ssh destination the user typed, captured from the foreground ssh process's argv (reuses the existing `KERN_PROCARGS2` helper). Authoritative — resolves `~/.ssh/config` aliases/jumps via the user's own `ssh`.
- **Remote cwd + display host** ← the **terminal title**. The remote shell prints `user@host:path` at each prompt (default bash `\u@\h:\w`); ghostty forwards title changes via `GHOSTTY_ACTION_SET_TITLE` — which, unlike OSC 7, is **not** host-validated, so it survives an SSH session. Glint parses `user@host:path` from it.

Then:
- **`SSHGitRunner: GitRunner`** (the `GitRunner` protocol already anticipated "an SSH runner can conform later") runs `ssh -o BatchMode=yes -o ControlMaster=auto … git -C <remote-path> <args>`. A per-target `ControlMaster` shares one authed connection so the Review open doesn't re-authenticate. A leading `~` in the remote path is expanded against a cached remote `$HOME`.
- `ReviewWindowController.present` / `ReviewModel` take a `runner:` (default `LocalGitRunner()` — local call sites unchanged). `openReview` resolves the remote root via `git rev-parse --show-toplevel` over SSH and honors `reviewAtRepoRoot` (whole root vs focused-cwd subtree, via `--show-prefix`), mirroring the local path.
- **Security isolation:** the parsed remote host/path are untrusted and feed **only** the SSH review runner — never `cachedCwd`, ⌘-click file-open, or Reveal in Finder. Worst case from a spoofed title = read-only `git` against a host the user already SSHed to.
- **Local-only ops disabled on remote panes:** Reveal in Finder and worktree ops no-op + beep on a remote pane; the git-status poll skips remote panes (a remote status badge is out of scope for v1).

## Coverage caveat

Works when the remote shell titles with its cwd — notably **default bash** (common on Linux servers) and any setup that sets `user@host:path`. A plain zsh remote without title integration emits no usable cwd → Review degrades to a beep rather than guessing. (Verified end-to-end against an Ubuntu host running default bash.)

## Testing / verification

- `GlintTests/RemoteTitleParserTests.swift` (9 cases) — `user@host:path` parsing incl. `~`/absolute/FQDN, whitespace trim, and the nil cases (no `@`, no `:`, empty path, spaces, bad host chars).
- `GlintTests/SSHGitRunnerTests.swift` (4 cases) — the pure `commandArgs` builder: `-C <cwd>`, `-p <port>`, `BatchMode=yes` always present, nil-cwd omits `-C`.
- Built arm64-only (`-sdk macosx -arch arm64`); unit tests pass.
- **Manual, end-to-end on a real Ubuntu host** (key auth via the system ssh-agent): `ssh ubuntu` → `cd ~/.hermes/…/<repo>` → ⌘⇧R opens the Review window listing the remote repo's modified files, with correct root vs subdir scoping under the `reviewAtRepoRoot` toggle.

## 中文

> **依赖 #57**(Review/Reveal 的「仓库根/当前目录」范围)。本分支基于 `fix/review-subdir-repo-root`,复用其中的 `reviewAtRepoRoot` 与 `present(runner:)` 改动。#57 合并后,本 PR 的 diff 会自动收缩为仅 SSH 审阅相关改动。

### 做什么 / 为什么

从 Glint 面板 `ssh` 到远程主机并 `cd` 进远程仓库时,**审阅改动(⌘⇧R)是坏的**:它在本地跑 `git`,而远程路径根本传不进来(ghostty 出于安全会丢弃非本地的 OSC 7;proc 回退读到的是本地 ssh 进程的 cwd)。结果 Review 要么空、要么审错本地目录。

本 PR 让 Review 跟随你上到远程主机 —— `ssh user@host`、`cd` 进仓库、⌘⇧R 即可看到远程仓库的 diff —— **无需任何预配置,也不需要重编 ghostty**。

### 怎么做

两个信号,缺一不可:
- **传输** ← 用户输入的 ssh 目标,从前台 ssh 进程的 argv 抓取(复用既有 `KERN_PROCARGS2` helper)。权威——经用户自己的 ssh 解析 `~/.ssh/config` 别名/跳板。
- **远程 cwd + 显示用主机名** ← **终端标题**。远程 shell 每次回车打印 `user@host:path`(bash 默认 `\u@\h:\w`);ghostty 通过 `GHOSTTY_ACTION_SET_TITLE` 转发标题变更——与 OSC 7 不同,**不**校验主机,故能穿越 SSH 会话。Glint 从中解析 `user@host:path`。

接着:
- **`SSHGitRunner: GitRunner`**(`GitRunner` 协议早已预留「未来可加 SSH runner」)执行 `ssh -o BatchMode=yes -o ControlMaster=auto … git -C <远程路径> <args>`。按目标复用 `ControlMaster`,打开 Review 时不必重新认证。远程路径开头的 `~` 按缓存的远程 `$HOME` 展开。
- `ReviewWindowController.present` / `ReviewModel` 新增 `runner:`(默认 `LocalGitRunner()`,本地调用点不变)。`openReview` 经 SSH 用 `git rev-parse --show-toplevel` 解析远程根,并遵循 `reviewAtRepoRoot`(整根 vs 当前目录子树,经 `--show-prefix`),与本地路径一致。
- **安全隔离**:解析出的远程 host/path 不可信,**只**喂给 SSH 审阅 runner——绝不进 `cachedCwd`、⌘-点击打开、或访达显示。伪造标题的最坏后果 = 对用户已 ssh 的主机跑只读 `git`。
- **远程面板禁用本地专属操作**:远程面板上「在访达中显示」与 worktree 操作改为 no-op + 蜂鸣;git 状态轮询跳过远程面板(v1 不做远程状态徽标)。

### 覆盖范围说明

当远程 shell 标题带 cwd 时生效——尤其是**默认 bash**(Linux 服务器常见)及任何设置 `user@host:path` 标题的环境。不带 cwd 的纯 zsh 远程 → Review 降级为蜂鸣,而非瞎猜。(已在 Ubuntu 默认 bash 主机上端到端验证。)

### 测试 / 验证

- `GlintTests/RemoteTitleParserTests.swift`(9 例):`user@host:path` 解析,含 `~`/绝对路径/FQDN、空白裁剪、以及 nil 情况(无 `@`、无 `:`、空路径、含空格、主机非法字符)。
- `GlintTests/SSHGitRunnerTests.swift`(4 例):纯函数 `commandArgs`——`-C <cwd>`、`-p <port>`、必有 `BatchMode=yes`、nil cwd 不加 `-C`。
- arm64 构建(`-sdk macosx -arch arm64`),单测通过。
- **真实 Ubuntu 主机端到端手测**(经系统 ssh-agent 的密钥认证):`ssh ubuntu` → `cd ~/.hermes/…/<仓库>` → ⌘⇧R 打开 Review,列出远程仓库改动;`reviewAtRepoRoot` 开关下根/子目录范围正确。
