### PR TITLE
feat(review): syntax highlighting in the diff view / diff 视图语法高亮

### DIFF
--- a/Glint.xcodeproj/project.pbxproj
+++ b/Glint.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		3932A4CFEFF6FB81AE283645 /* AgentHookInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265A192AC9BD06DB09346E90 /* AgentHookInstaller.swift */; };
 		3CB9F41E3B1CB4A8790D9159 /* GhosttyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC6FFB5185C403F6F44A1687 /* GhosttyManager.swift */; };
 		419DDD815048044125F5FE91 /* ReviewWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E982534C8CF6270BCF39106 /* ReviewWindow.swift */; };
+		456D76955277C3299291BF60 /* SyntaxHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8037A4E0001A21E3224DD798 /* SyntaxHighlighter.swift */; };
 		47BB527385B84454ABF8FC40 /* themes.json in Resources */ = {isa = PBXBuildFile; fileRef = 6860F8F626EFDB9A289FC727 /* themes.json */; };
 		4971664CE7FBF0629C8DD709 /* ReleaseNotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 407B3A9D15F4B9E613DA1CF8 /* ReleaseNotes.swift */; };
 		49DF8EE59313B7CFE29DA303 /* PaneTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E646AABA8ADCE8A2A5C6F55 /* PaneTreeView.swift */; };
@@ -59,6 +60,7 @@
 		F5AE37B67B17DD61B652E5B6 /* ReviewDiffParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CFFB91CE5C44976A6961F1F /* ReviewDiffParsingTests.swift */; };
 		F6AFF715FCE5357CEB07683D /* SettingsSafety.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB20921E3CAC1006A8FBD3AE /* SettingsSafety.swift */; };
 		F7ABF70CD455143BF89B89B3 /* SafeJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E2B9ADF809766CE4278047 /* SafeJSON.swift */; };
+		FAB0828152636BBBBC5989CD /* SyntaxHighlighterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FAD36B4BDB22AB47353C569 /* SyntaxHighlighterTests.swift */; };
 		FCB67525DF16A4DCF9B2AF7A /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 376568363043C189904E4E0A /* Localizable.xcstrings */; };
 		FE527C4220DD46528255F14E /* ModalOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11B3335E47DDAF77A883064 /* ModalOverlay.swift */; };
 		FEBC3158CB471E9ABDF931BB /* CodexUsageReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FBF22AEC81DBE92987A8CB4 /* CodexUsageReaderTests.swift */; };
@@ -97,6 +99,7 @@
 		38E3B385162995D0F1F5B72D /* CodexHome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexHome.swift; sourceTree = "<group>"; };
 		39F54835E4A44EC88236EFBE /* GitService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitService.swift; sourceTree = "<group>"; };
 		3E2E78BBA22734DD486C760B /* Glint.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Glint.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		3FAD36B4BDB22AB47353C569 /* SyntaxHighlighterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxHighlighterTests.swift; sourceTree = "<group>"; };
 		407B3A9D15F4B9E613DA1CF8 /* ReleaseNotes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseNotes.swift; sourceTree = "<group>"; };
 		41DDB9C7B5A277B7924270A3 /* PaneAgentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneAgentState.swift; sourceTree = "<group>"; };
 		4408F9761E584DE2AB6630E2 /* UpdaterController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdaterController.swift; sourceTree = "<group>"; };
@@ -112,6 +115,7 @@
 		712159D2C27AD5B865820384 /* WhatsNewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewView.swift; sourceTree = "<group>"; };
 		797C4E86D052EF8A68DD9B39 /* PaneSessionIdMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneSessionIdMigrationTests.swift; sourceTree = "<group>"; };
 		7CB74659D174004C620D538A /* GlintApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlintApp.swift; sourceTree = "<group>"; };
+		8037A4E0001A21E3224DD798 /* SyntaxHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxHighlighter.swift; sourceTree = "<group>"; };
 		81DADCF27E710CC77846E961 /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GhosttyKit.xcframework; path = Vendor/GhosttyKit.xcframework; sourceTree = "<group>"; };
 		829D894CF747D6BC08667239 /* AgentPaneSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentPaneSummary.swift; sourceTree = "<group>"; };
 		83E4DF4C5180D50C381B4976 /* WorkspaceIconKindTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceIconKindTests.swift; sourceTree = "<group>"; };
@@ -186,6 +190,7 @@
 				797C4E86D052EF8A68DD9B39 /* PaneSessionIdMigrationTests.swift */,
 				51DE2D7740BD03498A936B62 /* PersistenceRecoveryTests.swift */,
 				2CFFB91CE5C44976A6961F1F /* ReviewDiffParsingTests.swift */,
+				3FAD36B4BDB22AB47353C569 /* SyntaxHighlighterTests.swift */,
 				83E4DF4C5180D50C381B4976 /* WorkspaceIconKindTests.swift */,
 			);
 			path = GlintTests;
@@ -257,6 +262,7 @@
 			isa = PBXGroup;
 			children = (
 				9E982534C8CF6270BCF39106 /* ReviewWindow.swift */,
+				8037A4E0001A21E3224DD798 /* SyntaxHighlighter.swift */,
 			);
 			path = Review;
 			sourceTree = "<group>";
@@ -426,6 +432,7 @@
 				3194A1545E36E400BC2C33E6 /* PaneSessionIdMigrationTests.swift in Sources */,
 				E80809A987A07731FF35D01D /* PersistenceRecoveryTests.swift in Sources */,
 				F5AE37B67B17DD61B652E5B6 /* ReviewDiffParsingTests.swift in Sources */,
+				FAB0828152636BBBBC5989CD /* SyntaxHighlighterTests.swift in Sources */,
 				C748DE21F23B49B2FFD73DC7 /* WorkspaceIconKindTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -465,6 +472,7 @@
 				F6AFF715FCE5357CEB07683D /* SettingsSafety.swift in Sources */,
 				EF3ACBA990526130228FAD0B /* SettingsView.swift in Sources */,
 				CD30F5E1B78B3C46C9990FD6 /* SidebarView.swift in Sources */,
+				456D76955277C3299291BF60 /* SyntaxHighlighter.swift in Sources */,
 				7FC12666816053BEB64079CB /* Theme.swift in Sources */,
 				692D1A7D490E07D796535EAA /* UpdaterController.swift in Sources */,
 				D3D6CF13B67D30E9DA557F83 /* UsageStore.swift in Sources */,

--- a/Glint/Review/ReviewWindow.swift
+++ b/Glint/Review/ReviewWindow.swift
@@ -92,7 +92,10 @@ final class ReviewModel: ObservableObject {
         guard token == diffLoadToken else { return }
         // Parse off the main actor so a multi-thousand-line diff doesn't hitch
         // the UI; the result is cached so re-renders (splitter drags) don't reparse.
-        let doc = await Task.detached(priority: .userInitiated) { DiffDocument(text: text) }.value
+        let language = SyntaxLanguage.from(path: f.path)
+        let doc = await Task.detached(priority: .userInitiated) {
+            DiffDocument(text: text, language: language)
+        }.value
         guard token == diffLoadToken else { return }
         diffText = text
         diff = doc
@@ -585,6 +588,10 @@ struct DiffLine: Identifiable, Sendable {
     let id: Int
     let kind: Kind
     let text: String
+    /// Syntax-highlighted `text`. Token ranges carry `.foregroundColor`; the
+    /// rest is left unattributed so the row's base `.foregroundStyle` (the
+    /// add/del tint) still shows through on neutral text.
+    let attributed: AttributedString
     let oldNum: Int?
     let newNum: Int?
 }
@@ -603,8 +610,8 @@ struct DiffDocument: Sendable {
         self.lines = lines; self.oldWidth = oldWidth; self.newWidth = newWidth
     }
 
-    init(text: String) {
-        let parsed = Self.parse(text)
+    init(text: String, language: SyntaxLanguage? = nil) {
+        let parsed = Self.parse(text, language: language)
         // Size each gutter column to its widest number; drop a column that's
         // empty for the whole diff (pure additions hide the old column, etc.).
         let maxOld = parsed.compactMap(\.oldNum).max() ?? 0
@@ -621,10 +628,15 @@ struct DiffDocument: Sendable {
 
     /// Walk the unified diff, tracking old/new line numbers from each `@@` hunk
     /// header and dropping file-level meta lines.
-    static func parse(_ text: String) -> [DiffLine] {
+    static func parse(_ text: String, language: SyntaxLanguage? = nil) -> [DiffLine] {
         var out: [DiffLine] = []
         var oldLine = 0, newLine = 0
         var id = 0
+        // Syntax state carried across lines within a hunk so a block comment /
+        // triple string opened on an earlier line keeps tinting its body. Reset
+        // at each @@ header. ponytail: single stream — a deleted line inside an
+        // old-file block comment borrows the new-file state and may mis-tint.
+        var hlState = SyntaxHighlighter.State()
         // Normalize CRLF / lone CR to LF before splitting. Swift treats "\r\n" as
         // a single Character (extended grapheme cluster), so split(separator: "\n")
         // never matches it and silently merges every CRLF-terminated line into one
@@ -640,8 +652,10 @@ struct DiffDocument: Sendable {
             // the diff's final newline; real blank context lines are " ".
             if line.isEmpty { continue }
             if line.hasPrefix("@@") {
+                hlState = SyntaxHighlighter.State()   // new hunk → tint from a clean slate
                 (oldLine, newLine) = parseHunk(line)
-                out.append(DiffLine(id: id, kind: .hunk, text: line, oldNum: nil, newNum: nil)); id += 1
+                out.append(DiffLine(id: id, kind: .hunk, text: line,
+                                    attributed: AttributedString(line), oldNum: nil, newNum: nil)); id += 1
                 continue
             }
             if line.hasPrefix("+++") || line.hasPrefix("---")
@@ -657,13 +671,16 @@ struct DiffDocument: Sendable {
             // gutter clutter is gone — add/delete is shown via tint, not text.
             let body = String(line.dropFirst())
             if line.hasPrefix("+") {
-                out.append(DiffLine(id: id, kind: .add, text: body, oldNum: nil, newNum: newLine)); id += 1
+                let attr = SyntaxHighlighter.highlight(body, language: language, state: &hlState)
+                out.append(DiffLine(id: id, kind: .add, text: body, attributed: attr, oldNum: nil, newNum: newLine)); id += 1
                 newLine += 1
             } else if line.hasPrefix("-") {
-                out.append(DiffLine(id: id, kind: .del, text: body, oldNum: oldLine, newNum: nil)); id += 1
+                let attr = SyntaxHighlighter.highlight(body, language: language, state: &hlState)
+                out.append(DiffLine(id: id, kind: .del, text: body, attributed: attr, oldNum: oldLine, newNum: nil)); id += 1
                 oldLine += 1
             } else {
-                out.append(DiffLine(id: id, kind: .context, text: body, oldNum: oldLine, newNum: newLine)); id += 1
+                let attr = SyntaxHighlighter.highlight(body, language: language, state: &hlState)
+                out.append(DiffLine(id: id, kind: .context, text: body, attributed: attr, oldNum: oldLine, newNum: newLine)); id += 1
                 oldLine += 1; newLine += 1
             }
         }
@@ -734,7 +751,7 @@ private struct DiffContentView: View {
                 .frame(maxHeight: .infinity)
                 .background(c.gutter)
 
-                Text(line.text.isEmpty ? " " : line.text)
+                Text(line.text.isEmpty ? AttributedString(" ") : line.attributed)
                     .font(.system(size: 11.5, design: .monospaced))
                     .foregroundStyle(c.fg)
                     .textSelection(.enabled)

--- a/Glint/Review/SyntaxHighlighter.swift
+++ b/Glint/Review/SyntaxHighlighter.swift
@@ -1,0 +1,447 @@
+import Foundation
+import SwiftUI
+
+// MARK: - Language model
+
+/// A token-coloring profile for one language family — comment/string syntax
+/// plus a keyword set. Pure data, `Sendable`, so a `DiffDocument` can be
+/// parsed (and highlighted) off the main actor.
+///
+/// ponytail: this is token coloring, not a real grammar. It nails single-line
+/// constructs (keywords, strings, line/block comments, numbers, Capitalized
+/// types) and carries block-comment / triple-string state across lines within
+/// a hunk. Known ceilings: a multi-line construct opening above a hunk's first
+/// line isn't tracked, and deleted lines share the new-file state stream (a
+/// del line inside an old-file block comment may be mis-tinted). Both are
+/// low-salience for a read-only diff; upgrade to tree-sitter only if they bite.
+struct SyntaxLanguage: Sendable {
+    let lineComments: [String]                   // prefixes: "//", "#", "--"
+    let blockComment: (open: String, close: String)?
+    let tripleStrings: [String]                  // "\"\"\"", "'''"
+    let stringQuotes: [Character]                // single-char: " ' `
+    let escapes: Bool                            // honor backslash escapes inside strings
+    let keywords: Set<String>
+    /// Prose formats (markdown, plain text) set this false so stray digits in a
+    /// sentence ("see section 3") aren't tinted as numbers.
+    var highlightNumbers: Bool = true
+    /// Prose formats set this false so sentence-initial Capitalized words
+    /// ("The", "Here") aren't tinted as if they were type names.
+    var highlightTypes: Bool = true
+    /// Markdown fences a sub-language (```lang blocks); only the markdown
+    /// profile sets this, switching to that language's profile inside a fence.
+    var parsesFencedCode: Bool = false
+
+    /// Resolve a profile from a path's extension. nil for unknown → caller
+    /// colors strings + numbers only (no comment/keyword tinting), so nothing
+    /// is ever wrongly colored on a language we don't know.
+    static func from(path: String) -> SyntaxLanguage? {
+        let ext = (path as NSString).pathExtension.lowercased()
+        return table[ext]
+    }
+
+    /// Resolve a profile from a Markdown fence info string or language name
+    /// (e.g. "java", "javascript", "ts"). Takes the first word. nil if not
+    /// recognized → caller falls back to generic (strings + numbers).
+    static func from(languageName: String) -> SyntaxLanguage? {
+        guard let word = languageName.lowercased()
+            .split(separator: " ", omittingEmptySubsequences: true).first else { return nil }
+        let key = String(word)
+        return table[key] ?? fenceAliases[key]
+    }
+
+    private static let table: [String: SyntaxLanguage] = {
+        var t: [String: SyntaxLanguage] = [:]
+        for (exts, lang) in all { for e in exts { t[e] = lang } }
+        return t
+    }()
+
+    private static let all: [([String], SyntaxLanguage)] = [
+        (["swift"], swift),
+        (["c", "h", "m", "mm", "cc", "cpp", "cxx", "c++", "hpp", "hxx", "hh",
+          "java", "js", "mjs", "cjs", "jsx", "ts", "tsx", "cs", "kt", "kts",
+          "scala", "dart", "php"], cLike),
+        (["go", "golang"], go),
+        (["rs", "rust"], rust),
+        (["py", "pyi", "python", "rb", "ruby", "sh", "bash", "zsh", "fish",
+          "yaml", "yml", "toml", "ini", "cfg", "conf", "properties", "cmake",
+          "mk", "make", "dockerfile"], script),
+        (["sql"], sql),
+        // Prose: don't treat ' / " as strings (apostrophes in English would
+        // otherwise gulp whole sentences). Markdown tints only inline `code`.
+        (["md", "markdown", "mdx"], markdown),
+        (["txt", "text", "rst", "log", "csv", "tsv"], plain),
+    ]
+
+    // MARK: profiles
+
+    private static let blockC = (open: "/*", close: "*/")
+
+    private static let cLike = SyntaxLanguage(
+        lineComments: ["//"], blockComment: blockC, tripleStrings: [],
+        stringQuotes: ["\"", "'"], escapes: true,
+        keywords: [
+            // C / C++ / ObjC / Java / JS / TS / C# / Kotlin shared core.
+            "abstract", "as", "async", "await", "boolean", "break", "byte",
+            "case", "catch", "char", "class", "const", "continue", "default",
+            "delete", "do", "double", "else", "enum", "extends", "extern",
+            "final", "finally", "float", "for", "friend", "function", "goto",
+            "if", "implements", "import", "in", "inline", "instanceof", "int",
+            "interface", "let", "long", "namespace", "native", "new", "nil",
+            "nullptr", "operator", "override", "package", "private", "protected",
+            "public", "register", "restrict", "return", "short", "signed",
+            "sizeof", "static", "struct", "super", "switch", "synchronized",
+            "template", "this", "throw", "throws", "transient", "try", "typedef",
+            "typename", "typeof", "union", "unsigned", "using", "var", "virtual",
+            "void", "volatile", "while", "yield", "true", "false", "NULL",
+            "record", "sealed", "readonly", "partial", "get", "set", "value",
+            "dynamic", "alias", "type",
+        ])
+
+    private static let swift = SyntaxLanguage(
+        lineComments: ["//"], blockComment: blockC, tripleStrings: ["\"\"\""],
+        stringQuotes: ["\""], escapes: true,
+        keywords: [
+            "func", "let", "var", "if", "else", "guard", "for", "while", "switch",
+            "case", "default", "return", "struct", "class", "enum", "protocol",
+            "extension", "import", "init", "deinit", "self", "Self", "super",
+            "nil", "true", "false", "public", "private", "internal", "fileprivate",
+            "open", "package", "static", "final", "throw", "throws", "rethrows",
+            "try", "catch", "defer", "where", "as", "is", "in", "override",
+            "convenience", "required", "mutating", "nonmutating", "lazy",
+            "subscript", "operator", "associatedtype", "typealias", "weak",
+            "unowned", "repeat", "break", "continue", "fallthrough", "async",
+            "await", "some", "any", "actor", "distributed", "didSet", "willSet",
+            "get", "set", "indirect", "consuming", "borrowing", "macro",
+        ])
+
+    private static let go = SyntaxLanguage(
+        lineComments: ["//"], blockComment: blockC, tripleStrings: [],
+        stringQuotes: ["\"", "'", "`"], escapes: true,
+        keywords: [
+            "break", "case", "chan", "const", "continue", "default", "defer",
+            "else", "fallthrough", "for", "func", "go", "goto", "if", "import",
+            "interface", "map", "package", "range", "return", "select", "struct",
+            "switch", "type", "var", "nil", "true", "false", "iota",
+        ])
+
+    private static let rust = SyntaxLanguage(
+        lineComments: ["//"], blockComment: blockC, tripleStrings: [],
+        stringQuotes: ["\""], escapes: true,
+        keywords: [
+            "as", "async", "await", "break", "const", "continue", "crate", "dyn",
+            "else", "enum", "extern", "false", "fn", "for", "if", "impl", "in",
+            "let", "loop", "match", "mod", "move", "mut", "pub", "ref", "return",
+            "self", "Self", "static", "struct", "super", "trait", "true", "type",
+            "unsafe", "use", "where", "while", "Some", "None", "Ok", "Err",
+        ])
+
+    private static let script = SyntaxLanguage(
+        lineComments: ["#"], blockComment: nil,
+        tripleStrings: ["\"\"\"", "'''"], stringQuotes: ["\"", "'"], escapes: true,
+        keywords: [
+            // Python / Ruby / shell common.
+            "def", "class", "if", "elif", "else", "for", "while", "return",
+            "import", "from", "as", "pass", "break", "continue", "in", "is",
+            "not", "and", "or", "with", "try", "except", "finally", "raise",
+            "yield", "lambda", "global", "nonlocal", "assert", "del", "True",
+            "False", "None", "self", "end", "do", "then", "begin", "case",
+            "when", "until", "unless", "function", "echo", "export", "local",
+            "source", "unset", "set", "alias",
+        ])
+
+    private static let sql = SyntaxLanguage(
+        lineComments: ["--"], blockComment: blockC, tripleStrings: [],
+        stringQuotes: ["'", "\""], escapes: false,
+        keywords: [
+            "SELECT", "FROM", "WHERE", "INSERT", "INTO", "VALUES", "UPDATE",
+            "SET", "DELETE", "CREATE", "TABLE", "DROP", "ALTER", "ADD", "JOIN",
+            "LEFT", "RIGHT", "INNER", "OUTER", "ON", "AS", "AND", "OR", "NOT",
+            "NULL", "IS", "IN", "LIKE", "BETWEEN", "ORDER", "BY", "GROUP",
+            "HAVING", "LIMIT", "OFFSET", "DISTINCT", "UNION", "INDEX", "PRIMARY",
+            "KEY", "FOREIGN", "REFERENCES", "DEFAULT", "CONSTRAINT", "UNIQUE",
+            "CHECK", "CASE", "WHEN", "THEN", "ELSE", "END", "BEGIN", "COMMIT",
+            "ROLLBACK", "TRUE", "FALSE",
+        ])
+
+    /// Markdown: only backtick inline `code` and fenced code blocks are tinted;
+    /// prose (including apostrophes like "it's") is left alone, and `#`
+    /// headers aren't comments.
+    private static let markdown = SyntaxLanguage(
+        lineComments: [], blockComment: nil, tripleStrings: [],
+        stringQuotes: ["`"], escapes: false, keywords: [],
+        highlightNumbers: false, highlightTypes: false, parsesFencedCode: true)
+
+    /// Plain text: tint nothing.
+    private static let plain = SyntaxLanguage(
+        lineComments: [], blockComment: nil, tripleStrings: [],
+        stringQuotes: [], escapes: false, keywords: [],
+        highlightNumbers: false, highlightTypes: false)
+
+    /// Fence info-string aliases not already covered by the extension table
+    /// (java / py / ts / ... resolve via `table`). For ```lang code blocks.
+    private static let fenceAliases: [String: SyntaxLanguage] = [
+        "javascript": cLike, "typescript": cLike,
+        "csharp": cLike, "kotlin": cLike,
+        "objc": cLike, "objective-c": cLike, "objectivec": cLike,
+        "shell": script, "console": script, "terminal": script,
+        "text": plain, "plaintext": plain,
+    ]
+
+    /// Unknown-extension profile: strings + numbers only. No comment or
+    /// keyword tinting, so it never colors anything wrongly.
+    fileprivate static let generic = SyntaxLanguage(
+        lineComments: [], blockComment: nil, tripleStrings: [],
+        stringQuotes: ["\"", "'"], escapes: true, keywords: [])
+}
+
+// MARK: - Tokenizer
+
+enum SyntaxHighlighter {
+    /// Cross-line state carried between lines within one hunk so a block
+    /// comment / triple-quoted string opened on an earlier line keeps tinting
+    /// its continuation lines. Reset at each `@@` hunk header by the caller.
+    struct State: Sendable {
+        var inBlockComment = false
+        var inTriple: String? = nil
+        /// Non-nil while inside a Markdown ``` / ~~~ fenced code block; lines
+        /// are then tinted with `lang`'s profile instead of markdown prose.
+        struct Fence: Sendable { let lang: SyntaxLanguage; let char: Character }
+        var fence: Fence? = nil
+    }
+
+    /// Color `line`'s tokens into an `AttributedString`. Token ranges carry a
+    /// `.foregroundColor` attribute; everything else is left unattributed so
+    /// the caller's base `.foregroundStyle` shows through (keeps the row's
+    /// add/delete tint on neutral text).
+    static func highlight(_ line: String, language: SyntaxLanguage?, state: inout State) -> AttributedString {
+        let lang = language ?? .generic
+        if lang.parsesFencedCode {
+            return scanMarkdown(line, markdown: lang, state: &state)
+        }
+        return scan(Array(line), lang: lang, state: &state)
+    }
+
+    // MARK: Markdown fence handling
+
+    private static func scanMarkdown(_ line: String, markdown: SyntaxLanguage, state: inout State) -> AttributedString {
+        let trimmed = line.drop(while: { $0 == " " || $0 == "\t" })
+
+        // Closing fence (only meaningful inside one): same char, nothing after.
+        if state.fence != nil, let m = fenceMarker(trimmed), m.char == state.fence?.char, m.rest.isEmpty {
+            state.fence = nil
+            state.inBlockComment = false; state.inTriple = nil
+            return tinted(line, Theme.text3)
+        }
+        // Opening fence: 3+ backticks/tildes; the info string names the lang.
+        if state.fence == nil, let m = fenceMarker(trimmed) {
+            state.fence = State.Fence(lang: resolveFenceLang(m.rest), char: m.char)
+            state.inBlockComment = false; state.inTriple = nil
+            return tinted(line, Theme.text3)
+        }
+        // Inside a fence: tint with the fenced language's profile.
+        if let f = state.fence {
+            return scan(Array(line), lang: f.lang, state: &state)
+        }
+        // Markdown prose — only inline `code` tints.
+        return scan(Array(line), lang: markdown, state: &state)
+    }
+
+    private struct Marker { let char: Character; let rest: String }
+
+    /// `s` begins with 3+ backticks or tildes → marker char + the trailing
+    /// info string (e.g. "java"). ` ```java ` → ('`', "java"). nil otherwise.
+    private static func fenceMarker(_ s: Substring) -> Marker? {
+        guard let first = s.first, first == "`" || first == "~" else { return nil }
+        var idx = s.startIndex
+        while idx < s.endIndex && s[idx] == first { idx = s.index(after: idx) }
+        guard s.distance(from: s.startIndex, to: idx) >= 3 else { return nil }
+        let rest = String(s[idx...]).trimmingCharacters(in: .whitespaces)
+        return Marker(char: first, rest: rest)
+    }
+
+    /// Resolve a fence info string (e.g. "java", "javascript") to a profile,
+    /// falling back to generic (strings + numbers) if unrecognized.
+    private static func resolveFenceLang(_ info: String) -> SyntaxLanguage {
+        SyntaxLanguage.from(languageName: info) ?? .generic
+    }
+
+    private static func tinted(_ line: String, _ color: Color) -> AttributedString {
+        var s = AttributedString(line)
+        s.foregroundColor = color
+        return s
+    }
+
+    // ASCII-scoped class checks. Code tokens are ASCII; using Character's
+    // Unicode-aware isNumber/isLetter/isUppercase would let non-ASCII digits
+    // (½, fullwidth １) and letters (Δ, É) start or over-extend tinted runs.
+    @inline(__always) private static func isDigit(_ c: Character) -> Bool { c >= "0" && c <= "9" }
+    @inline(__always) private static func isLetter(_ c: Character) -> Bool {
+        (c >= "a" && c <= "z") || (c >= "A" && c <= "Z")
+    }
+    @inline(__always) private static func isUpper(_ c: Character) -> Bool { c >= "A" && c <= "Z" }
+
+    private static func scan(_ a: [Character], lang: SyntaxLanguage, state: inout State) -> AttributedString {
+        let n = a.count
+        var i = 0
+        var runs: [(String, Color?)] = []
+
+        let linePrefixes = lang.lineComments.map { Array($0) }
+        let blockOpen = lang.blockComment.map { Array($0.0) }
+        let blockClose = lang.blockComment.map { Array($0.1) }
+        let triples = lang.tripleStrings.map { Array($0) }
+        let quotes = Set(lang.stringQuotes)
+        let keywords = lang.keywords
+
+        @inline(__always)
+        func match(_ pre: [Character], _ t: Int) -> Bool {
+            guard t + pre.count <= n else { return false }
+            for k in 0..<pre.count where a[t + k] != pre[k] { return false }
+            return true
+        }
+        func find(_ needle: [Character], from t: Int) -> Int? {
+            let m = needle.count
+            guard m > 0 else { return nil }
+            var j = t
+            while j + m <= n {
+                var ok = true
+                for k in 0..<m where a[j + k] != needle[k] { ok = false; break }
+                if ok { return j }
+                j += 1
+            }
+            return nil
+        }
+        func slice(_ lo: Int, _ hi: Int) -> String { String(a[lo..<hi]) }
+
+        // Entering mid-construct from a previous line: finish it first.
+        if state.inBlockComment, let close = blockClose {
+            if let c = find(close, from: i) {
+                let e = c + close.count
+                runs.append((slice(i, e), Theme.text3))
+                i = e
+                state.inBlockComment = false
+            } else {
+                runs.append((slice(i, n), Theme.text3))
+                return build(runs)
+            }
+        }
+        if let triple = state.inTriple {
+            let needle = Array(triple)
+            if let c = find(needle, from: i) {
+                let e = c + needle.count
+                runs.append((slice(i, e), Theme.green))
+                i = e
+                state.inTriple = nil
+            } else {
+                runs.append((slice(i, n), Theme.green))
+                return build(runs)
+            }
+        }
+
+        while i < n {
+            let c = a[i]
+
+            // Line comment → rest of line.
+            if linePrefixes.contains(where: { match($0, i) }) {
+                runs.append((slice(i, n), Theme.text3))
+                break
+            }
+
+            // Block comment (may run past EOL → carry state).
+            if let open_ = blockOpen, match(open_, i) {
+                if let close = blockClose, let c = find(close, from: i + open_.count) {
+                    let e = c + close.count
+                    runs.append((slice(i, e), Theme.text3))
+                    i = e
+                } else {
+                    runs.append((slice(i, n), Theme.text3))
+                    state.inBlockComment = true
+                    break
+                }
+                continue
+            }
+
+            // Triple-quoted string (may run past EOL → carry state).
+            if let t = triples.first(where: { match($0, i) }) {
+                if let c = find(t, from: i + t.count) {
+                    let e = c + t.count
+                    runs.append((slice(i, e), Theme.green))
+                    i = e
+                } else {
+                    runs.append((slice(i, n), Theme.green))
+                    state.inTriple = String(t)
+                    break
+                }
+                continue
+            }
+
+            // Single-quoted string (unterminated → tint to EOL, no state).
+            if quotes.contains(c) {
+                var j = i + 1
+                while j < n {
+                    if lang.escapes && a[j] == "\\" { j += 2; continue }
+                    if a[j] == c { j += 1; break }
+                    j += 1
+                }
+                runs.append((slice(i, min(j, n)), Theme.green))
+                i = min(j, n)
+                continue
+            }
+
+            // Number (loose: digits + hex/exp/suffix letters + ._).
+            if lang.highlightNumbers && (isDigit(c) || (c == "." && i + 1 < n && isDigit(a[i + 1]))) {
+                var j = i + 1
+                while j < n {
+                    let d = a[j]
+                    if isLetter(d) || isDigit(d) || d == "." || d == "_" { j += 1 } else { break }
+                }
+                runs.append((slice(i, j), Theme.orange))
+                i = j
+                continue
+            }
+
+            // Identifier / keyword / Type.
+            if isLetter(c) || c == "_" {
+                var j = i + 1
+                while j < n {
+                    let d = a[j]
+                    if isLetter(d) || isDigit(d) || d == "_" { j += 1 } else { break }
+                }
+                let word = slice(i, j)
+                if keywords.contains(word) {
+                    runs.append((word, Theme.accentBright))
+                } else if lang.highlightTypes && isUpper(c) {
+                    runs.append((word, Theme.cyan))
+                } else {
+                    runs.append((word, nil))
+                }
+                i = j
+                continue
+            }
+
+            runs.append((slice(i, i + 1), nil))
+            i += 1
+        }
+
+        return build(runs)
+    }
+
+    /// Fold runs into one `AttributedString`, coalescing adjacent uncolored
+    /// runs so a line of plain punctuation isn't a hundred tiny appends.
+    private static func build(_ runs: [(String, Color?)]) -> AttributedString {
+        var out = AttributedString()
+        var pending = ""
+        for (text, color) in runs {
+            guard !text.isEmpty else { continue }
+            if let color {
+                if !pending.isEmpty { out += AttributedString(pending); pending = "" }
+                var s = AttributedString(text)
+                s.foregroundColor = color
+                out += s
+            } else {
+                pending += text
+            }
+        }
+        if !pending.isEmpty { out += AttributedString(pending) }
+        return out
+    }
+}

--- a/Glint/Review/SyntaxHighlighter.swift
+++ b/Glint/Review/SyntaxHighlighter.swift
@@ -64,11 +64,13 @@ struct SyntaxLanguage: Sendable {
         (["rs", "rust"], rust),
         (["py", "pyi", "python", "rb", "ruby", "sh", "bash", "zsh", "fish",
           "cmake", "mk", "make"], script),
-        // Config/data formats: `#` comments + strings + numbers, but NO
-        // keywords and NO type tinting — YAML `if:`/`do:` keys and Capitalized
-        // values must not be tinted as code.
-        (["yaml", "yml", "toml", "ini", "cfg", "conf", "properties",
-          "dockerfile"], config),
+        // YAML is fully uncolored (plain) — its keys/values read as data, and
+        // any token coloring (keywords, types, even strings/numbers) reads as
+        // noise on a config diff.
+        (["yaml", "yml"], plain),
+        // Other config/data formats: `#` comments + strings + numbers, but no
+        // keywords and no type tinting.
+        (["toml", "ini", "cfg", "conf", "properties", "dockerfile"], config),
         (["sql"], sql),
         // Prose: don't treat ' / " as strings (apostrophes in English would
         // otherwise gulp whole sentences). Markdown tints only inline `code`.

--- a/Glint/Review/SyntaxHighlighter.swift
+++ b/Glint/Review/SyntaxHighlighter.swift
@@ -30,6 +30,10 @@ struct SyntaxLanguage: Sendable {
     /// Markdown fences a sub-language (```lang blocks); only the markdown
     /// profile sets this, switching to that language's profile inside a fence.
     var parsesFencedCode: Bool = false
+    /// SQL keywords are conventionally written either UPPER or lower; match
+    /// without regard to case. The `keywords` set is then expected to hold
+    /// one canonical casing (uppercase, by SQL convention).
+    var caseInsensitiveKeywords: Bool = false
 
     /// Resolve a profile from a path's extension. nil for unknown → caller
     /// colors strings + numbers only (no comment/keyword tinting), so nothing
@@ -175,7 +179,7 @@ struct SyntaxLanguage: Sendable {
             "KEY", "FOREIGN", "REFERENCES", "DEFAULT", "CONSTRAINT", "UNIQUE",
             "CHECK", "CASE", "WHEN", "THEN", "ELSE", "END", "BEGIN", "COMMIT",
             "ROLLBACK", "TRUE", "FALSE",
-        ])
+        ], caseInsensitiveKeywords: true)
 
     /// Markdown: only backtick inline `code` and fenced code blocks are tinted;
     /// prose (including apostrophes like "it's") is left alone, and `#`
@@ -421,7 +425,10 @@ enum SyntaxHighlighter {
                     if isLetter(d) || isDigit(d) || d == "_" { j += 1 } else { break }
                 }
                 let word = slice(i, j)
-                if keywords.contains(word) {
+                let hit = lang.caseInsensitiveKeywords
+                    ? keywords.contains(word.uppercased())
+                    : keywords.contains(word)
+                if hit {
                     runs.append((word, Theme.accentBright))
                 } else if lang.highlightTypes && isUpper(c) {
                     runs.append((word, Theme.cyan))

--- a/Glint/Review/SyntaxHighlighter.swift
+++ b/Glint/Review/SyntaxHighlighter.swift
@@ -63,8 +63,12 @@ struct SyntaxLanguage: Sendable {
         (["go", "golang"], go),
         (["rs", "rust"], rust),
         (["py", "pyi", "python", "rb", "ruby", "sh", "bash", "zsh", "fish",
-          "yaml", "yml", "toml", "ini", "cfg", "conf", "properties", "cmake",
-          "mk", "make", "dockerfile"], script),
+          "cmake", "mk", "make"], script),
+        // Config/data formats: `#` comments + strings + numbers, but NO
+        // keywords and NO type tinting — YAML `if:`/`do:` keys and Capitalized
+        // values must not be tinted as code.
+        (["yaml", "yml", "toml", "ini", "cfg", "conf", "properties",
+          "dockerfile"], config),
         (["sql"], sql),
         // Prose: don't treat ' / " as strings (apostrophes in English would
         // otherwise gulp whole sentences). Markdown tints only inline `code`.
@@ -148,6 +152,14 @@ struct SyntaxLanguage: Sendable {
             "when", "until", "unless", "function", "echo", "export", "local",
             "source", "unset", "set", "alias",
         ])
+
+    /// Config/data formats (YAML, TOML, INI, …): `#` comments, strings, and
+    /// numbers only. No keyword set and no type tinting, so keys like `if:`/
+    /// `do:` and Capitalized values aren't tinted as code.
+    private static let config = SyntaxLanguage(
+        lineComments: ["#"], blockComment: nil, tripleStrings: [],
+        stringQuotes: ["\"", "'"], escapes: true, keywords: [],
+        highlightTypes: false)
 
     private static let sql = SyntaxLanguage(
         lineComments: ["--"], blockComment: blockC, tripleStrings: [],

--- a/GlintTests/SyntaxHighlighterTests.swift
+++ b/GlintTests/SyntaxHighlighterTests.swift
@@ -99,19 +99,21 @@ final class SyntaxHighlighterTests: XCTestCase {
         XCTAssertFalse(segments(attr).contains { $0.1 })
     }
 
-    /// Config formats (YAML/…) have no keywords and no type tinting: a key like
-    /// `if:` and a Capitalized value must not be tinted, while strings are.
-    /// Regression guard for the YAML-over-coloring bug.
-    func testConfigFormatDoesNotTintKeysOrTypes() {
-        let yaml = SyntaxLanguage.from(path: "f.yaml")
-        var state = SyntaxHighlighter.State()
-        let a = SyntaxHighlighter.highlight("if: runner == 'ubuntu'", language: yaml, state: &state)
-        let segs = segments(a)
-        XCTAssertFalse(segs.contains { $0.1 && $0.0.contains("if") })      // key not a keyword
-        XCTAssertTrue(segs.contains { $0.1 && $0.0.contains("ubuntu") })   // string tinted
-
+    /// TOML/INI (config) tint strings but not keys or Capitalized values;
+    /// YAML is fully uncolored (plain) — strings, numbers, comments all base.
+    func testConfigAndYAMLProfiles() {
+        let toml = SyntaxLanguage.from(path: "f.toml")
+        var s = SyntaxHighlighter.State()
+        let a = SyntaxHighlighter.highlight("if: runner == 'ubuntu'", language: toml, state: &s)
+        XCTAssertFalse(segments(a).contains { $0.1 && $0.0.contains("if") })      // key not a keyword
+        XCTAssertTrue(segments(a).contains { $0.1 && $0.0.contains("ubuntu") })   // string tinted
         var s2 = SyntaxHighlighter.State()
-        let b = SyntaxHighlighter.highlight("name: Ubuntu", language: yaml, state: &s2)
+        let b = SyntaxHighlighter.highlight("name: Ubuntu", language: toml, state: &s2)
         XCTAssertFalse(segments(b).contains { $0.1 && $0.0.contains("Ubuntu") })  // Capitalized value not a type
+
+        let yaml = SyntaxLanguage.from(path: "f.yaml")
+        var s3 = SyntaxHighlighter.State()
+        let c = SyntaxHighlighter.highlight("if: runner == 'ubuntu' # note", language: yaml, state: &s3)
+        XCTAssertTrue(segments(c).allSatisfy { !$0.1 })                           // YAML: nothing tinted
     }
 }

--- a/GlintTests/SyntaxHighlighterTests.swift
+++ b/GlintTests/SyntaxHighlighterTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+@testable import Glint
+
+/// Pure-logic guards for the diff-view tokenizer in `SyntaxHighlighter.swift`.
+/// It's a mini char-scanner with cross-line state, so the highest-value checks
+/// are: keywords/strings get tinted while plain identifiers don't, block-comment
+/// state carries across lines within a hunk, and unknown extensions never tint
+/// code as comments/keywords (strings only — never wrongly colored).
+final class SyntaxHighlighterTests: XCTestCase {
+
+    /// (substring, is-color-present) per run — lets assertions talk about which
+    /// text got tinted without pinning exact Theme colors (those can move).
+    private func segments(_ s: AttributedString) -> [(String, Bool)] {
+        s.runs.map { (String(s.characters[$0.range]), $0.foregroundColor != nil) }
+    }
+
+    /// A Swift line: `let` (keyword) and the string literal are tinted; `name`
+    /// (plain lowercase identifier) is not.
+    func testColorsKeywordAndStringNotPlainIdentifier() {
+        var state = SyntaxHighlighter.State()
+        let attr = SyntaxHighlighter.highlight(#"let name = "Glint""#,
+                                                language: SyntaxLanguage.from(path: "f.swift"),
+                                                state: &state)
+        let segs = segments(attr)
+        XCTAssertTrue(segs.contains { $0.1 && $0.0 == "let" })              // keyword tinted
+        XCTAssertTrue(segs.contains { $0.1 && $0.0.contains("Glint") })    // string tinted
+        XCTAssertTrue(segs.contains { !$0.1 && $0.0.contains("name") })    // plain ident left base
+        XCTAssertFalse(segs.contains { $0.1 && $0.0.contains("name") })    // …not wrongly tinted
+    }
+
+    /// A block comment opened on one line keeps tinting the next line via the
+    /// carried `State`, and stays open when the closer is absent.
+    func testBlockCommentCarriesAcrossLines() {
+        let lang = SyntaxLanguage.from(path: "f.swift")
+        var state = SyntaxHighlighter.State()
+        SyntaxHighlighter.highlight("/* opening comment", language: lang, state: &state)
+        XCTAssertTrue(state.inBlockComment)
+
+        let second = SyntaxHighlighter.highlight("still inside the block", language: lang, state: &state)
+        let segs = segments(second)
+        XCTAssertEqual(segs.count, 1)                          // whole line is one run
+        XCTAssertEqual(segs[0].0, "still inside the block")
+        XCTAssertTrue(segs[0].1)                              // …and it's tinted
+        XCTAssertTrue(state.inBlockComment)                   // still no closer
+    }
+
+    /// Unknown extension (nil language) tints strings but never code as
+    /// comments or keywords — so a language we don't know can't be mis-tinted.
+    func testUnknownLanguageTintsStringsOnly() {
+        var state = SyntaxHighlighter.State()
+        let attr = SyntaxHighlighter.highlight(#"x = "y""#, language: nil, state: &state)
+        let segs = segments(attr)
+        XCTAssertTrue(segs.contains { !$0.1 && $0.0.contains("x") })      // plain ident, base
+        XCTAssertTrue(segs.contains { $0.1 && $0.0.contains("y") })       // string tinted
+        XCTAssertFalse(state.inBlockComment)                              // no block comment parsing
+    }
+
+    /// Markdown tints only backtick inline code; prose must NOT be tinted —
+    /// not apostrophe'd words, and crucially not sentence-initial Capitalized
+    /// words ("Here", "The"), which the type-coloring rule would otherwise
+    /// catch. Regression guard for the .md-over-coloring bug.
+    func testMarkdownColorsInlineCodeNotProse() {
+        var state = SyntaxHighlighter.State()
+        let attr = SyntaxHighlighter.highlight("Here's prose, see `code` now",
+                                                language: SyntaxLanguage.from(path: "f.md"),
+                                                state: &state)
+        let segs = segments(attr)
+        XCTAssertTrue(segs.contains { $0.1 && $0.0.contains("code") })    // inline code tinted
+        XCTAssertFalse(segs.contains { $0.1 && $0.0.contains("prose") })  // lowercase prose not tinted
+        XCTAssertFalse(segs.contains { $0.1 && $0.0.contains("Here") })   // Capitalized prose not tinted
+    }
+
+    /// A ```lang fenced block switches to that language's profile for its
+    /// body lines, then returns to prose on the closing fence.
+    func testMarkdownFencedCodeBlockUsesFencedLanguage() {
+        let md = SyntaxLanguage.from(path: "f.md")
+        var state = SyntaxHighlighter.State()
+        _ = SyntaxHighlighter.highlight("```java", language: md, state: &state)
+        XCTAssertNotNil(state.fence)                                       // entered a java fence
+        let code = SyntaxHighlighter.highlight("public class Foo {", language: md, state: &state)
+        let segs = segments(code)
+        XCTAssertTrue(segs.contains { $0.1 && $0.0 == "public" })          // java keyword tinted
+        XCTAssertTrue(segs.contains { $0.1 && $0.0 == "class" })
+        _ = SyntaxHighlighter.highlight("```", language: md, state: &state)
+        XCTAssertNil(state.fence)                                          // fence closed
+        // After closing, a Capitalized prose word is NOT tinted (back to prose).
+        let after = SyntaxHighlighter.highlight("Back to prose now", language: md, state: &state)
+        XCTAssertFalse(segments(after).contains { $0.1 && $0.0.contains("Back") })
+    }
+
+    /// ASCII scoping: non-ASCII letters/digits (Greek-uppercase Δ, fraction ½)
+    /// must NOT start tinted runs. Character.isLetter/isNumber/isUppercase are
+    /// Unicode-aware and would otherwise mis-tokenize code identifiers.
+    func testASCIIScopedTokenization() {
+        var state = SyntaxHighlighter.State()
+        let attr = SyntaxHighlighter.highlight("Δfoo ½bar",
+                                                language: SyntaxLanguage.from(path: "f.swift"),
+                                                state: &state)
+        XCTAssertFalse(segments(attr).contains { $0.1 })
+    }
+}

--- a/GlintTests/SyntaxHighlighterTests.swift
+++ b/GlintTests/SyntaxHighlighterTests.swift
@@ -99,6 +99,26 @@ final class SyntaxHighlighterTests: XCTestCase {
         XCTAssertFalse(segments(attr).contains { $0.1 })
     }
 
+    /// SQL keywords are conventionally written either UPPER or lower; both
+    /// must tint. Without case-insensitive lookup, a modern lowercase-style
+    /// SQL file would have zero keywords highlighted.
+    func testSQLKeywordsCaseInsensitive() {
+        let sql = SyntaxLanguage.from(path: "f.sql")
+        var s1 = SyntaxHighlighter.State()
+        let upper = SyntaxHighlighter.highlight("SELECT id FROM users WHERE active",
+                                                language: sql, state: &s1)
+        XCTAssertTrue(segments(upper).contains { $0.1 && $0.0 == "SELECT" })
+        XCTAssertTrue(segments(upper).contains { $0.1 && $0.0 == "FROM" })
+        XCTAssertTrue(segments(upper).contains { $0.1 && $0.0 == "WHERE" })
+
+        var s2 = SyntaxHighlighter.State()
+        let lower = SyntaxHighlighter.highlight("select id from users where active",
+                                                language: sql, state: &s2)
+        XCTAssertTrue(segments(lower).contains { $0.1 && $0.0 == "select" })
+        XCTAssertTrue(segments(lower).contains { $0.1 && $0.0 == "from" })
+        XCTAssertTrue(segments(lower).contains { $0.1 && $0.0 == "where" })
+    }
+
     /// TOML/INI (config) tint strings but not keys or Capitalized values;
     /// YAML is fully uncolored (plain) — strings, numbers, comments all base.
     func testConfigAndYAMLProfiles() {

--- a/GlintTests/SyntaxHighlighterTests.swift
+++ b/GlintTests/SyntaxHighlighterTests.swift
@@ -98,4 +98,20 @@ final class SyntaxHighlighterTests: XCTestCase {
                                                 state: &state)
         XCTAssertFalse(segments(attr).contains { $0.1 })
     }
+
+    /// Config formats (YAML/…) have no keywords and no type tinting: a key like
+    /// `if:` and a Capitalized value must not be tinted, while strings are.
+    /// Regression guard for the YAML-over-coloring bug.
+    func testConfigFormatDoesNotTintKeysOrTypes() {
+        let yaml = SyntaxLanguage.from(path: "f.yaml")
+        var state = SyntaxHighlighter.State()
+        let a = SyntaxHighlighter.highlight("if: runner == 'ubuntu'", language: yaml, state: &state)
+        let segs = segments(a)
+        XCTAssertFalse(segs.contains { $0.1 && $0.0.contains("if") })      // key not a keyword
+        XCTAssertTrue(segs.contains { $0.1 && $0.0.contains("ubuntu") })   // string tinted
+
+        var s2 = SyntaxHighlighter.State()
+        let b = SyntaxHighlighter.highlight("name: Ubuntu", language: yaml, state: &s2)
+        XCTAssertFalse(segments(b).contains { $0.1 && $0.0.contains("Ubuntu") })  // Capitalized value not a type
+    }
 }


### PR DESCRIPTION
## What & why

The Review diff pane rendered every code line in a single neutral color. This adds lightweight, dependency-free syntax highlighting so changed code reads like code while reviewing — keywords, strings, comments, numbers, and types tint per language, in **both the unified and the new split** diff views. The add/delete row tint and line-number gutter are preserved.

## How

- **New `Glint/Review/SyntaxHighlighter.swift`** — a pure-Swift, zero-resident-allocation line tokenizer. A `SyntaxLanguage` profile is resolved from the file extension:
  - **Code**: Swift, C-family (C/C++/ObjC/Java/JS/TS/C#/Kotlin/…), Go, Rust, shell-family (Python/Ruby/shell), SQL.
  - **Markdown**: tints only inline `` `code` `` and ```` ```lang ```` fenced blocks (the fenced language's profile is used inside); prose is left untouched.
  - **Config/data** (TOML/INI/conf/properties/Dockerfile): `#` comments + strings + numbers, no keyword/type tinting. **YAML is fully uncolored** — its keys/values read as data and any tinting reads as noise.
  - Unknown extensions tint strings + numbers only, so a language we don't recognize is never wrongly colored.
- Tokenization runs **off-main, once per file load**, alongside `DiffDocument.parse`, and is cached — re-renders never reparse. Block-comment / triple-string / fence state is carried across lines within a hunk and reset at each `@@` header.
- `DiffLine` gains an `AttributedString`; both the unified row and the split-view cell render `Text(line.attributed)`. Token ranges carry `.foregroundColor`; everything else falls through to the row's base `.foregroundStyle`, so the add/delete tint still shows on neutral text. Colors reuse the existing `Theme` palette; tokenization is ASCII-scoped.

**Known ceilings (acceptable for a read-only diff; upgrade path = tree-sitter):** a multi-line construct opening above a hunk's first line isn't tracked; deleted lines share the new-file state stream.

## Testing / verification

- arm64 build: **BUILD SUCCEEDED**.
- New `SyntaxHighlighterTests` (7 cases): keyword/string/number tinting, block-comment state carry, unknown-language safety, Markdown inline-code-vs-prose (incl. Capitalized prose), fenced-block language switching, ASCII-scoped tokenization, and config/YAML profile behavior. All pass; existing review tests unaffected.
- Rebased onto latest `main` (resolves #55 line-classify + #61 split-diff); highlighting threaded into both view modes. Manually verified across Swift/Java/Markdown/YAML files.

## 中文

### 做什么 & 为什么

Review 的 diff 面板之前把每行代码渲染成单一中性色。本次加入轻量、零依赖的语法高亮,让 review 时的改动代码「像代码一样可读」——按语言给关键字、字符串、注释、数字、类型上色,**统一视图与分屏视图都生效**,同时保留 add/delete 行底色与行号 gutter。

### 怎么做

- **新增 `Glint/Review/SyntaxHighlighter.swift`** —— 纯 Swift、零常驻内存的行级 tokenizer,按扩展名解析 `SyntaxLanguage` profile:
  - **代码**:Swift、C 系(C/C++/ObjC/Java/JS/TS/C#/Kotlin…)、Go、Rust、脚本系(Python/Ruby/shell)、SQL。
  - **Markdown**:只染行内 `` `code` `` 与 ```` ```lang ```` 围栏代码块(围栏内用该语言 profile);正文不上色。
  - **配置/数据**(TOML/INI/conf/properties/Dockerfile):`#` 注释 + 字符串 + 数字,无关键字/类型上色。**YAML 完全不上色**——键值是数据,任何上色都是噪音。
  - 未知扩展名只染字符串 + 数字,确保不认识的文件绝不被误上色。
- 高亮**后台线程、每文件加载时跑一次**,与 `DiffDocument.parse` 同流程并缓存。块注释/三引号/围栏状态在 hunk 内跨行携带,每个 `@@` 处重置。
- `DiffLine` 增加 `attributed`;统一视图行与分屏格子均渲染 `Text(line.attributed)`。token 区段带 `.foregroundColor`,其余回退到行的 `.foregroundStyle`,故 add/delete 底色仍在中性文本上生效。配色复用 `Theme`,分词限定 ASCII。

**已知边界(只读 diff 可接受;升级路径=tree-sitter):** 跨 hunk 开头的多行构造不跟踪;del 行共享 new-file 状态流。

### 测试 / 验证

- arm64 编译:**BUILD SUCCEEDED**。
- 新增 `SyntaxHighlighterTests`(7 例):关键字/字符串/数字上色、块注释跨行状态、未知语言安全、Markdown 行内代码 vs 正文、围栏块按语言切换、ASCII 范围分词、config/YAML profile 行为。全部通过;现有 review 测试未受影响。
- 已 rebase 到最新 `main`(解 #55 行分类 + #61 分屏),高亮接入两种视图;对 Swift/Java/Markdown/YAML 手动目检。
