### PR TITLE
fix: 10 findings from recall-biased review of v0.1.24..HEAD

### DIFF
--- a/Glint/Git/GitDiff.swift
+++ b/Glint/Git/GitDiff.swift
@@ -39,10 +39,25 @@ extension GitService {
                 nameStatus: (try? await names)?.stdout ?? "",
                 numstat: (try? await nums)?.stdout ?? "")
             if let u = try? await untrk, u.ok {
-                for path in u.stdout.split(separator: "\0", omittingEmptySubsequences: true) {
-                    let p = String(path)
+                let paths = u.stdout.split(separator: "\0", omittingEmptySubsequences: true).map(String.init)
+                // Count adds per untracked file via the runner so the right
+                // file is read — under SSH Review, `repo` is a REMOTE path so
+                // a local FileManager read would either return 0 or, worse,
+                // read a coincidentally-same-path LOCAL file. `git diff
+                // --no-index --numstat /dev/null <path>` runs in the runner's
+                // cwd (local or remote) and prints "<adds>\t<dels>\t<path>"
+                // for text, "-\t-\t<path>" for binary (which becomes 0).
+                let counts = await withTaskGroup(of: (String, Int).self) { group in
+                    for p in paths {
+                        group.addTask { (p, await self.untrackedAddCount(repo: repo, relPath: p)) }
+                    }
+                    var dict: [String: Int] = [:]
+                    for await (p, n) in group { dict[p] = n }
+                    return dict
+                }
+                for p in paths {
                     map[p] = GitFileChange(path: p, kind: .untracked,
-                                           additions: Self.lineCount(repo: repo, relPath: p),
+                                           additions: counts[p] ?? 0,
                                            deletions: 0, isBinary: false)
                 }
             }
@@ -124,15 +139,17 @@ extension GitService {
         return out
     }
 
-    /// Best-effort newline count of an untracked file. Skips reading anything
-    /// over 512 KB or non-UTF8 (binary) so a huge/binary untracked file can't
-    /// stall or balloon the file list.
-    private static func lineCount(repo: String, relPath: String) -> Int {
-        let full = (repo as NSString).appendingPathComponent(relPath)
-        guard let attrs = try? FileManager.default.attributesOfItem(atPath: full),
-              let size = attrs[.size] as? Int, size <= 512 * 1024,
-              let text = try? String(contentsOfFile: full, encoding: .utf8) else { return 0 }
-        if text.isEmpty { return 0 }
-        return text.reduce(0) { $1 == "\n" ? $0 + 1 : $0 } + (text.hasSuffix("\n") ? 0 : 1)
+    /// `+N` line count for an untracked file in the runner's repo (local or
+    /// remote). Uses `git diff --no-index --numstat /dev/null <path>` so the
+    /// SSH runner counts the REMOTE file rather than reading a same-pathed
+    /// LOCAL file via FileManager. Returns 0 for binary (numstat prints `-`)
+    /// and on any error — the Review file list degrades to a missing badge,
+    /// never to a wrong one.
+    private func untrackedAddCount(repo: String, relPath: String) async -> Int {
+        guard let r = try? await git(["diff", "--no-index", "--numstat", "/dev/null", relPath],
+                                     cwd: repo, allowFailure: true) else { return 0 }
+        let parts = r.stdout.split(separator: "\n").first?.split(separator: "\t", maxSplits: 2)
+        if let parts, parts.count == 3, let n = Int(parts[0]) { return n }
+        return 0
     }
 }

--- a/Glint/Git/GitService.swift
+++ b/Glint/Git/GitService.swift
@@ -203,12 +203,21 @@ struct SSHGitRunner: GitRunner {
     /// The tilde-prefix carve-out is only safe when it has no shell metachars
     /// itself; the title path allowlist guarantees this, but we re-validate
     /// here so the safety doesn't rely on a caller in a different file.
+    /// Allowed in the `~user` part: ASCII alnum + `_`/`-`/`.` — covers the
+    /// common corp LDAP/AD `admin.user` form that bash's `getpwnam` resolves
+    /// fine. Other chars the path allowlist accepts (space, `+`, `,`, `()`,
+    /// `=`, `@`, CJK letters, …) are valid POSIX usernames in theory but
+    /// either bash won't tilde-expand them or they cross into metachar
+    /// territory once the carve-out is unquoted, so we keep the conservative
+    /// fallback to fully single-quoting the whole path. Net effect for those:
+    /// no tilde expansion — but no Review breakage either, since the path
+    /// allowlist was loosened to UNQUOTED rendering, not "must be unquoted."
     static func quoteRemoteCwd(_ cwd: String) -> String {
         guard cwd.hasPrefix("~") else { return posixShellQuoted(cwd) }
         let slash = cwd.firstIndex(of: "/")
         let tildePart = String(cwd[..<(slash ?? cwd.endIndex)])
         let safe = tildePart.allSatisfy {
-            $0 == "~" || $0 == "_" || $0 == "-"
+            $0 == "~" || $0 == "_" || $0 == "-" || $0 == "."
                 || ($0 >= "a" && $0 <= "z")
                 || ($0 >= "A" && $0 <= "Z")
                 || ($0 >= "0" && $0 <= "9")

--- a/Glint/Pane/GhosttySurfaceView.swift
+++ b/Glint/Pane/GhosttySurfaceView.swift
@@ -412,6 +412,7 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
         // process_output renders bytes as child output (history), NOT as input —
         // it must never go through text_input or the shell would execute it.
         payload.withCString { ghostty_surface_process_output(s, $0, UInt(strlen($0))) }
+        markScrollbackDirty()
     }
 
     /// Snapshot the pane's current scrollback to disk as colored text (ANSI SGR).
@@ -426,6 +427,16 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
     /// queue, which also drops the frame early when the grid hasn't changed.
     func flushScrollbackToDisk() {
         guard let id = scrollbackID, let s = surface else { return }
+        // Per-pane dirty bit. Without it the 5s flush serializes every live
+        // pane's full grid (viewport + 3000 scrollback rows × per-cell color/
+        // attrs) on MainActor under the renderer-state lock every tick, even
+        // for occluded background tabs that haven't seen activity in minutes
+        // — adding linear-in-tabs main-thread cost to every flush. We can't
+        // catch arbitrary process output (no cheap "grid changed" signal in
+        // the C API), but covering user input + our own writes + foreground-
+        // pid changes catches the common idle case (a finished Claude/Codex
+        // turn) and lets idle panes settle to zero cost.
+        guard scrollbackNeedsFlush else { return }
         let json = ghostty_surface_render_grid_json(s, "", 0, 0, UInt(maxScrollbackLines))
         defer { ghostty_string_free(json) }
         guard let ptr = json.ptr, json.len > 0 else { return }
@@ -433,7 +444,36 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
         ScrollbackArchive.writeRendered(id: id, gridJSON: data, maxLines: maxScrollbackLines,
                                         priorHistory: restoredHistory,
                                         restoreMarker: Self.restoreMarkerText)
+        scrollbackNeedsFlush = false
+        scrollbackLastFlushedPid = (ghostty_surface_foreground_pid(s) > 0)
+            ? pid_t(ghostty_surface_foreground_pid(s)) : 0
     }
+
+    /// Set whenever something touches the grid we know about: user input
+    /// (text_input), our own writes (process_output, scrollback restore), or
+    /// a foreground-pid flip noticed by the cwd poller. Starts true so the
+    /// FIRST flush of a session always runs (captures the restored history).
+    /// Cleared at the tail of a successful flush.
+    private var scrollbackNeedsFlush = true
+    private var scrollbackLastFlushedPid: pid_t = 0
+
+    /// Called by the per-store flush loop right before `flushScrollbackToDisk`.
+    /// Marks the pane dirty when its foreground process changed since the last
+    /// successful flush, so a user `cd`ing or a TUI launching shows up even if
+    /// no keystroke was sent in between (cwd polling already notices these
+    /// every tick — we just piggy-back the signal).
+    func noteForegroundPidForScrollback() {
+        guard let s = surface else { return }
+        let pid = pid_t(ghostty_surface_foreground_pid(s))
+        guard pid > 0 else { return }
+        if pid != scrollbackLastFlushedPid { scrollbackNeedsFlush = true }
+    }
+
+    /// Mark the pane's scrollback dirty so the next flush serializes the grid.
+    /// Called from every place we write to the terminal (user input, paste,
+    /// drop, scrollback restore, programmatic injection).
+    @inline(__always)
+    fileprivate func markScrollbackDirty() { scrollbackNeedsFlush = true }
 
     /// The dim epilogue echoed after restored history. Shared by `restoreScrollback`
     /// (writes it) and `flushScrollbackToDisk` (locates it in the grid to split
@@ -849,17 +889,40 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
         guard let at = t.firstIndex(of: "@") else { return nil }
         let user = String(t[..<at])
         guard !user.isEmpty, !user.contains(" ") else { return nil }
-        let rest = t[t.index(after: at)...]
-        guard let colon = rest.firstIndex(of: ":") else { return nil }
-        let host = String(rest[..<colon]).trimmingCharacters(in: .whitespaces)
-        let path = String(rest[rest.index(after: colon)...]).trimmingCharacters(in: .whitespaces)
+        let rest = String(t[t.index(after: at)...])
+        // Host/path split. IPv6 literals can include colons inside `[...]`
+        // (e.g. `user@[::1]:/path`), so when the host starts with `[` we
+        // consume up to its matching `]` first and look for the `:` after it.
+        // Splitting on the first `:` would otherwise misread host as `[` and
+        // fail allowlist immediately.
+        let host: String
+        let path: String
+        if rest.hasPrefix("["),
+           let close = rest.firstIndex(of: "]"),
+           rest.index(after: close) < rest.endIndex,
+           rest[rest.index(after: close)] == ":" {
+            host = String(rest[rest.index(after: rest.startIndex)..<close])
+                .trimmingCharacters(in: .whitespaces)
+            path = String(rest[rest.index(close, offsetBy: 2)...])
+                .trimmingCharacters(in: .whitespaces)
+        } else {
+            guard let colon = rest.firstIndex(of: ":") else { return nil }
+            host = String(rest[..<colon]).trimmingCharacters(in: .whitespaces)
+            path = String(rest[rest.index(after: colon)...]).trimmingCharacters(in: .whitespaces)
+        }
         guard !host.isEmpty, !path.isEmpty else { return nil }
+        // Host allowlist: ASCII alnum + `.`/`-`/`_` (RFC 1123) plus `:` so an
+        // IPv6 literal we just unbracketed (`::1`, `fe80::1`) passes. We've
+        // already required brackets in the title, so a bare colon here can
+        // only come from the IPv6 path above — a plain-DNS host can't contain
+        // one. Non-ASCII hosts still fail closed (not a real DNS name).
         let hostOk = host.unicodeScalars.allSatisfy { s in
             let v = s.value
             return (v >= 0x30 && v <= 0x39)            // 0-9
                 || (v >= 0x41 && v <= 0x5A)            // A-Z
                 || (v >= 0x61 && v <= 0x7A)            // a-z
                 || v == 0x2E || v == 0x2D || v == 0x5F // . - _
+                || v == 0x3A                            // :  (IPv6)
         }
         guard hostOk else { return nil }
         let pathAllowed: Set<Character> = [".", "-", "_", "/", "~", "@", "+", "=", ",", "(", ")", " "]
@@ -905,14 +968,32 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
         var i = 1   // skip argv[0] (the ssh binary path)
         while i < argv.count {
             let a = argv[i]
+            // ssh short flags that consume the next argv slot. Without this set,
+            // every option-arg (-i key, -l user, -o k=v, -L tunnel, …) advanced
+            // the index by 1 and its VALUE was then taken as the destination —
+            // making `ssh -i ~/.ssh/id_rsa user@server` silently fail to
+            // capture, after which `openReview` would fall through to the
+            // LOCAL repo with no diagnostic. Lifted from `man ssh(1)`'s short-
+            // flag synopsis; bundled-arg forms like `-llogin` are treated as
+            // single tokens by ssh itself, so a `hasPrefix("-")` skip is still
+            // correct for those.
             if a == "-p", i + 1 < argv.count { port = Int(argv[i + 1]); i += 2; continue }
-            if a.hasPrefix("-") { i += 1; continue }   // ignore -i/-l/-v/… best-effort
+            if Self.sshFlagsTakingArg.contains(a), i + 1 < argv.count { i += 2; continue }
+            if a.hasPrefix("-") { i += 1; continue }
             if destination == nil { destination = a } else { sawRemoteCommand = true }
             i += 1
         }
         guard let destination, !sawRemoteCommand else { return nil }
         return (destination, port)
     }
+
+    /// ssh(1) short flags that take a separate argument. Used to skip the
+    /// value slot when parsing the foreground ssh argv so the destination
+    /// isn't misidentified as the flag's argument.
+    private static let sshFlagsTakingArg: Set<String> = [
+        "-B", "-b", "-c", "-D", "-E", "-e", "-F", "-I", "-i", "-J",
+        "-L", "-l", "-m", "-O", "-o", "-Q", "-R", "-S", "-W", "-w"
+    ]
 
     /// Everything the SSH review runner needs, or nil when the focused pane
     /// isn't a capturable SSH session with a known remote path.
@@ -1088,6 +1169,7 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
                         ghostty_surface_text_input(s, cptr, 1)
                     }
                 }
+                markScrollbackDirty()
             } else {
                 pasteClipboardText(into: s)
             }
@@ -1532,6 +1614,7 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
         joined.withCString { ptr in
             ghostty_surface_text_input(s, ptr, UInt(strlen(ptr)))
         }
+        markScrollbackDirty()
         return true
     }
 
@@ -1790,6 +1873,7 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
                     ghostty_surface_text_input(s, cptr, UInt(bp.count))
                 }
             }
+            markScrollbackDirty()
         }
     }
 
@@ -1865,6 +1949,7 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
         quoted.withCString { ptr in
             ghostty_surface_text_input(s, ptr, UInt(strlen(ptr)))
         }
+        markScrollbackDirty()
         return true
     }
 
@@ -1947,6 +2032,7 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
                     ghostty_surface_text_input(s, cptr, 1)
                 }
             }
+            markScrollbackDirty()
         } else {
             pasteClipboardText(into: s)
         }
@@ -2010,6 +2096,7 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
             // which ghostty's renderer shows as a white-background highlight.
             ghostty_surface_text_input(s, ptr, UInt(strlen(ptr)))
         }
+        markScrollbackDirty()
         // Explicitly clear any residual preedit (commit doesn't always wipe
         // it, leaving underlined ghost text trailing the real input).
         ghostty_surface_preedit(s, nil, 0)

--- a/Glint/Review/ReviewWindow.swift
+++ b/Glint/Review/ReviewWindow.swift
@@ -830,11 +830,18 @@ struct DiffDocument: Sendable {
         var out: [DiffLine] = []
         var oldLine = 0, newLine = 0
         var id = 0
-        // Syntax state carried across lines within a hunk so a block comment /
-        // triple string opened on an earlier line keeps tinting its body. Reset
-        // at each @@ header. ponytail: single stream — a deleted line inside an
-        // old-file block comment borrows the new-file state and may mis-tint.
-        var hlState = SyntaxHighlighter.State()
+        // TWO highlight states walk in parallel — one for the old-file timeline
+        // (`-` lines + context), one for the new-file timeline (`+` lines +
+        // context). A single shared state lets a multi-line construct opened
+        // on a `-` line (e.g. removing `/* TODO`) tint the following `+` /
+        // context lines as comment continuation even though those lines aren't
+        // inside any comment in the new file — visually hiding real code under
+        // gray. Mirror: a `+` opener bleeding into following `-` lines.
+        // Context lines advance BOTH states (they exist in both versions) and
+        // render through the NEW state, which is what the file looks like
+        // post-diff and what the user is reviewing. Reset both at each @@.
+        var oldState = SyntaxHighlighter.State()
+        var newState = SyntaxHighlighter.State()
         // Normalize CRLF / lone CR to LF before splitting. Swift treats "\r\n" as
         // a single Character (extended grapheme cluster), so split(separator: "\n")
         // never matches it and silently merges every CRLF-terminated line into one
@@ -850,7 +857,8 @@ struct DiffDocument: Sendable {
             // the diff's final newline; real blank context lines are " ".
             if line.isEmpty { continue }
             if line.hasPrefix("@@") {
-                hlState = SyntaxHighlighter.State()   // new hunk → tint from a clean slate
+                oldState = SyntaxHighlighter.State()   // new hunk → tint from a clean slate
+                newState = SyntaxHighlighter.State()
                 (oldLine, newLine) = parseHunk(line)
                 out.append(DiffLine(id: id, kind: .hunk, text: line,
                                     attributed: AttributedString(line), oldNum: nil, newNum: nil)); id += 1
@@ -868,15 +876,21 @@ struct DiffDocument: Sendable {
             // gutter clutter is gone — add/delete is shown via tint, not text.
             let body = String(line.dropFirst())
             if line.hasPrefix("+") {
-                let attr = SyntaxHighlighter.highlight(body, language: language, state: &hlState)
+                let attr = SyntaxHighlighter.highlight(body, language: language, state: &newState)
                 out.append(DiffLine(id: id, kind: .add, text: body, attributed: attr, oldNum: nil, newNum: newLine)); id += 1
                 newLine += 1
             } else if line.hasPrefix("-") {
-                let attr = SyntaxHighlighter.highlight(body, language: language, state: &hlState)
+                let attr = SyntaxHighlighter.highlight(body, language: language, state: &oldState)
                 out.append(DiffLine(id: id, kind: .del, text: body, attributed: attr, oldNum: oldLine, newNum: nil)); id += 1
                 oldLine += 1
             } else if line.hasPrefix(" ") {
-                let attr = SyntaxHighlighter.highlight(body, language: language, state: &hlState)
+                // Context exists in both versions: advance oldState too so a
+                // subsequent `-` line sees the right state, but render through
+                // newState (the post-diff view).
+                var oldAdvance = oldState
+                _ = SyntaxHighlighter.highlight(body, language: language, state: &oldAdvance)
+                oldState = oldAdvance
+                let attr = SyntaxHighlighter.highlight(body, language: language, state: &newState)
                 out.append(DiffLine(id: id, kind: .context, text: body, attributed: attr, oldNum: oldLine, newNum: newLine)); id += 1
                 oldLine += 1; newLine += 1
             }
@@ -1327,11 +1341,17 @@ final class ReviewWindowController: NSObject, NSWindowDelegate {
 
         let w = window ?? makeWindow()
         w.title = title
-        // Sink fires synchronously with the current value on subscribe (@Published
-        // behavior), so this also seeds the open-time appearance — no need to set
-        // it separately. The same sink handles every subsequent theme switch.
-        themeCancellable = store.$themeRevision.sink { [weak self] _ in
-            self?.window?.appearance = NSAppearance(named: Theme.current.isDark ? .darkAqua : .aqua)
+        // The sink fires synchronously with the current value on subscribe
+        // (@Published behavior) — but only on `w`, the local NSWindow we just
+        // created. Capture `w` directly in the closure so the synchronous
+        // first fire applies the open-time appearance BEFORE `self.window`
+        // has been assigned below. Previously this closed over `self?.window`
+        // which was still nil on the first present() of the session, so the
+        // initial open used AppKit's system appearance instead of the user's
+        // Theme pick. Subsequent opens reused the cached `window` ivar and
+        // looked correct, masking the bug.
+        themeCancellable = store.$themeRevision.sink { [weak w] _ in
+            w?.appearance = NSAppearance(named: Theme.current.isDark ? .darkAqua : .aqua)
         }
         // Zero the hosting view's safe-area at the AppKit layer instead of with
         // SwiftUI's `.ignoresSafeArea()`. The modifier makes SwiftUI re-coordinate

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -1342,10 +1342,20 @@ final class WorkspaceStore: ObservableObject {
         self.sidebarCollapsed = loaded.sidebarCollapsed
         Self.current = self
 
-        // Debounced autosave: any @Published change → save 0.5s later.
-        saveCancellable = objectWillChange
-            .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
-            .sink { [weak self] _ in self?.persist() }
+        // Debounced autosave: only persistable @Published fields trigger a save.
+        // Wiring this to bare `objectWillChange` re-encodes on every transient
+        // hook event (paneAgentState/paneProcesses/UI-only flags) — none of
+        // which are part of PersistedState — so the disk write does nothing but
+        // burn CPU and IO during active agent turns. Subscribe to the actual
+        // persisted publishers instead, drop the synthetic initial value, and
+        // map each one to Void so they merge into a single sink.
+        saveCancellable = Publishers.MergeMany(
+            $workspaces.dropFirst().map { _ in () }.eraseToAnyPublisher(),
+            $selectedWorkspaceID.dropFirst().map { _ in () }.eraseToAnyPublisher(),
+            $sidebarCollapsed.dropFirst().map { _ in () }.eraseToAnyPublisher()
+        )
+        .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
+        .sink { [weak self] _ in self?.persist() }
 
         // Sweep live surface cwds every second so a crash/quit still leaves
         // recent dirs persisted. The closure captures self weakly so the
@@ -1567,7 +1577,15 @@ final class WorkspaceStore: ObservableObject {
     /// feature is off. Each view only writes when it has new bytes.
     func flushScrollback() {
         guard restoreTerminalScrollback else { return }
-        for view in surfaceViews.values { view.flushScrollbackToDisk() }
+        for view in surfaceViews.values {
+            // Mark dirty when the pane's foreground pid changed since the last
+            // flush — catches the "user `cd`'d / launched a TUI / agent
+            // exited" case where no keystroke would have flipped the bit but
+            // the grid clearly evolved. Cheap (a single sysctl read; the cwd
+            // sweep just did the same one) and idempotent.
+            view.noteForegroundPidForScrollback()
+            view.flushScrollbackToDisk()
+        }
     }
 
     func captureCwdsFromLiveSurfaces() {
@@ -1605,27 +1623,39 @@ final class WorkspaceStore: ObservableObject {
                     // Track CURRENT claude/codex/opencode foreground so the
                     // next launch can optionally `--continue` / `resume --last`
                     // (gated by the per-agent setting). Cleared the moment the
-                    // foreground is a non-agent shell/tool, so we don't auto-
-                    // resume on a pane the user explicitly exited from. A *nil*
-                    // foreground (no live surface / transient empty pid) is
-                    // unknown, not an exit — leave the hint alone so a momentary
-                    // read gap doesn't drop a still-live session's resume hint.
+                    // foreground is a benign shell — i.e. the user actually
+                    // exited the agent — NOT when a tool subprocess (vim, git,
+                    // rg, npm, …) briefly fronts the foreground pid mid-turn.
+                    // Without this guard, a `Bash(vim …)` from inside a live
+                    // Claude/Codex turn would wipe lastAgent + sessionIds, and
+                    // a quit during the vim window would persist an empty map
+                    // → restart loses the #45 multi-pane resume entirely. A
+                    // *nil* foreground (no live surface / transient empty pid)
+                    // is unknown, not an exit — leave the hint alone.
                     let agentKind = Self.agentKind(forProcessName: name)
                     let agentToken = agentKind?.rawValue
-                    if workspaces[i].panes[paneID]?.lastAgent != agentToken {
-                        workspaces[i].panes[paneID]?.lastAgent = agentToken
+                    let foregroundIsExit = agentKind == nil && Self.isBenignShellProcessName(name)
+                    // Update lastAgent when foreground is a known agent OR the
+                    // pane is genuinely back at a shell. A transient tool
+                    // subprocess leaves lastAgent (and sessionIds below)
+                    // untouched.
+                    if agentKind != nil || foregroundIsExit {
+                        if workspaces[i].panes[paneID]?.lastAgent != agentToken {
+                            workspaces[i].panes[paneID]?.lastAgent = agentToken
+                        }
                     }
                     // A session id is only meaningful while its agent is the
-                    // foreground. Drop any entry whose key isn't the current
-                    // foreground (agent==nil clears them all) so a future
-                    // restart can't try to resume a session the user has
-                    // moved on from; the next hook event for a re-launched
-                    // agent repopulates its own slot. Comparing against
-                    // `agentKind?.rawValue` (not a free-form String) is what
-                    // structurally guarantees the writer here and the reader
-                    // at `surfaceView`'s `pane.sessionIds[kind.rawValue]`
-                    // can't drift on spelling.
-                    if let existing = workspaces[i].panes[paneID]?.sessionIds,
+                    // foreground. Filter to the current foreground (or wipe
+                    // when foreground is a shell, i.e. agent exited) so a
+                    // future restart can't try to resume a session the user
+                    // has moved on from. Comparing against `agentKind?.rawValue`
+                    // (not a free-form String) is what structurally guarantees
+                    // the writer here and the reader at `surfaceView`'s
+                    // `pane.sessionIds[kind.rawValue]` can't drift on spelling.
+                    // SKIPPED when the foreground is a transient tool subproc
+                    // (same reason as lastAgent above).
+                    if (agentKind != nil || foregroundIsExit),
+                       let existing = workspaces[i].panes[paneID]?.sessionIds,
                        !existing.isEmpty {
                         let kept = existing.filter { $0.key == agentToken }
                         if kept.count != existing.count {
@@ -1714,12 +1744,19 @@ final class WorkspaceStore: ObservableObject {
         let foregroundKind = surfaceViews[key]?.foregroundProcessName()
             .flatMap(Self.agentKind(named:))
         let polledKind = paneProcesses[key].flatMap(Self.agentKind(named:))
-        // Fall back to .claude when nothing resolves: the hook wrapper's own
-        // AGENT arg defaults to "claude" when unset (AgentBridge then omits the
-        // empty token), so an unresolvable kind means "a hook fired for a pane
-        // we can't otherwise classify" — better to show an agent than to drop
-        // the event and leave the pane looking like a bare shell.
-        let kind = explicitKind ?? paneAgentState[key]?.kind ?? foregroundKind ?? polledKind ?? .claude
+        // `resolvedKind` is best-guess identification for THIS event; nil when
+        // we genuinely don't know which CLI fired. We still process the event
+        // (status badge, detail text, kind = .claude as a safe display default
+        // — see `kind` below), but a nil resolvedKind MUST NOT be used to key a
+        // sessionId write: stashing a Codex/OpenCode/Devin uuid under "claude"
+        // sticks until the next poll tick (~1s race window) and a quit in that
+        // window persists a misrouted resume map — restart would run
+        // `claude --resume <foreign-uuid>` and fail. Every Glint-installed
+        // reporter sets `agent` already, so this nil-path is normally
+        // unreachable; the guard is defense-in-depth for future agent
+        // integrations whose installer forgets the AGENT arg.
+        let resolvedKind: PaneAgentKind? = explicitKind ?? paneAgentState[key]?.kind ?? foregroundKind ?? polledKind
+        let kind = resolvedKind ?? .claude
 
         // Stash the per-pane session id whenever the hook carries one. The
         // shared reporter extracts it from each CLI's stdin payload via
@@ -1727,12 +1764,14 @@ final class WorkspaceStore: ObservableObject {
         // time AgentBridge has decoded `session_b64` they all land here as
         // `info["session"]`. Without this stash the restart path can only
         // run `--continue`/`--last`, which collapses every same-cwd pane
-        // onto one session (#45).
-        if let sessionId = info["session"] as? String,
+        // onto one session (#45). Skip the write when `resolvedKind` is nil
+        // (see above) so we never cross-contaminate sessionIds.
+        if let resolvedKind,
+           let sessionId = info["session"] as? String,
            Self.isValidSessionId(sessionId),
            let wsIdx = workspaces.firstIndex(where: { $0.id == key.workspace }),
-           workspaces[wsIdx].panes[key.pane]?.sessionIds[kind.rawValue] != sessionId {
-            workspaces[wsIdx].panes[key.pane]?.sessionIds[kind.rawValue] = sessionId
+           workspaces[wsIdx].panes[key.pane]?.sessionIds[resolvedKind.rawValue] != sessionId {
+            workspaces[wsIdx].panes[key.pane]?.sessionIds[resolvedKind.rawValue] = sessionId
         }
 
         // Note: we deliberately do NOT force-write paneProcesses here. The

--- a/GlintTests/RemoteTitleParserTests.swift
+++ b/GlintTests/RemoteTitleParserTests.swift
@@ -130,4 +130,21 @@ final class RemoteTitleParserTests: XCTestCase {
     func testHostRejectsNonAscii() {
         XCTAssertNil(GhosttySurfaceView.parseRemoteTitle("u@主机:/x"))
     }
+
+    /// IPv6 literal hosts come wrapped in `[…]` so the inner `:` separators
+    /// don't get confused with the host/path delimiter. The parser consumes
+    /// up to the matching `]` first, otherwise it splits at the first inner
+    /// `:` and the host comes out as `[` (which fails the allowlist).
+    func testIPv6BracketedHost() {
+        let r = GhosttySurfaceView.parseRemoteTitle("deploy@[::1]:/srv/app")
+        XCTAssertEqual(r?.user, "deploy")
+        XCTAssertEqual(r?.host, "::1")
+        XCTAssertEqual(r?.path, "/srv/app")
+    }
+
+    func testIPv6FullLiteral() {
+        let r = GhosttySurfaceView.parseRemoteTitle("ci@[fe80::1ff:fe23:4567:890a]:~/build")
+        XCTAssertEqual(r?.host, "fe80::1ff:fe23:4567:890a")
+        XCTAssertEqual(r?.path, "~/build")
+    }
 }

--- a/GlintTests/ReviewDiffParsingTests.swift
+++ b/GlintTests/ReviewDiffParsingTests.swift
@@ -134,6 +134,30 @@ rename to n
         XCTAssertTrue(DiffDocument.parse("").isEmpty)
     }
 
+    /// Old-file and new-file syntax-highlight states must walk independently:
+    /// a `/*` opener removed from the OLD side must NOT leak `inBlockComment`
+    /// onto the `+` and context lines that follow (they aren't inside a
+    /// comment in the new file). Symmetric the other way.
+    /// We can't easily assert on AttributedString tinting without a renderer
+    /// here, so just lock the structural contract — `parse` returns the right
+    /// kinds + bodies for a diff that previously triggered the bleed.
+    func testParseTwoStateHighlightAcceptsDeletedCommentOpener() {
+        let diff = """
+        @@ -1,3 +1,3 @@
+        -/* TODO: drop me
+        +let x = 5
+         let y = 6
+        """
+        let lines = DiffDocument.parse(diff)
+        XCTAssertEqual(lines.count, 4)   // hunk + del + add + context
+        XCTAssertEqual(lines[1].kind, .del)
+        XCTAssertEqual(lines[1].text, "/* TODO: drop me")
+        XCTAssertEqual(lines[2].kind, .add)
+        XCTAssertEqual(lines[2].text, "let x = 5")
+        XCTAssertEqual(lines[3].kind, .context)
+        XCTAssertEqual(lines[3].text, "let y = 6")
+    }
+
     // MARK: TreeNode.build
 
     /// Directories nest, folders sort before files at each level (case

--- a/GlintTests/SSHGitRunnerTests.swift
+++ b/GlintTests/SSHGitRunnerTests.swift
@@ -134,4 +134,17 @@ final class SSHGitRunnerTests: XCTestCase {
         let gitIndex = a.firstIndex(of: "git")!
         XCTAssertEqual(a[gitIndex + 2], "'~bad;rm/proj'")
     }
+
+    /// Dotted corp usernames (LDAP/AD `admin.user`) are the most common
+    /// `~user`-form Review hits in the wild. Must stay UNQUOTED so the remote
+    /// shell tilde-expands them; previously `.` wasn't in the carve-out
+    /// allowlist, so the path silently fell through to literal quoting and
+    /// every dotted-user Review showed "Not a git repository".
+    func testTildeDottedUsernamePreserved() {
+        let a = SSHGitRunner.commandArgs(target: "h", port: nil,
+                                         controlPath: "/x",
+                                         cwd: "~admin.user/proj", gitArgs: [])
+        let gitIndex = a.firstIndex(of: "git")!
+        XCTAssertEqual(a[gitIndex + 2], "~admin.user'/proj'")
+    }
 }


### PR DESCRIPTION
## Summary

`/code-review` 在 high-effort recall-biased 模式下扫了 `v0.1.24..HEAD`(28 个 commit、~4900 行改动)发现的 10 项问题,全部修复。

### Correctness (1-8)

| # | File | Bug |
|---|---|---|
| 1 | `WorkspaceStore.swift:1628` | `sessionIds`/`lastAgent` wipe 缺 `isBenignShellProcessName` 守卫 → Claude 跑 `Bash(vim …)` 1s 内被 vim 错当成 agent 退出 → quit-during-vim 后 #45 多 pane resume 整个回退到 bare shell |
| 2 | `GitDiff.swift:130` | untracked +N 用 `FileManager` 读本地 → SSH Review 下永远 0(或更糟:读到同路径的不相关本地文件)|
| 3 | `GhosttySurfaceView.swift:898` | `foregroundSshTarget` 除 `-p` 外其他 ssh option-arg 全按零参数处理 → `ssh -i key user@server` 把 key 当 destination → openReview 静默 fallback 到本地 |
| 4 | `ReviewWindow.swift:829` | 单 SyntaxHighlighter.State 同时跟 `-`/`+`/context → `-/* TODO` 让后续 `+`/context 全染成灰色注释续行 |
| 5 | `ReviewWindow.swift:1333` | `themeCancellable` closure 关 `self?.window`,但 `@Published` 同步首发在 `window = w` 赋值前 → 首次 ⌘⇧R 用错主题 |
| 6 | `GitService.swift:206` | `quoteRemoteCwd` 的 `~user` 字符集缺 `.` → `~admin.user` 这种 LDAP/AD dotted 用户名 fallback 到全引 → 远端找不到目录 |
| 7 | `GhosttySurfaceView.swift:853` | `parseRemoteTitle` 在第一个 `:` 切 → IPv6 字面 host (`[::1]`) parse 不出 |
| 8 | `WorkspaceStore.swift:1744` | `kind = ... ?? .claude` fallback + `sessionIds[kind.rawValue] = ...` → 未识别 reporter 把外来 uuid 错串到 "claude" 键,restart 跑 `claude --resume <foreign-uuid>` |

### Efficiency (9-10)

| # | File | Cost |
|---|---|---|
| 9 | `GhosttySurfaceView.swift:427` | 5s × N pane 都在主线程跑 `render_grid_json`(取 renderer 锁 + 序列化 ≤3000 行 per-cell 色彩)即便 idle → 加 per-pane `scrollbackNeedsFlush` 脏位 |
| 10 | `WorkspaceStore.swift:1346` | autosave 订阅裸 `objectWillChange` → 每个 hook 事件(`paneAgentState` 等非持久化 `@Published`)都触发 0.5s 防抖写盘 → 改为合并 3 个真正持久化的 publisher |

## What changed

- 增量 ~290 行,改 5 源文件 + 3 测试文件,无新增文件
- 不动 xcodegen 项目结构,不动 `Localizable.xcstrings`(没新增用户文案)
- 不动 `ReleaseNotes.swift`(此 commit 不打 tag — 按 CLAUDE.md 「不允许预先开占位条目」规则)

## Test plan

- [x] `xcodebuild test` 157/157 通过(+4 个新增 regression 测试)
- [x] 主 target Debug build 通过
- [x] 新增测试覆盖:
  - `testParseTwoStateHighlightAcceptsDeletedCommentOpener` — 双 highlight state(#4)
  - `testIPv6BracketedHost` / `testIPv6FullLiteral` — IPv6 host(#7)
  - `testTildeDottedUsernamePreserved` — `~admin.user`(#6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)