### PR TITLE
fix(review): neutralize remote-shell command injection in SSH Review / 修复 SSH Review 的远端命令注入

### DIFF
--- a/Glint/Git/GitService.swift
+++ b/Glint/Git/GitService.swift
@@ -142,6 +142,16 @@ struct SSHGitRunner: GitRunner {
 
     /// Pure: the full `ssh … git -C <cwd> <args>` argv. Split out so the wire
     /// format is unit-testable without spawning ssh.
+    ///
+    /// **`cwd` is single-quoted on purpose.** `Process` passes our argv to
+    /// `/usr/bin/ssh` without a shell, but ssh joins the remote-command portion
+    /// with spaces and hands it to the REMOTE LOGIN SHELL, which re-parses the
+    /// whole thing — so an unquoted `;` / `$(…)` / backtick / space in `cwd`
+    /// would execute arbitrary remote code in the user's authenticated session.
+    /// `cwd` is sourced from the remote shell's terminal title (attacker-
+    /// controllable by anyone who can set `PS1`/`PROMPT_COMMAND` on the remote),
+    /// so this matters. POSIX single-quoting passes every byte through
+    /// literally; embedded `'` is closed-escaped-reopened (`'\''`).
     static func commandArgs(target: String, port: Int?, controlPath: String,
                             cwd: String?, gitArgs: [String]) -> [String] {
         var a = ["-o", "BatchMode=yes",
@@ -150,9 +160,17 @@ struct SSHGitRunner: GitRunner {
         if let port { a += ["-p", "\(port)"] }
         a.append(target)
         a.append("git")
-        if let cwd, !cwd.isEmpty { a += ["-C", cwd] }
+        if let cwd, !cwd.isEmpty { a += ["-C", shellQuote(cwd)] }
         a += gitArgs
         return a
+    }
+
+    /// POSIX shell single-quote. Every byte passes literally; embedded `'` is
+    /// terminated, backslash-escaped, and reopened so the result is one
+    /// re-parse-safe shell word. Use for any value derived from untrusted
+    /// remote-shell data that ssh will hand to the remote login shell.
+    static func shellQuote(_ s: String) -> String {
+        return "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 
     /// Expand a leading `~` against the remote `$HOME` (cached per target).

--- a/Glint/Pane/GhosttySurfaceView.swift
+++ b/Glint/Pane/GhosttySurfaceView.swift
@@ -822,6 +822,17 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
     /// zsh remotes, custom titles, full-screen apps that clear it — so Review
     /// degrades to its no-path behavior instead of guessing. Static + internal
     /// so the parser is directly unit-testable.
+    ///
+    /// **Security:** the title is forwarded verbatim from the remote shell via
+    /// `GHOSTTY_ACTION_SET_TITLE` (NOT host-validated), so it's attacker-
+    /// controllable by anyone who can set the remote `PS1`/`PROMPT_COMMAND`.
+    /// `path` ultimately becomes the `<cwd>` in `ssh user@host git -C <cwd>`,
+    /// and ssh hands the remote command to the LOGIN SHELL which re-parses it
+    /// — so an unquoted `;`/`$()`/backtick in `path` would execute arbitrary
+    /// remote code in the user's authenticated session. Reject anything outside
+    /// a strict POSIX-path allowlist: letters, digits, and `._-/~`. (Real
+    /// defense is the single-quoting in `SSHGitRunner.commandArgs`; this is
+    /// belt-and-suspenders so obvious junk never reaches the wire.)
     static func parseRemoteTitle(_ title: String) -> (user: String, host: String, path: String)? {
         let t = title.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let at = t.firstIndex(of: "@") else { return nil }
@@ -833,7 +844,11 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
         let path = String(rest[rest.index(after: colon)...]).trimmingCharacters(in: .whitespaces)
         guard !host.isEmpty,
               host.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "." || $0 == "-" || $0 == "_" }),
-              !path.isEmpty else { return nil }
+              !path.isEmpty,
+              path.allSatisfy({ $0.isLetter || $0.isNumber
+                                || $0 == "." || $0 == "-" || $0 == "_"
+                                || $0 == "/" || $0 == "~" })
+        else { return nil }
         return (user, host, path)
     }
 

--- a/GlintTests/RemoteTitleParserTests.swift
+++ b/GlintTests/RemoteTitleParserTests.swift
@@ -58,4 +58,28 @@ final class RemoteTitleParserTests: XCTestCase {
         // a real hostname, so reject rather than mis-parse.
         XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@ho st:/x"))
     }
+
+    /// Path is restricted to a POSIX-path allowlist as belt-and-suspenders for
+    /// the single-quoting at the SSH-runner layer: shell metacharacters in the
+    /// title (which a malicious remote PS1 can set verbatim) must never reach
+    /// the wire — `;`, `$(…)`, backticks, `&`, `|`, spaces, etc. all reject.
+    /// Letters / digits / `._-/~` pass.
+    func testPathRejectsShellMetacharacters() {
+        XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@host:/x;rm -rf ~"))
+        XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@host:/x$(whoami)"))
+        XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@host:/x`id`"))
+        XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@host:/x&y"))
+        XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@host:/x|y"))
+        XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@host:/x y"))
+        XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@host:/x\"y\""))
+    }
+
+    /// Confirm legitimate POSIX paths still parse — leading `~`, absolute,
+    /// nested, dotfiles, hyphens, underscores, digits. Otherwise the
+    /// allowlist would over-reject and silently kill Review on normal hosts.
+    func testPathAllowsTypicalPosixPaths() {
+        XCTAssertNotNil(GhosttySurfaceView.parseRemoteTitle("u@host:~/.config/nvim"))
+        XCTAssertNotNil(GhosttySurfaceView.parseRemoteTitle("u@host:/var/log/nginx-2026.log"))
+        XCTAssertNotNil(GhosttySurfaceView.parseRemoteTitle("u@host:/srv/app_v2/dist"))
+    }
 }

--- a/GlintTests/SSHGitRunnerTests.swift
+++ b/GlintTests/SSHGitRunnerTests.swift
@@ -8,15 +8,20 @@ import XCTest
 final class SSHGitRunnerTests: XCTestCase {
 
     func testBasicArgv() {
+        // Production `cwd` reaches commandArgs already `~`-expanded by
+        // `resolveRemoteCwd` (so the remote login shell sees a literal absolute
+        // path, not a metachar that needs re-expansion). The unit test reflects
+        // that: a normal absolute path lands single-quoted, with the rest of
+        // the argv untouched.
         let a = SSHGitRunner.commandArgs(target: "deploy@prod-server", port: nil,
                                          controlPath: "/tmp/x.sock",
-                                         cwd: "~/code/api", gitArgs: ["status"])
+                                         cwd: "/home/deploy/code/api", gitArgs: ["status"])
         XCTAssertEqual(a, [
             "-o", "BatchMode=yes",
             "-o", "ControlMaster=auto", "-o", "ControlPersist=10m",
             "-o", "ControlPath=/tmp/x.sock",
             "deploy@prod-server",
-            "git", "-C", "~/code/api", "status"
+            "git", "-C", "'/home/deploy/code/api'", "status"
         ])
     }
 
@@ -27,10 +32,10 @@ final class SSHGitRunnerTests: XCTestCase {
         let portIndex = a.firstIndex(of: "-p")
         XCTAssertNotNil(portIndex)
         XCTAssertEqual(a[portIndex! + 1], "2222")
-        // cwd present → `-C` lands right after `git`.
+        // cwd present → `-C` lands right after `git`, single-quoted.
         let gitIndex = a.firstIndex(of: "git")!
         XCTAssertEqual(a[gitIndex + 1], "-C")
-        XCTAssertEqual(a[gitIndex + 2], "/srv/app")
+        XCTAssertEqual(a[gitIndex + 2], "'/srv/app'")
     }
 
     func testNilCwdOmitsCFlag() {
@@ -51,5 +56,29 @@ final class SSHGitRunnerTests: XCTestCase {
         let idx = a.firstIndex(of: "BatchMode=yes")
         XCTAssertNotNil(idx)
         XCTAssertEqual(a[idx! - 1], "-o")
+    }
+
+    /// ssh joins our remote-command args with spaces and hands them to the
+    /// REMOTE LOGIN SHELL, which re-parses the whole string — so cwd must be
+    /// single-quoted at the argv layer to neutralize `;` / `$(…)` / backtick /
+    /// space. The cwd ultimately comes from a remote terminal title that
+    /// anyone with PS1 access controls, so this is a real injection sink.
+    func testCwdShellQuotedForInjection() {
+        let a = SSHGitRunner.commandArgs(target: "host", port: nil,
+                                         controlPath: "/tmp/x.sock",
+                                         cwd: "/srv/app; rm -rf ~",
+                                         gitArgs: ["status"])
+        let gitIndex = a.firstIndex(of: "git")!
+        // The malicious payload is fully contained in one shell-quoted token,
+        // so the remote shell sees one literal cwd arg — not two commands.
+        XCTAssertEqual(a[gitIndex + 1], "-C")
+        XCTAssertEqual(a[gitIndex + 2], "'/srv/app; rm -rf ~'")
+    }
+
+    /// A `'` inside cwd must be closed-escaped-reopened (`'\''`) so the wrapper
+    /// single-quote isn't terminated mid-payload. POSIX-portable construction.
+    func testShellQuoteEscapesEmbeddedSingleQuote() {
+        let q = SSHGitRunner.shellQuote("a'b")
+        XCTAssertEqual(q, "'a'\\''b'")
     }
 }


### PR DESCRIPTION
## What & why

#62 (just merged) mines `user@host:path` from the remote shell's terminal title (forwarded verbatim via `GHOSTTY_ACTION_SET_TITLE`, NOT host-validated), and `path` ultimately becomes the `<cwd>` in `ssh user@host git -C <cwd>`. `Process` passes our argv to `/usr/bin/ssh` without a shell — but **ssh joins the remote-command portion with spaces and hands the whole string to the REMOTE LOGIN SHELL**, which re-parses it. So an unquoted `;` / `$(…)` / backtick / space in `path` would execute arbitrary remote code in the user's authenticated session.

#62's description claimed *"worst case from a spoofed title = read-only git against a host the user already SSHed to."* That promise only holds once `cwd` is shell-safe — currently it isn't.

## How (defense in depth)

1. **`parseRemoteTitle` allowlist** — restrict `path` to letters / digits / `._-/~`. Rejects obvious junk before it hits the wire and keeps the parser honest about what it claims to accept.
2. **`SSHGitRunner.commandArgs` single-quote** — POSIX-correctly wrap `cwd` (`'cwd'`, with embedded `'` closed-escaped-reopened as `'\''`). Even if (1) is somehow bypassed, the remote shell sees one literal cwd token, not a command sequence.

Production `cwd` reaches `commandArgs` already `~`-expanded by `resolveRemoteCwd`, so the absolute path inside the quotes works directly as `git -C` — no re-expansion needed.

## Tests

- `testCwdShellQuotedForInjection` — proves a payload like `/srv/app; rm -rf ~` is fully contained inside one shell-quoted token at the wire.
- `testShellQuoteEscapesEmbeddedSingleQuote` — pins the POSIX close-escape-reopen construction.
- `RemoteTitleParserTests`: new `testPathRejectsShellMetacharacters` (`;`, `\$(…)`, backticks, `&`, `|`, space, quotes) + `testPathAllowsTypicalPosixPaths` (lock the allow/deny boundary).
- Local arm64 build green; 17/17 SSH-related tests pass.

## Why this lands as its own follow-up

Spotted by background security review immediately after #62 merged; merging cleanly on top of main is faster than reverting + re-rolling #62. Same author trail, single commit, narrow surface.

## 中文

### 做什么

#62 刚合并的 SSH Review 从终端标题（不做主机校验）抽出 `user@host:path`，path 最终成为 `ssh user@host git -C <cwd>` 的 cwd。`Process` 传 argv 不经过 shell，但 **ssh 把远端命令部分拼成一个字符串发给远端登录 shell 二次解析**，所以未引用的 `;` / `\$(…)` / 反引号会在用户已认证的会话里执行任意远端代码。#62 描述里"最坏 = 只读 git"的承诺需要 cwd 是 shell-safe 才成立——当前不是。

### 怎么做（两层防御）

1. **`parseRemoteTitle` 加白名单** — path 限定为字母 / 数字 / `._-/~`。
2. **`SSHGitRunner.commandArgs` 单引号** — POSIX 转义 cwd（`'cwd'`，嵌入的 `'` 用 `'\''` 闭-逃-开）。即便白名单被绕过，远端 shell 看到的也是一个字面字符串 token。

### 测试

新增 4 个测试覆盖注入用例 / 引号转义 / shell metachar 拒绝 / 典型 POSIX 路径通过。本地 arm64 17/17 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)