### PR TITLE
fix(review): tilde-preserving quote + dedupe shellQuote / 保留 ~ 不引并统一 shellQuote

### DIFF
--- a/Glint/Agent/AgentChoice.swift
+++ b/Glint/Agent/AgentChoice.swift
@@ -124,11 +124,6 @@ extension AgentLaunchItem {
     /// codex's own default, so it launches bare with no override.
     private static func codexCommand(for home: CodexHome) -> String {
         guard home.resolvedURL != CodexHome.default.resolvedURL else { return "codex" }
-        return "CODEX_HOME=\(shellQuoted(home.resolvedURL.path)) codex"
-    }
-
-    private static func shellQuoted(_ path: String) -> String {
-        if !path.contains("'") { return "'\(path)'" }
-        return "'\(path.replacingOccurrences(of: "'", with: "'\\''"))'"
+        return "CODEX_HOME=\(posixShellQuoted(home.resolvedURL.path)) codex"
     }
 }

--- a/Glint/Agent/PaneAgentState.swift
+++ b/Glint/Agent/PaneAgentState.swift
@@ -67,7 +67,7 @@ enum PaneAgentKind: String, Codable {
         case .claude:
             return validated.map { "claude --resume \($0)\n" } ?? "claude --continue\n"
         case .codex:
-            let prefix = codexHome.map { "CODEX_HOME=\(Self.shellQuoted($0)) " } ?? ""
+            let prefix = codexHome.map { "CODEX_HOME=\(posixShellQuoted($0)) " } ?? ""
             return validated.map { "\(prefix)codex resume \($0)\n" }
                 ?? "\(prefix)codex resume --last\n"
         case .opencode:
@@ -75,14 +75,6 @@ enum PaneAgentKind: String, Codable {
         case .devin:
             return validated.map { "devin --resume \($0)\n" } ?? "devin --continue\n"
         }
-    }
-
-    /// Single-quote a path for shell assignment. Matches the launch-side
-    /// quoting in `AgentLaunchItem.codexCommand`, so the persisted home
-    /// round-trips byte-for-byte into the resume command.
-    private static func shellQuoted(_ path: String) -> String {
-        if !path.contains("'") { return "'\(path)'" }
-        return "'\(path.replacingOccurrences(of: "'", with: "'\\''"))'"
     }
 }
 

--- a/Glint/Git/GitService.swift
+++ b/Glint/Git/GitService.swift
@@ -100,20 +100,37 @@ struct LocalGitRunner: GitRunner {
     }
 }
 
+/// POSIX shell single-quote: every byte passes through literally; an embedded
+/// `'` is terminated, backslash-escaped, and reopened so the result is exactly
+/// one re-parse-safe shell word. Use for any value that will be re-parsed by a
+/// shell (a local `sh -c` command line, the remote-command portion of an ssh
+/// invocation, anything written into a script). One canonical implementation
+/// so all the call sites stay byte-equivalent.
+func posixShellQuoted(_ s: String) -> String {
+    if !s.contains("'") { return "'\(s)'" }
+    return "'\(s.replacingOccurrences(of: "'", with: "'\\''"))'"
+}
+
 /// Runs git over SSH against a captured destination, so `GitService`'s
-/// high-level methods work unchanged against a REMOTE repo — `cwd` is the
-/// remote path (a leading `~` is expanded against the remote `$HOME`). Reuses
-/// a per-target SSH `ControlMaster` so the status poll and the Review window
-/// don't each re-authenticate, and forces `BatchMode` so a missing key never
-/// hangs a background call (a host needing an interactive password degrades to
-/// empty results, same shape as a local non-repo). The remote title/host data
-/// that produces `target`/`cwd` is untrusted; this runner only ever runs
-/// read-only `git`, so the worst a spoofed title can do is query a repo on a
-/// host the user already SSHed to.
+/// high-level methods work unchanged against a REMOTE repo. `cwd` is the
+/// remote path; the runner POSIX-quotes it (and every `gitArg`) before
+/// handing it to ssh so the remote login shell — which re-parses the entire
+/// remote-command portion ssh sends it — sees one literal token per element.
+/// A leading `~` in `cwd` is preserved UNQUOTED so the remote shell performs
+/// tilde expansion against the user's actual `$HOME` (no local round-trip to
+/// resolve `$HOME` first; no cache to poison).
+///
+/// Reuses a per-target SSH `ControlMaster` so the status poll and the Review
+/// window don't each re-authenticate, and forces `BatchMode` so a missing key
+/// never hangs a background call (a host needing an interactive password
+/// degrades to empty results, same shape as a local non-repo). The remote
+/// title/host data that produces `target`/`cwd` is untrusted (anyone who can
+/// set the remote `PS1`/`PROMPT_COMMAND` controls it); this runner only ever
+/// runs read-only `git`, so the worst a spoofed title can do is query a repo
+/// on a host the user already SSHed to.
 struct SSHGitRunner: GitRunner {
     let target: String
     let port: Int?
-
     /// Per-target ControlMaster socket so repeated calls share one authed
     /// connection; `ControlPersist=10m` keeps it alive briefly after the last
     /// call so a Review open right after a status poll reuses it.
@@ -124,34 +141,39 @@ struct SSHGitRunner: GitRunner {
     /// the second ssh would tunnel through the first's connection — i.e. land
     /// on the wrong host. Hashing is also short enough to fit comfortably under
     /// macOS's 104-byte unix socket path limit even for long ssh aliases.
-    private var controlPath: String {
+    let controlPath: String
+
+    init(target: String, port: Int?) {
+        self.target = target
+        self.port = port
         var slug = target
         if let port { slug += ":\(port)" }
         let digest = SHA256.hash(data: Data(slug.utf8))
         let safe = digest.prefix(8).map { String(format: "%02x", $0) }.joined()
-        return FileManager.default.temporaryDirectory
+        self.controlPath = FileManager.default.temporaryDirectory
             .appendingPathComponent("glint-ssh-\(safe).sock").path
     }
 
     func run(_ args: [String], cwd: String?) async throws -> GitResult {
-        let remoteCwd = try await resolveRemoteCwd(cwd)
         let argv = Self.commandArgs(target: target, port: port,
-                                    controlPath: controlPath, cwd: remoteCwd, gitArgs: args)
+                                    controlPath: controlPath, cwd: cwd, gitArgs: args)
         return try await Self.spawn(argv)
     }
 
     /// Pure: the full `ssh … git -C <cwd> <args>` argv. Split out so the wire
     /// format is unit-testable without spawning ssh.
     ///
-    /// **`cwd` is single-quoted on purpose.** `Process` passes our argv to
-    /// `/usr/bin/ssh` without a shell, but ssh joins the remote-command portion
-    /// with spaces and hands it to the REMOTE LOGIN SHELL, which re-parses the
-    /// whole thing — so an unquoted `;` / `$(…)` / backtick / space in `cwd`
-    /// would execute arbitrary remote code in the user's authenticated session.
-    /// `cwd` is sourced from the remote shell's terminal title (attacker-
-    /// controllable by anyone who can set `PS1`/`PROMPT_COMMAND` on the remote),
-    /// so this matters. POSIX single-quoting passes every byte through
-    /// literally; embedded `'` is closed-escaped-reopened (`'\''`).
+    /// **Every element after `target` is POSIX-quoted on purpose.** `Process`
+    /// passes our argv to `/usr/bin/ssh` without a shell, but ssh joins the
+    /// remote-command portion with spaces and hands the resulting string to
+    /// the REMOTE LOGIN SHELL, which re-parses it. So any unquoted `;` /
+    /// `$(…)` / backtick / space in any element (cwd OR gitArg) would execute
+    /// arbitrary remote code in the user's authenticated session. Callers may
+    /// thread remote-derived data through both, so both layers must quote.
+    ///
+    /// `cwd` is handled specially: a leading `~` (or `~user`) is kept unquoted
+    /// so the remote shell can perform tilde expansion, and the rest of the
+    /// path is single-quoted — see `quoteRemoteCwd`.
     static func commandArgs(target: String, port: Int?, controlPath: String,
                             cwd: String?, gitArgs: [String]) -> [String] {
         var a = ["-o", "BatchMode=yes",
@@ -160,52 +182,40 @@ struct SSHGitRunner: GitRunner {
         if let port { a += ["-p", "\(port)"] }
         a.append(target)
         a.append("git")
-        if let cwd, !cwd.isEmpty { a += ["-C", shellQuote(cwd)] }
-        a += gitArgs
+        if let cwd, !cwd.isEmpty { a += ["-C", quoteRemoteCwd(cwd)] }
+        a += gitArgs.map(posixShellQuoted)
         return a
     }
 
-    /// POSIX shell single-quote. Every byte passes literally; embedded `'` is
-    /// terminated, backslash-escaped, and reopened so the result is one
-    /// re-parse-safe shell word. Use for any value derived from untrusted
-    /// remote-shell data that ssh will hand to the remote login shell.
-    static func shellQuote(_ s: String) -> String {
-        return "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
-    }
-
-    /// Expand a leading `~` against the remote `$HOME` (cached per target).
-    /// nil/empty cwd → nil (git runs in the remote login dir). Absolute paths
-    /// pass straight through.
-    private func resolveRemoteCwd(_ cwd: String?) async throws -> String? {
-        guard let cwd, !cwd.isEmpty else { return nil }
-        guard cwd.hasPrefix("~") else { return cwd }
-        let home = try await Self.remoteHome(target: target, port: port, controlPath: controlPath)
-        guard !home.isEmpty else { return cwd }   // couldn't resolve → best-effort passthrough
-        var rest = cwd
-        let leading: Set<Character> = ["~", "/"]
-        while let first = rest.first, leading.contains(first) { rest.removeFirst() }
-        return rest.isEmpty ? home : "\(home)/\(rest)"
-    }
-
-    // MARK: remote $HOME cache (serial-queue guarded: NSLock is unavailable in
-    // async contexts under Swift 6, and a blocking `.sync` read/write here is
-    // fine — the cache is tiny and the contention is one Review open at a time).
-    private static var homeCache: [String: String] = [:]
-    private static let homeQueue = DispatchQueue(label: "app.glint.git.sshhome")
-
-    private static func remoteHome(target: String, port: Int?, controlPath: String) async throws -> String {
-        let key = "\(target)#\(port.map(String.init) ?? "")"
-        if let cached = Self.homeQueue.sync(execute: { Self.homeCache[key] }) { return cached }
-        var a = ["-o", "BatchMode=yes", "-o", "ControlMaster=auto",
-                 "-o", "ControlPersist=10m", "-o", "ControlPath=\(controlPath)"]
-        if let port { a += ["-p", "\(port)"] }
-        // ssh runs this through the remote login shell, so `$HOME` expands
-        // remotely; printf gives the value with no trailing newline.
-        a += [target, "printf", "%s", "$HOME"]
-        let r = try await Self.spawn(a)
-        let home = r.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
-        Self.homeQueue.sync { Self.homeCache[key] = home }
-        return home
+    /// Quote `cwd` for inclusion as `git -C <quoted>` in the remote command.
+    /// Single-quotes everything EXCEPT a leading `~` (or `~user`) segment,
+    /// which is left unquoted so the remote login shell performs tilde
+    /// expansion. Bash's default `\w` PS1 prints `~/proj` for the user's home
+    /// — keeping that working is the whole point of the carve-out.
+    ///
+    /// Examples (assuming remote `$HOME=/home/deploy`):
+    ///   `~/proj`         → `~'/proj'`          → `/home/deploy/proj`
+    ///   `~admin/proj`    → `~admin'/proj'`     → admin's `$HOME` + `/proj`
+    ///   `~`              → `~`                  → `/home/deploy`
+    ///   `/abs/path`      → `'/abs/path'`       → literal
+    ///   `/srv/has space` → `'/srv/has space'`  → literal (space safe in quotes)
+    ///
+    /// The tilde-prefix carve-out is only safe when it has no shell metachars
+    /// itself; the title path allowlist guarantees this, but we re-validate
+    /// here so the safety doesn't rely on a caller in a different file.
+    static func quoteRemoteCwd(_ cwd: String) -> String {
+        guard cwd.hasPrefix("~") else { return posixShellQuoted(cwd) }
+        let slash = cwd.firstIndex(of: "/")
+        let tildePart = String(cwd[..<(slash ?? cwd.endIndex)])
+        let safe = tildePart.allSatisfy {
+            $0 == "~" || $0 == "_" || $0 == "-"
+                || ($0 >= "a" && $0 <= "z")
+                || ($0 >= "A" && $0 <= "Z")
+                || ($0 >= "0" && $0 <= "9")
+        }
+        guard safe else { return posixShellQuoted(cwd) }
+        guard let slash else { return tildePart }
+        return tildePart + posixShellQuoted(String(cwd[slash...]))
     }
 
     /// Spawn `/usr/bin/ssh <args>` and capture stdout/stderr — mirrors

--- a/Glint/Pane/GhosttySurfaceView.swift
+++ b/Glint/Pane/GhosttySurfaceView.swift
@@ -824,15 +824,26 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
     /// so the parser is directly unit-testable.
     ///
     /// **Security:** the title is forwarded verbatim from the remote shell via
-    /// `GHOSTTY_ACTION_SET_TITLE` (NOT host-validated), so it's attacker-
-    /// controllable by anyone who can set the remote `PS1`/`PROMPT_COMMAND`.
-    /// `path` ultimately becomes the `<cwd>` in `ssh user@host git -C <cwd>`,
-    /// and ssh hands the remote command to the LOGIN SHELL which re-parses it
-    /// — so an unquoted `;`/`$()`/backtick in `path` would execute arbitrary
-    /// remote code in the user's authenticated session. Reject anything outside
-    /// a strict POSIX-path allowlist: letters, digits, and `._-/~`. (Real
-    /// defense is the single-quoting in `SSHGitRunner.commandArgs`; this is
-    /// belt-and-suspenders so obvious junk never reaches the wire.)
+    /// `GHOSTTY_ACTION_SET_TITLE` (NOT host-validated, unlike OSC 7), so it's
+    /// attacker-controllable by anyone who can set the remote `PS1` /
+    /// `PROMPT_COMMAND`. `path` ultimately becomes the `<cwd>` in
+    /// `ssh user@host git -C <cwd>`, and ssh hands the remote command to the
+    /// LOGIN SHELL which re-parses it — so an unquoted `;` / `$(…)` / backtick
+    /// in `path` would execute arbitrary remote code in the user's
+    /// authenticated session. The real defense is the single-quoting in
+    /// `SSHGitRunner.commandArgs`; this allowlist is belt-and-suspenders so
+    /// obvious junk never reaches the wire.
+    ///
+    /// Path: accept any Unicode letter/digit (so CJK paths like `~/项目` work
+    /// — see CLAUDE.md i18n rule) plus `._-/~@+=,()` and ASCII space, then
+    /// reject any `..` segment so an attacker can't escape the project root
+    /// in the rendered breadcrumb / Review window header. `;`, `$`, backtick,
+    /// `&`, `|`, `<`, `>`, `*`, `?`, `[`, `]`, `{`, `}`, `\`, `"`, `'` all
+    /// still reject — that's the metachar set we care about.
+    ///
+    /// Host: ASCII-only allowlist (letters/digits/`.-_`) per RFC 1123. A
+    /// CJK / non-ASCII host means it's not a real DNS name and we'd rather
+    /// fail closed than mis-route the ssh.
     static func parseRemoteTitle(_ title: String) -> (user: String, host: String, path: String)? {
         let t = title.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let at = t.firstIndex(of: "@") else { return nil }
@@ -842,13 +853,26 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
         guard let colon = rest.firstIndex(of: ":") else { return nil }
         let host = String(rest[..<colon]).trimmingCharacters(in: .whitespaces)
         let path = String(rest[rest.index(after: colon)...]).trimmingCharacters(in: .whitespaces)
-        guard !host.isEmpty,
-              host.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "." || $0 == "-" || $0 == "_" }),
-              !path.isEmpty,
-              path.allSatisfy({ $0.isLetter || $0.isNumber
-                                || $0 == "." || $0 == "-" || $0 == "_"
-                                || $0 == "/" || $0 == "~" })
-        else { return nil }
+        guard !host.isEmpty, !path.isEmpty else { return nil }
+        let hostOk = host.unicodeScalars.allSatisfy { s in
+            let v = s.value
+            return (v >= 0x30 && v <= 0x39)            // 0-9
+                || (v >= 0x41 && v <= 0x5A)            // A-Z
+                || (v >= 0x61 && v <= 0x7A)            // a-z
+                || v == 0x2E || v == 0x2D || v == 0x5F // . - _
+        }
+        guard hostOk else { return nil }
+        let pathAllowed: Set<Character> = [".", "-", "_", "/", "~", "@", "+", "=", ",", "(", ")", " "]
+        let pathOk = path.allSatisfy { c in
+            c.isLetter || c.isNumber || pathAllowed.contains(c)
+        }
+        guard pathOk else { return nil }
+        // Reject `..` traversal anywhere in the path. The path is just a UI
+        // breadcrumb / Review header, but a `..`-laced title would still let
+        // a malicious remote misrepresent where Review is operating.
+        for seg in path.split(separator: "/", omittingEmptySubsequences: false) {
+            if seg == ".." { return nil }
+        }
         return (user, host, path)
     }
 
@@ -1501,22 +1525,14 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
     /// Shared by drag-drop and ⌘V/right-click paste of Finder files.
     @discardableResult
     private func injectFileURLs(_ urls: [URL], into s: ghostty_surface_t) -> Bool {
-        let joined = urls.map { shellQuote($0.path) }.joined(separator: " ")
-        // shellQuote keeps quoting intact, but a filename can legally embed
+        let joined = urls.map { posixShellQuoted($0.path) }.joined(separator: " ")
+        // Quoting preserves filenames intact, but a filename can legally embed
         // a newline — gate on the actual injected string, same as paste.
         guard confirmUnsafeTextInjection(joined) else { return false }
         joined.withCString { ptr in
             ghostty_surface_text_input(s, ptr, UInt(strlen(ptr)))
         }
         return true
-    }
-
-    /// Single-quote a path, escaping embedded single quotes as `'\''`.
-    /// Matches what `printf %q` would do for POSIX shells (good enough for
-    /// zsh/bash; fish users can adjust their shell anyway).
-    private func shellQuote(_ path: String) -> String {
-        if !path.contains("'") { return "'\(path)'" }
-        return "'\(path.replacingOccurrences(of: "'", with: "'\\''"))'"
     }
 
     // MARK: - ⌘-click to open files
@@ -1845,7 +1861,7 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
         let pb = NSPasteboard.general
         guard let pngData = imagePNGData(from: pb) else { return false }
         guard let path = persistPastedImage(pngData) else { return false }
-        let quoted = shellQuote(path)
+        let quoted = posixShellQuoted(path)
         quoted.withCString { ptr in
             ghostty_surface_text_input(s, ptr, UInt(strlen(ptr)))
         }

--- a/GlintTests/RemoteTitleParserTests.swift
+++ b/GlintTests/RemoteTitleParserTests.swift
@@ -59,19 +59,26 @@ final class RemoteTitleParserTests: XCTestCase {
         XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@ho st:/x"))
     }
 
-    /// Path is restricted to a POSIX-path allowlist as belt-and-suspenders for
-    /// the single-quoting at the SSH-runner layer: shell metacharacters in the
-    /// title (which a malicious remote PS1 can set verbatim) must never reach
-    /// the wire — `;`, `$(…)`, backticks, `&`, `|`, spaces, etc. all reject.
-    /// Letters / digits / `._-/~` pass.
+    /// Path is restricted to a metachar-free allowlist as belt-and-suspenders
+    /// for the single-quoting at the SSH-runner layer: a malicious remote `PS1`
+    /// could set the title to anything, but the obvious-injection set must
+    /// never reach the wire. Spaces, `@`, `()`, `+`, `=`, `,` are NOT
+    /// metachars (they're literal inside POSIX single quotes) and parse — see
+    /// the `Allows…` tests below for the legitimate uses they cover.
     func testPathRejectsShellMetacharacters() {
         XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@host:/x;rm -rf ~"))
         XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@host:/x$(whoami)"))
         XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@host:/x`id`"))
         XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@host:/x&y"))
         XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@host:/x|y"))
-        XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@host:/x y"))
         XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@host:/x\"y\""))
+        XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@host:/x>y"))
+        XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@host:/x<y"))
+        XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@host:/x*y"))
+        XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@host:/x?y"))
+        XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@host:/x[y]"))
+        XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@host:/x\\y"))
+        XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@host:/x'y'"))
     }
 
     /// Confirm legitimate POSIX paths still parse — leading `~`, absolute,
@@ -81,5 +88,46 @@ final class RemoteTitleParserTests: XCTestCase {
         XCTAssertNotNil(GhosttySurfaceView.parseRemoteTitle("u@host:~/.config/nvim"))
         XCTAssertNotNil(GhosttySurfaceView.parseRemoteTitle("u@host:/var/log/nginx-2026.log"))
         XCTAssertNotNil(GhosttySurfaceView.parseRemoteTitle("u@host:/srv/app_v2/dist"))
+    }
+
+    /// `@` appears in real-world paths (npm scopes like `node_modules/@types`,
+    /// git refs, email-named directories) and is shell-safe (not a metachar).
+    /// The previous allowlist over-rejected this; loosen to accept.
+    func testPathAllowsAtSign() {
+        let r = GhosttySurfaceView.parseRemoteTitle("u@host:/srv/app/node_modules/@types/node")
+        XCTAssertEqual(r?.path, "/srv/app/node_modules/@types/node")
+    }
+
+    /// Spaces inside a path are legitimate (Documents folder, "My Project"),
+    /// and SSHGitRunner's single-quoting handles them safely. The previous
+    /// allowlist over-rejected; titles like `~/My Code` now parse.
+    func testPathAllowsSpace() {
+        let r = GhosttySurfaceView.parseRemoteTitle("u@host:~/My Code/api")
+        XCTAssertEqual(r?.path, "~/My Code/api")
+    }
+
+    /// CJK and other Unicode characters in the path must parse — CLAUDE.md
+    /// mandates i18n / zh-Hans support, and remote users routinely cd into
+    /// directories with non-ASCII names. `Character.isLetter` is Unicode-wide
+    /// so the allowlist accepts these by design.
+    func testPathAllowsCJK() {
+        let r = GhosttySurfaceView.parseRemoteTitle("u@host:~/项目/网站")
+        XCTAssertEqual(r?.path, "~/项目/网站")
+    }
+
+    /// `..` traversal in the path is rejected even when every character is
+    /// otherwise allowlist-clean. The path drives the breadcrumb / Review
+    /// window header, and a `..`-laced title would let a malicious remote
+    /// misrepresent where Review is operating.
+    func testPathRejectsDotDotTraversal() {
+        XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@host:/srv/app/../etc"))
+        XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@host:~/../root"))
+    }
+
+    /// Host is ASCII-only (RFC 1123). A non-ASCII host name is never a real
+    /// DNS-resolvable hostname and indicates a malformed title — fail closed
+    /// rather than mis-route the ssh.
+    func testHostRejectsNonAscii() {
+        XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@主机:/x"))
     }
 }

--- a/GlintTests/SSHGitRunnerTests.swift
+++ b/GlintTests/SSHGitRunnerTests.swift
@@ -8,11 +8,8 @@ import XCTest
 final class SSHGitRunnerTests: XCTestCase {
 
     func testBasicArgv() {
-        // Production `cwd` reaches commandArgs already `~`-expanded by
-        // `resolveRemoteCwd` (so the remote login shell sees a literal absolute
-        // path, not a metachar that needs re-expansion). The unit test reflects
-        // that: a normal absolute path lands single-quoted, with the rest of
-        // the argv untouched.
+        // Absolute cwd lands single-quoted; a non-flag gitArg ("status") is
+        // also quoted because the remote login shell re-parses every token.
         let a = SSHGitRunner.commandArgs(target: "deploy@prod-server", port: nil,
                                          controlPath: "/tmp/x.sock",
                                          cwd: "/home/deploy/code/api", gitArgs: ["status"])
@@ -21,7 +18,7 @@ final class SSHGitRunnerTests: XCTestCase {
             "-o", "ControlMaster=auto", "-o", "ControlPersist=10m",
             "-o", "ControlPath=/tmp/x.sock",
             "deploy@prod-server",
-            "git", "-C", "'/home/deploy/code/api'", "status"
+            "git", "-C", "'/home/deploy/code/api'", "'status'"
         ])
     }
 
@@ -43,8 +40,8 @@ final class SSHGitRunnerTests: XCTestCase {
                                          controlPath: "/tmp/x.sock",
                                          cwd: nil, gitArgs: ["status"])
         let gitIndex = a.firstIndex(of: "git")!
-        // Immediately after `git` come the git args, with no `-C` injected.
-        XCTAssertEqual(a[gitIndex + 1], "status")
+        // Immediately after `git` come the git args (quoted), with no `-C` injected.
+        XCTAssertEqual(a[gitIndex + 1], "'status'")
         XCTAssertFalse(a.contains("-C"))
     }
 
@@ -78,7 +75,63 @@ final class SSHGitRunnerTests: XCTestCase {
     /// A `'` inside cwd must be closed-escaped-reopened (`'\''`) so the wrapper
     /// single-quote isn't terminated mid-payload. POSIX-portable construction.
     func testShellQuoteEscapesEmbeddedSingleQuote() {
-        let q = SSHGitRunner.shellQuote("a'b")
-        XCTAssertEqual(q, "'a'\\''b'")
+        XCTAssertEqual(posixShellQuoted("a'b"), "'a'\\''b'")
+    }
+
+    /// A leading `~` (or `~user`) MUST stay unquoted so the remote login shell
+    /// performs tilde expansion against the user's actual `$HOME` — otherwise
+    /// `~/proj` would land at a literal directory called `~`. Everything after
+    /// the tilde segment is single-quoted so spaces/metachars are still safe.
+    func testCommandArgsPreservesLeadingTildeUnquoted() {
+        let a = SSHGitRunner.commandArgs(target: "h", port: nil,
+                                         controlPath: "/tmp/x.sock",
+                                         cwd: "~/code/api", gitArgs: ["status"])
+        let gitIndex = a.firstIndex(of: "git")!
+        XCTAssertEqual(a[gitIndex + 1], "-C")
+        XCTAssertEqual(a[gitIndex + 2], "~'/code/api'")
+    }
+
+    /// `~admin/proj` must expand to admin's home (not the login user's), so the
+    /// whole `~admin` prefix stays unquoted as one shell tilde-prefix word.
+    func testTildeUserPreserved() {
+        let a = SSHGitRunner.commandArgs(target: "h", port: nil,
+                                         controlPath: "/x", cwd: "~admin/proj", gitArgs: [])
+        let gitIndex = a.firstIndex(of: "git")!
+        XCTAssertEqual(a[gitIndex + 2], "~admin'/proj'")
+    }
+
+    /// Bare `~` (no slash) means `$HOME` — keep it unquoted with nothing
+    /// appended; quoting it would yield a literal directory `~`.
+    func testBareTildeUnquoted() {
+        let a = SSHGitRunner.commandArgs(target: "h", port: nil,
+                                         controlPath: "/x", cwd: "~", gitArgs: [])
+        let gitIndex = a.firstIndex(of: "git")!
+        XCTAssertEqual(a[gitIndex + 2], "~")
+    }
+
+    /// gitArgs themselves are re-parsed by the remote shell, so every one
+    /// (flags included) must round-trip as a single token. A revision spec
+    /// like `main^{commit}` contains shell metachars that would otherwise
+    /// blow up — must be quoted at the wire layer.
+    func testGitArgsAreShellQuoted() {
+        let a = SSHGitRunner.commandArgs(target: "h", port: nil,
+                                         controlPath: "/x", cwd: nil,
+                                         gitArgs: ["log", "--format=%H %s", "main^{commit}"])
+        let gitIndex = a.firstIndex(of: "git")!
+        XCTAssertEqual(Array(a[(gitIndex + 1)...]),
+                       ["'log'", "'--format=%H %s'", "'main^{commit}'"])
+    }
+
+    /// Belt-and-suspenders: if a `~`-prefix segment ever DID contain a shell
+    /// metachar (the title allowlist should keep this from happening, but
+    /// `quoteRemoteCwd` re-validates so the safety doesn't depend on a caller),
+    /// fall back to fully single-quoting the whole path — losing tilde
+    /// expansion but never letting a metachar reach the remote shell.
+    func testTildeWithMetacharsFallsBackToFullQuote() {
+        let a = SSHGitRunner.commandArgs(target: "h", port: nil,
+                                         controlPath: "/x",
+                                         cwd: "~bad;rm/proj", gitArgs: [])
+        let gitIndex = a.firstIndex(of: "git")!
+        XCTAssertEqual(a[gitIndex + 2], "'~bad;rm/proj'")
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #65. The previous fix correctly stopped command injection through the SSH-Review cwd, but did it by single-quoting the entire path — which broke tilde expansion (`~/proj` became a literal directory), forcing a `resolveRemoteCwd` + `remoteHome` + cache layer that was itself a new source of complexity and stale-state risk. A `/code-review` pass found 10 issues across security, correctness, and cleanup; this PR addresses all of them.

### What changed

- **Tilde-preserving quote.** `SSHGitRunner.commandArgs` now keeps a leading `~` (or `~user`) unquoted, single-quotes the rest. The remote login shell does the tilde expansion itself — no local round-trip to resolve `$HOME` first, no cache to poison. The `~`-prefix is whitelist-validated; anything sketchy falls back to full single-quoting.
- **Quote every gitArg.** `#65` only quoted `cwd`. `gitArgs` ride the same re-parsed remote command string, so a rev-spec like `main^{commit}` could still cause trouble — they're now quoted too.
- **Cached `controlPath`.** Now a `let` set once via custom init, not a computed property hashing on every `run()`.
- **One canonical `posixShellQuoted`.** Module-level in `GitService.swift`, used by all four call sites (`GitService` / `GhosttySurfaceView` / `PaneAgentState` / `AgentChoice`). Deletes three byte-identical private copies.
- **Path allowlist tightening + loosening.** Reject `..` traversal so a malicious `PS1` can't lie about location in the Review breadcrumb. Reject non-ASCII hostnames (RFC 1123 — not a real DNS name, fail closed). Accept Unicode letters/digits so CJK paths like `~/项目` parse (CLAUDE.md i18n), plus `@+=,()` and space for npm scopes / paths with spaces.
- **Killed the `homeCache` path entirely.** `resolveRemoteCwd` + `remoteHome` + `homeQueue` are all gone — no longer needed once tilde expansion happens remotely.

## Test plan

- [x] `xcodebuild test` — all 27 tests pass (11 `SSHGitRunnerTests`, 16 `RemoteTitleParserTests`)
- [x] New SSH-Runner tests: tilde-passthrough wire format, `~user` preservation, bare `~`, gitArg quoting, `~`-with-metachar fallback
- [x] New parser tests: `@` (npm scopes), space, CJK (i18n), `..`-rejection, non-ASCII host rejection
- [x] Extended `testPathRejectsShellMetacharacters` to cover `<>*?[]\\'` in addition to `;\$()` backtick `&|"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)