### PR TITLE
fix(settings): clarify macOS notification toggle only fires when Glint is in background

### DIFF
--- a/Glint/Chrome/SettingsView.swift
+++ b/Glint/Chrome/SettingsView.swift
@@ -1330,7 +1330,7 @@ private struct AgentsPane: View {
             }
             SettingsDivider()
             SettingsRow("Show macOS notification for agent attention",
-                        subtitle: "Pop a banner in Notification Center when a background agent needs approval, finishes, or fails. Silent — the chime stays the audio cue.") {
+                        subtitle: "Only fires while Glint is in the background. Pops a banner in Notification Center when an agent needs approval, finishes, or fails. Silent — the chime stays the audio cue.") {
                 Toggle("", isOn: $store.systemNotificationOnAgentAttention)
                     .toggleStyle(.switch).labelsHidden()
             }

--- a/Glint/Resources/Localizable.xcstrings
+++ b/Glint/Resources/Localizable.xcstrings
@@ -4679,13 +4679,13 @@
         }
       }
     },
-    "Pop a banner in Notification Center when a background agent needs approval, finishes, or fails. Silent — the chime stays the audio cue.": {
+    "Only fires while Glint is in the background. Pops a banner in Notification Center when an agent needs approval, finishes, or fails. Silent — the chime stays the audio cue.": {
       "extractionState": "manual",
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "后台 agent 需要批准、完成或出错时,在通知中心弹出横幅。静默——声音仍由提示音负责。"
+            "value": "仅在 Glint 处于后台时触发。agent 需要批准、完成或出错时在通知中心弹出横幅。静默——声音仍由提示音负责。"
           }
         }
       }


### PR DESCRIPTION
## Summary

设置里 macOS 通知开关的副标题没说清楚真正的触发条件:实际门是 \`WorkspaceStore.swift:1866\` 的 \`!NSApp.isActive\` —— Glint 整体在前台时永远不发,跟前台 workspace 无关。原文「a background agent needs …」让人以为是按 workspace 区分(像上面的 Dock badge 那样)。

副标题开头加上「仅在 Glint 处于后台时触发」,先说前提条件再说事件。

## Test plan

- [x] xcodebuild Debug 通过
- [x] 中英文同步:Localizable.xcstrings 的 key 重命名 + zh-Hans 翻译同步更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)