### PR TITLE
feat(review): adjustable context lines in Changes Only / 仅显示改动模式下可调上下文行数

### DIFF
--- a/Glint/Resources/Localizable.xcstrings
+++ b/Glint/Resources/Localizable.xcstrings
@@ -67,6 +67,28 @@
         }
       }
     },
+    "Fewer context lines": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "减少上下文行数"
+          }
+        }
+      }
+    },
+    "More context lines": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "增加上下文行数"
+          }
+        }
+      }
+    },
     "Show Whitespace": {
       "extractionState": "manual",
       "localizations": {

--- a/Glint/Review/ReviewWindow.swift
+++ b/Glint/Review/ReviewWindow.swift
@@ -612,6 +612,11 @@ private struct DiffPaneView: View {
     @ObservedObject var model: ReviewModel
     @AppStorage("glint.review.diffMode") private var modeRaw = DiffMode.unified.rawValue
     @AppStorage("glint.review.diffShowContext") private var showContext = true
+    // Context lines around each change, applied only in Changes Only mode
+    // (showContext == false): 0 = pure changes only, N = N lines around each
+    // change. Render-time over the whole-file load, so +/- is instant with no
+    // git re-fetch. Persisted globally → carries across Review sessions.
+    @AppStorage("glint.review.contextLines") private var contextLines = 0
     private var mode: DiffMode { DiffMode(rawValue: modeRaw) ?? .unified }
 
     var body: some View {
@@ -643,7 +648,7 @@ private struct DiffPaneView: View {
             // indication that the filter is what hid everything.
             hint(String(localized: "No changes after filter"))
         } else {
-            DiffContentView(doc: model.diff, mode: mode, showContext: showContext)
+            DiffContentView(doc: model.diff, mode: mode, showContext: showContext, contextLines: contextLines)
                 // Re-mount on FILE or DATA change only (path / ignoreWhitespace
                 // both change the underlying diff). Mode and showContext are
                 // pure render filters on the same data — keep the view, reset
@@ -663,6 +668,9 @@ private struct DiffPaneView: View {
             Spacer(minLength: 8)
             diffModeMenu
             contextLinesMenu
+            if !showContext {
+                contextStepper
+            }
             ignoreWSMenu
             if !f.isBinary {
                 if f.additions > 0 {
@@ -709,6 +717,25 @@ private struct DiffPaneView: View {
             ],
             help: contextHelp
         )
+    }
+
+    // Adjusts contextLines — the Changes-Only window size: 0 = pure changes, N =
+    // N lines around each change. No upper bound; large N just converges toward
+    // the whole file, which Show All covers explicitly. Hidden in Show All.
+    private var contextLabel: String { "\(contextLines)" }
+    private func stepContext(_ delta: Int) {
+        contextLines = max(0, contextLines + delta)
+    }
+
+    private var contextStepper: some View {
+        HStack(spacing: 1) {
+            HeaderIconButton(symbol: "minus", help: "Fewer context lines", size: 10) { stepContext(-1) }
+            Text(contextLabel)
+                .font(.system(size: 10.5, weight: .medium, design: .monospaced))
+                .foregroundStyle(Color.secondary)
+                .frame(width: 30)
+            HeaderIconButton(symbol: "plus", help: "More context lines", size: 10) { stepContext(1) }
+        }
     }
 
     // Toggle --ignore-all-space (indentation/whitespace-only changes → context).
@@ -878,6 +905,38 @@ struct DiffDocument: Sendable {
         return out
     }
 
+    /// From a whole-file diff (`--unified=1000000`), keep each maximal change run
+    /// plus up to `n` lines of context around it — a render-time re-derival of
+    /// `git diff --unified=n` so adjusting n is instant (no re-fetch). `n < 0`
+    /// returns everything (whole file); 0 drops all context (changes only). Runs
+    /// whose context windows overlap merge into one visible block, matching git's
+    /// own hunk merging; hunk headers are always kept.
+    static func windowed(_ lines: [DiffLine], context n: Int) -> [DiffLine] {
+        if n < 0 { return lines }
+        let count = lines.count
+        var keep = [Bool](repeating: false, count: count)
+        var i = 0
+        while i < count {
+            if lines[i].kind == .add || lines[i].kind == .del {
+                // Back-fill up to n context lines immediately before this run.
+                var b = i - 1, back = n
+                while b >= 0, back > 0, lines[b].kind == .context { keep[b] = true; b -= 1; back -= 1 }
+                // Keep the whole contiguous change run, then up to n context after.
+                var j = i
+                while j < count, lines[j].kind == .add || lines[j].kind == .del { keep[j] = true; j += 1 }
+                var f = j, fwd = n
+                while f < count, fwd > 0, lines[f].kind == .context { keep[f] = true; f += 1; fwd -= 1 }
+                i = f          // a following run's back-fill reclaims any gap, idempotently
+            } else {
+                i += 1
+            }
+        }
+        var out: [DiffLine] = []
+        out.reserveCapacity(count)
+        for (idx, line) in lines.enumerated() where keep[idx] || line.kind == .hunk { out.append(line) }
+        return out
+    }
+
     /// `@@ -oldStart,oldCount +newStart,newCount @@ ...` → (oldStart, newStart).
     private static func parseHunk(_ line: String) -> (Int, Int) {
         var old = 0, new = 0
@@ -901,6 +960,7 @@ private struct DiffContentView: View {
     let doc: DiffDocument
     let mode: DiffMode
     let showContext: Bool
+    let contextLines: Int
     private static let maxLines = 6000
     @State private var cursor = -1   // index into RenderPlan.anchors; -1 = not yet jumped
 
@@ -948,7 +1008,9 @@ private struct DiffContentView: View {
     private var renderPlan: RenderPlan {
         switch mode {
         case .unified:
-            let filtered = showContext ? doc.lines : doc.lines.filter { $0.kind != .context }
+            // Show All renders the whole file; Changes Only windows each change
+            // run with `contextLines` of context (render-time, no re-fetch).
+            let filtered = showContext ? doc.lines : DiffDocument.windowed(doc.lines, context: contextLines)
             let capped = filtered.prefix(Self.maxLines)
             var anchors: [Int] = []
             var ids: [Int] = []
@@ -962,7 +1024,11 @@ private struct DiffContentView: View {
             }
             return RenderPlan(kind: .unified(capped), anchors: anchors, ids: ids, totalCount: filtered.count)
         case .split:
-            let filtered = showContext ? doc.splitRows : doc.splitRows.filter { !Self.isContextPair($0) }
+            // windowed keeps a `[DiffLine]` mask, so re-pair after windowing in
+            // Changes Only; Show All uses the pre-paired whole-file rows.
+            let filtered = showContext
+                ? doc.splitRows
+                : DiffDocument.pair(DiffDocument.windowed(doc.lines, context: contextLines))
             let capped = filtered.prefix(Self.maxLines)
             var anchors: [Int] = []
             var ids: [Int] = []
@@ -981,13 +1047,6 @@ private struct DiffContentView: View {
     private static func isChangeRow(_ r: SplitRow) -> Bool {
         if case .pair(let l, let rg) = r.body {
             return (l?.kind == .add || l?.kind == .del) || (rg?.kind == .add || rg?.kind == .del)
-        }
-        return false
-    }
-
-    private static func isContextPair(_ r: SplitRow) -> Bool {
-        if case .pair(let l, let rg) = r.body, let l, let rg {
-            return l.kind == .context && rg.kind == .context
         }
         return false
     }


### PR DESCRIPTION
## What & why

The Review window's **Changes Only** mode showed each change with **zero** surrounding context — useful for a tight scan, but often you want a few lines around a change to read it in place, and the existing **Show All** jumps straight to the whole file. This adds a **− N +** stepper so you can dial in exactly N context lines around each change run without leaving Changes Only.

## How

- A new `contextLines: Int` (`@AppStorage("glint.review.contextLines")`, default `0`) holds the window size; persisted globally so it carries across Review sessions.
- `DiffDocument.windowed(_:context:)` re-derives `git diff --unified=N` **at render time** over the existing whole-file load (`--unified=1000000`): keep each maximal change run plus up to `n` context lines around it; runs whose context windows overlap merge into one block, matching git's own hunk merging. `0` ⇒ pure changes only (unchanged from before).
- `Show All` is untouched — in that mode the whole file is already shown, so the stepper is hidden; it appears only in Changes Only.
- `+`/`−` is render-time, so it's instant with **no git re-fetch and no scroll jump** (`contextLines` is deliberately kept out of the view's remount `.id`).
- All visible strings localized (`en` + `zh-Hans`).

## Testing / verification

- `xcodebuild -sdk macosx -arch arm64` clean (rebased onto latest `main`, which already includes #61).
- Manually: in Changes Only, `− 0 +` → `+` reveals N lines around each change, `−` collapses back; value persists across sessions; Show All unchanged; works in both Unified and Split.

## 中文

**做什么** — Review 的「仅显示改动」之前每个改动块周围 **0** 行上下文，扫改动很紧凑，但想就近读上下文就得切到「显示全部」（直接整文件）。本 PR 加了个 **− N +** 步进器，在「仅显示改动」里精确调节每个改动块周围显示多少行上下文，不用切到整文件。

**怎么做**
- 新增 `contextLines`（`@AppStorage`，默认 `0`）存窗口大小，全局持久化、跨会话保留。
- `DiffDocument.windowed(_:context:)` 在**渲染期**从已有的整文件 diff 重新推导 `git diff --unified=N`：保留每个改动 run + 周围最多 N 行 context，相邻 run 的 context 窗口重叠会自动合并（和 git 的 hunk 合并语义一致）。`0` 即纯改动（和原来一样）。
- **显示全部**不动 —— 整文件已全显示，步进器隐藏；只在「仅显示改动」出现。
- `+`/`−` 是渲染期操作，**即时、不重新拉 git、不跳滚动**（`contextLines` 刻意不进视图重挂载的 `.id`）。
- 可见文案均已本地化（`en` + `zh-Hans`）。

**验证** — 基于 latest `main`（已含 #61）arm64 构建通过；手测「仅显示改动」下步进器 +/-、跨会话持久、显示全部不变、Unified/Split 两种模式。

Builds on top of #61 (already merged).