### PR TITLE
fix(sidebar): drop selected-card left accent bar, keep only wash

### DIFF
--- a/Glint/Chrome/SidebarView.swift
+++ b/Glint/Chrome/SidebarView.swift
@@ -1030,30 +1030,16 @@ private struct WorkspaceCard: View {
     /// the parent VStack.
     private func cardBackground(active: Bool) -> some View {
         let fill: Color = {
-            // 选中态走 accent wash + 左侧 indicator 双语言 —— wash 16% 改 10%,
-            // Codex 风的"轻选中":重在 indicator 条说话,wash 只是淡淡的色温
-            // 信号,不抢戏。idle 行裸,hover 行极淡黑/白 wash。
+            // 选中态只用 accent wash,不再叠左侧 indicator 条 —— wash 在浅色下
+            // 微弱但仍可读,加竖条反而抢戏。idle 裸,hover 极淡黑/白 wash。
             if active { return store.accent.opacity(0.10) }
             if isHovered { return Theme.overlay(0.04) }
             return .clear
         }()
-        return ZStack(alignment: .leading) {
-            RoundedRectangle(cornerRadius: 9, style: .continuous)
-                .fill(fill)
-            // 选中态加一根 3pt 宽 accent 左竖条,挤进 2pt 让它"嵌"在 card 内边而
-            // 不是贴外缘 —— 亮色下仅靠 16% accent 底色对比太弱,加这条左指示条
-            // 后扫一眼就分得清当前选的是谁(暗色下也只是更明确,不冲突)。
-            if active {
-                RoundedRectangle(cornerRadius: 1.5, style: .continuous)
-                    .fill(store.accent)
-                    .frame(width: 3)
-                    .padding(.vertical, 6)
-                    .padding(.leading, 2)
-                    .transition(.opacity)
-            }
-        }
-        .animation(.spring(response: 0.28, dampingFraction: 0.85), value: active)
-        .animation(.easeOut(duration: 0.16), value: isHovered)
+        return RoundedRectangle(cornerRadius: 9, style: .continuous)
+            .fill(fill)
+            .animation(.spring(response: 0.28, dampingFraction: 0.85), value: active)
+            .animation(.easeOut(duration: 0.16), value: isHovered)
     }
 
     /// One-shot green celebration driven by `justCompletedFlash`: a faint


### PR DESCRIPTION
## Summary

#534cc7f (\`feat(chrome): light-mode chrome polish …\`) 在选中工作区卡上多画了一根 3pt 宽 accent 竖条,跟原有的 10% accent wash 叠在一起。实际使用下竖条比 wash 抢戏更明显,且工作区切换时左缘还会跳动一下,影响视觉聚焦。

去掉竖条,只保留 wash 底色 —— 浅色下虽然没那么扎眼但仍可读,加竖条反而过载。

## Test plan

- [x] xcodebuild Debug 通过
- [x] 选中态:wash 仍生效,无竖条
- [x] hover 态:极淡 wash 不变
- [x] idle 态:裸,不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)