### PR TITLE
fix(review): bound git ops to stop hangs + faster file list / 限制 git 操作防卡死 + 加快文件列表

### DIFF
--- a/Glint/Git/GitDiff.swift
+++ b/Glint/Git/GitDiff.swift
@@ -40,35 +40,7 @@ extension GitService {
                 numstat: (try? await nums)?.stdout ?? "")
             if let u = try? await untrk, u.ok {
                 let paths = u.stdout.split(separator: "\0", omittingEmptySubsequences: true).map(String.init)
-                // Count adds per untracked file via the runner so the right
-                // file is read — under SSH Review, `repo` is a REMOTE path so
-                // a local FileManager read would either return 0 or, worse,
-                // read a coincidentally-same-path LOCAL file. `git diff
-                // --no-index --numstat /dev/null <path>` runs in the runner's
-                // cwd (local or remote) and prints "<adds>\t<dels>\t<path>"
-                // for text, "-\t-\t<path>" for binary (which becomes 0).
-                // Bound concurrency: one git subprocess per untracked file
-                // would otherwise fan out N-wide, and each call pins 3
-                // dispatch threads (runner blocks on the process + 2 pipe
-                // readers) — a repo with many untracked files blows the
-                // 64-thread dispatch ceiling and hangs the app. Seed at most
-                // `maxConcurrent`, refill one as each finishes.
-                let maxConcurrent = 4
-                var iter = paths.makeIterator()
-                let counts = await withTaskGroup(of: (String, Int).self) { group in
-                    for _ in 0..<min(maxConcurrent, paths.count) {
-                        guard let p = iter.next() else { break }
-                        group.addTask { (p, await self.untrackedAddCount(repo: repo, relPath: p)) }
-                    }
-                    var dict: [String: Int] = [:]
-                    for await (p, n) in group {
-                        dict[p] = n
-                        if let next = iter.next() {
-                            group.addTask { (next, await self.untrackedAddCount(repo: repo, relPath: next)) }
-                        }
-                    }
-                    return dict
-                }
+                let counts = await countUntracked(repo: repo, paths: paths)
                 for p in paths {
                     map[p] = GitFileChange(path: p, kind: .untracked,
                                            additions: counts[p] ?? 0,
@@ -153,13 +125,68 @@ extension GitService {
         return out
     }
 
-    /// `+N` line count for an untracked file in the runner's repo (local or
-    /// remote). Uses `git diff --no-index --numstat /dev/null <path>` so the
-    /// SSH runner counts the REMOTE file rather than reading a same-pathed
-    /// LOCAL file via FileManager. Returns 0 for binary (numstat prints `-`)
-    /// and on any error — the Review file list degrades to a missing badge,
-    /// never to a wrong one.
-    private func untrackedAddCount(repo: String, relPath: String) async -> Int {
+    /// Per-untracked-file add counts, branched on the runner. LOCAL reads the
+    /// bytes directly — N untracked files used to mean N `git diff --no-index`
+    /// subprocess spawns (bounded to 4 wide), and the file list blocked on
+    /// every one before it could render. REMOTE can't `FileManager`-read the
+    /// path (it lives on the far host), so it keeps the bounded git spawn.
+    private func countUntracked(repo: String, paths: [String]) async -> [String: Int] {
+        if !runner.isRemote {
+            // No Process, no thread pinning — all files count concurrently in
+            // the cooperative pool, so the list isn't gated on ceil(N/4)
+            // serial rounds of process startup.
+            return await withTaskGroup(of: (String, Int).self) { group in
+                for p in paths {
+                    group.addTask { (p, Self.untrackedAddCountLocal(repo: repo, relPath: p)) }
+                }
+                var dict: [String: Int] = [:]
+                for await (p, n) in group { dict[p] = n }
+                return dict
+            }
+        }
+        // Remote: bytes only reachable via git. Bound concurrency — one
+        // subprocess per file fans out N-wide and each pins 3 dispatch threads
+        // (process + 2 pipe readers), blowing the 64-thread ceiling on a repo
+        // with many untracked files. Seed at most `maxConcurrent`, refill one
+        // as each finishes.
+        let maxConcurrent = 4
+        var iter = paths.makeIterator()
+        return await withTaskGroup(of: (String, Int).self) { group in
+            for _ in 0..<min(maxConcurrent, paths.count) {
+                guard let p = iter.next() else { break }
+                group.addTask { (p, await self.untrackedAddCountRemote(repo: repo, relPath: p)) }
+            }
+            var dict: [String: Int] = [:]
+            for await (p, n) in group {
+                dict[p] = n
+                if let next = iter.next() {
+                    group.addTask { (next, await self.untrackedAddCountRemote(repo: repo, relPath: next)) }
+                }
+            }
+            return dict
+        }
+    }
+
+    /// Local-only: count an untracked file's added lines from its bytes — exact
+    /// for the badge. Each `\n` ends an added line, plus one for trailing
+    /// content with no newline; a NUL byte marks it binary (git's heuristic) →
+    /// 0, and a bad UTF-8 decode → 0 too — both matching `git diff --numstat`'s
+    /// `-`. Static/pure so it's trivially Sendable into the TaskGroup.
+    private static func untrackedAddCountLocal(repo: String, relPath: String) -> Int {
+        let abs = (repo as NSString).appendingPathComponent(relPath)
+        guard let data = FileManager.default.contents(atPath: abs), !data.isEmpty,
+              !data.contains(0),
+              let s = String(data: data, encoding: .utf8) else { return 0 }
+        let newlines = s.reduce(0) { $1 == "\n" ? $0 + 1 : $0 }
+        return newlines + (s.hasSuffix("\n") ? 0 : 1)
+    }
+
+    /// `+N` line count for an untracked file in a REMOTE repo (SSH Review): the
+    /// path only resolves on the far host, so we ask git (running there) via
+    /// `git diff --no-index --numstat /dev/null <path>` instead of reading a
+    /// same-pathed LOCAL file. Returns 0 for binary (numstat prints `-`) and on
+    /// any error — the list degrades to a missing badge, never a wrong one.
+    private func untrackedAddCountRemote(repo: String, relPath: String) async -> Int {
         guard let r = try? await git(["diff", "--no-index", "--numstat", "/dev/null", relPath],
                                      cwd: repo, allowFailure: true) else { return 0 }
         let parts = r.stdout.split(separator: "\n").first?.split(separator: "\t", maxSplits: 2)

--- a/Glint/Git/GitDiff.swift
+++ b/Glint/Git/GitDiff.swift
@@ -32,8 +32,8 @@ extension GitService {
         case .workingTree:
             // name-status (kind) + numstat (line counts) run concurrently, then
             // untracked files are appended as additions.
-            async let names = git(["diff", "HEAD", "--name-status"], cwd: repo, allowFailure: true)
-            async let nums  = git(["diff", "HEAD", "--numstat"], cwd: repo, allowFailure: true)
+            async let names = git(["diff", "HEAD", "--name-status"], cwd: repo, allowFailure: true, timeout: Self.readTimeout)
+            async let nums  = git(["diff", "HEAD", "--numstat"], cwd: repo, allowFailure: true, timeout: Self.readTimeout)
             async let untrk = git(["ls-files", "--others", "--exclude-standard", "-z"], cwd: repo, allowFailure: true)
             var map = Self.mergeNameNumstat(
                 nameStatus: (try? await names)?.stdout ?? "",
@@ -50,8 +50,8 @@ extension GitService {
             return map.values.sorted { $0.path < $1.path }
 
         case .branch(let base):
-            async let names = git(["diff", "\(base)...HEAD", "--name-status"], cwd: repo, allowFailure: true)
-            async let nums  = git(["diff", "\(base)...HEAD", "--numstat"], cwd: repo, allowFailure: true)
+            async let names = git(["diff", "\(base)...HEAD", "--name-status"], cwd: repo, allowFailure: true, timeout: Self.readTimeout)
+            async let nums  = git(["diff", "\(base)...HEAD", "--numstat"], cwd: repo, allowFailure: true, timeout: Self.readTimeout)
             let map = Self.mergeNameNumstat(
                 nameStatus: (try? await names)?.stdout ?? "",
                 numstat: (try? await nums)?.stdout ?? "")
@@ -78,15 +78,15 @@ extension GitService {
                 // toggles apply uniformly — without this, untracked files were
                 // silently exempt from the menu state.
                 let r = try? await git(args + ["--no-index", "--", "/dev/null", file.path],
-                                       cwd: repo, allowFailure: true)
+                                       cwd: repo, allowFailure: true, timeout: Self.readTimeout)
                 return r?.stdout ?? ""
             }
             let r = try? await git(args + ["HEAD", "--", file.path],
-                                   cwd: repo, allowFailure: true)
+                                   cwd: repo, allowFailure: true, timeout: Self.readTimeout)
             return r?.stdout ?? ""
         case .branch(let base):
             let r = try? await git(args + ["\(base)...HEAD", "--", file.path],
-                                   cwd: repo, allowFailure: true)
+                                   cwd: repo, allowFailure: true, timeout: Self.readTimeout)
             return r?.stdout ?? ""
         }
     }
@@ -130,51 +130,65 @@ extension GitService {
     /// subprocess spawns (bounded to 4 wide), and the file list blocked on
     /// every one before it could render. REMOTE can't `FileManager`-read the
     /// path (it lives on the far host), so it keeps the bounded git spawn.
+    /// Both go through `boundedMap` so a repo with many untracked files can't
+    /// fan out N-wide: local byte-reads don't pin dispatch threads, but an
+    /// unbounded fan-out would still pile up N full-file buffers (and file
+    /// handles) at once — the memory cliff the remote bound exists to avoid.
     private func countUntracked(repo: String, paths: [String]) async -> [String: Int] {
         if !runner.isRemote {
-            // No Process, no thread pinning — all files count concurrently in
-            // the cooperative pool, so the list isn't gated on ceil(N/4)
-            // serial rounds of process startup.
-            return await withTaskGroup(of: (String, Int).self) { group in
-                for p in paths {
-                    group.addTask { (p, Self.untrackedAddCountLocal(repo: repo, relPath: p)) }
-                }
-                var dict: [String: Int] = [:]
-                for await (p, n) in group { dict[p] = n }
-                return dict
+            // No Process, no thread pinning — bytes read in the cooperative
+            // pool. Wider than remote (each task holds a file buffer, not 3
+            // threads), but still bounded to cap peak memory.
+            return await boundedMap(paths: paths, maxConcurrent: 8) {
+                Self.untrackedAddCountLocal(repo: repo, relPath: $0)
             }
         }
-        // Remote: bytes only reachable via git. Bound concurrency — one
-        // subprocess per file fans out N-wide and each pins 3 dispatch threads
-        // (process + 2 pipe readers), blowing the 64-thread ceiling on a repo
-        // with many untracked files. Seed at most `maxConcurrent`, refill one
-        // as each finishes.
-        let maxConcurrent = 4
+        // Remote: each git spawn pins 3 dispatch threads (process + 2 pipe
+        // readers), so a tighter bound than local.
+        return await boundedMap(paths: paths, maxConcurrent: 4) {
+            await self.untrackedAddCountRemote(repo: repo, relPath: $0)
+        }
+    }
+
+    /// Map `body` over `paths` with concurrency capped at `maxConcurrent`,
+    /// refilling one slot as each finishes (so the whole list completes in
+    /// ceil(N/maxConcurrent) rounds, never an N-wide fan-out). Shared by the
+    /// local byte-count and the remote git-spawn paths.
+    private func boundedMap(paths: [String], maxConcurrent: Int,
+                            _ body: @Sendable @escaping (String) async -> Int) async -> [String: Int] {
         var iter = paths.makeIterator()
         return await withTaskGroup(of: (String, Int).self) { group in
             for _ in 0..<min(maxConcurrent, paths.count) {
                 guard let p = iter.next() else { break }
-                group.addTask { (p, await self.untrackedAddCountRemote(repo: repo, relPath: p)) }
+                group.addTask { (p, await body(p)) }
             }
             var dict: [String: Int] = [:]
             for await (p, n) in group {
                 dict[p] = n
                 if let next = iter.next() {
-                    group.addTask { (next, await self.untrackedAddCountRemote(repo: repo, relPath: next)) }
+                    group.addTask { (next, await body(next)) }
                 }
             }
             return dict
         }
     }
 
+    /// Don't load an untracked file larger than this into RAM just to badge its
+    /// +N — degrade to 0 (same as a binary file). × the local TaskGroup's
+    /// concurrency (8) is the worst-case peak, so a stray multi-MB build
+    /// artifact can't OOM the app the way an unbounded whole-file read could.
+    private static let maxLocalCountBytes = 20_000_000
+
     /// Local-only: count an untracked file's added lines from its bytes — exact
     /// for the badge. Each `\n` ends an added line, plus one for trailing
     /// content with no newline; a NUL byte marks it binary (git's heuristic) →
-    /// 0, and a bad UTF-8 decode → 0 too — both matching `git diff --numstat`'s
-    /// `-`. Static/pure so it's trivially Sendable into the TaskGroup.
+    /// 0, an oversized file → 0 (see `maxLocalCountBytes`), and a bad UTF-8
+    /// decode → 0 too — all matching `git diff --numstat`'s `-`. Static/pure so
+    /// it's trivially Sendable into the TaskGroup.
     private static func untrackedAddCountLocal(repo: String, relPath: String) -> Int {
         let abs = (repo as NSString).appendingPathComponent(relPath)
         guard let data = FileManager.default.contents(atPath: abs), !data.isEmpty,
+              data.count <= maxLocalCountBytes,
               !data.contains(0),
               let s = String(data: data, encoding: .utf8) else { return 0 }
         let newlines = s.reduce(0) { $1 == "\n" ? $0 + 1 : $0 }

--- a/Glint/Git/GitDiff.swift
+++ b/Glint/Git/GitDiff.swift
@@ -47,12 +47,26 @@ extension GitService {
                 // --no-index --numstat /dev/null <path>` runs in the runner's
                 // cwd (local or remote) and prints "<adds>\t<dels>\t<path>"
                 // for text, "-\t-\t<path>" for binary (which becomes 0).
+                // Bound concurrency: one git subprocess per untracked file
+                // would otherwise fan out N-wide, and each call pins 3
+                // dispatch threads (runner blocks on the process + 2 pipe
+                // readers) — a repo with many untracked files blows the
+                // 64-thread dispatch ceiling and hangs the app. Seed at most
+                // `maxConcurrent`, refill one as each finishes.
+                let maxConcurrent = 4
+                var iter = paths.makeIterator()
                 let counts = await withTaskGroup(of: (String, Int).self) { group in
-                    for p in paths {
+                    for _ in 0..<min(maxConcurrent, paths.count) {
+                        guard let p = iter.next() else { break }
                         group.addTask { (p, await self.untrackedAddCount(repo: repo, relPath: p)) }
                     }
                     var dict: [String: Int] = [:]
-                    for await (p, n) in group { dict[p] = n }
+                    for await (p, n) in group {
+                        dict[p] = n
+                        if let next = iter.next() {
+                            group.addTask { (next, await self.untrackedAddCount(repo: repo, relPath: next)) }
+                        }
+                    }
                     return dict
                 }
                 for p in paths {

--- a/Glint/Git/GitService.swift
+++ b/Glint/Git/GitService.swift
@@ -46,57 +46,97 @@ protocol GitRunner: Sendable {
     /// Run `git args` with the runner's notion of `cwd`. Never throws on a
     /// non-zero git exit (that's a normal signal, e.g. "branch missing"); only
     /// throws if the process itself couldn't be launched.
-    func run(_ args: [String], cwd: String?) async throws -> GitResult
+    ///
+    /// `timeout` (seconds) is a hard ceiling: a wedged git/ssh is SIGTERM'd at
+    /// the deadline (then SIGKILL'd after a 2s grace) so it can't pin dispatch
+    /// threads forever. `nil` = no Process-level deadline — for mutating ops
+    /// that must NOT be interrupted mid-flight (e.g. `git apply`, which writes
+    /// the working tree non-atomically); the SSH runner's ConnectTimeout still
+    /// bounds the connect phase. Read/poll callers pass a short ceiling.
+    func run(_ args: [String], cwd: String?, timeout: TimeInterval?) async throws -> GitResult
+}
+
+/// env flags shared by both runners: never block on a credential prompt, never
+/// invoke a pager, never take index.lock just to read status.
+private func gitQuietEnv() -> [String: String] {
+    var env = ProcessInfo.processInfo.environment
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    env["GIT_PAGER"] = "cat"
+    env["GIT_OPTIONAL_LOCKS"] = "0"
+    return env
+}
+
+/// Spawn `executable arguments` with `cwd`/`env`, drain both pipes concurrently
+/// (so neither fixed pipe buffer can deadlock on large output), and enforce an
+/// optional hard `timeout`. On the deadline: SIGTERM, then SIGKILL after a 2s
+/// grace — a process wedged in uninterruptible I/O (hung NFS/SMB, a stuck ssh
+/// master) ignores SIGTERM, so escalation is what actually delivers the
+/// "no call pins threads forever" guarantee. `kill(pid, 0)` is the kernel truth
+/// (`Process.isRunning` can lag the reap) and no-ops once the process has exited.
+private func captureProcess(executable: String, arguments: [String], cwd: String?,
+                            env: [String: String], timeout: TimeInterval?) async throws -> GitResult {
+    try await withCheckedThrowingContinuation { (cont: CheckedContinuation<GitResult, Error>) in
+        DispatchQueue.global(qos: .userInitiated).async {
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: executable)
+            proc.arguments = arguments
+            if let cwd, !cwd.isEmpty {
+                proc.currentDirectoryURL =
+                    URL(fileURLWithPath: (cwd as NSString).expandingTildeInPath)
+            }
+            proc.environment = env
+
+            let outPipe = Pipe(), errPipe = Pipe()
+            proc.standardOutput = outPipe
+            proc.standardError = errPipe
+            do {
+                try proc.run()
+            } catch {
+                cont.resume(throwing: GitError.launchFailed(error.localizedDescription))
+                return
+            }
+
+            var outData = Data(), errData = Data()
+            let group = DispatchGroup()
+            let q = DispatchQueue(label: "app.glint.git.read", attributes: .concurrent)
+            q.async(group: group) { outData = outPipe.fileHandleForReading.readDataToEndOfFile() }
+            q.async(group: group) { errData = errPipe.fileHandleForReading.readDataToEndOfFile() }
+
+            var watchdog: DispatchWorkItem?
+            if let timeout {
+                let pid = proc.processIdentifier
+                let w = DispatchWorkItem {
+                    guard pid > 0 else { return }
+                    if kill(pid, 0) == 0 { kill(pid, SIGTERM) }
+                    DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(2)) {
+                        if kill(pid, 0) == 0 { kill(pid, SIGKILL) }
+                    }
+                }
+                DispatchQueue.global().asyncAfter(
+                    deadline: .now() + .milliseconds(Int(timeout * 1000)), execute: w)
+                watchdog = w
+            }
+            group.wait()
+            proc.waitUntilExit()
+            watchdog?.cancel()
+
+            cont.resume(returning: GitResult(
+                exitCode: proc.terminationStatus,
+                stdout: String(decoding: outData, as: UTF8.self),
+                stderr: String(decoding: errData, as: UTF8.self)))
+        }
+    }
 }
 
 /// Runs git as a local subprocess. The app is non-sandboxed, so this is
-/// unrestricted. Reads both pipes concurrently so neither pipe's fixed buffer
-/// can deadlock on large output, and disables interactive prompts/pagers so a
-/// stray credential/pager prompt can never hang a background call.
+/// unrestricted. Pipe handling + the timeout watchdog live in the shared
+/// `captureProcess`; this just supplies the local executable + cwd + quiet-env.
 struct LocalGitRunner: GitRunner {
     var gitPath: String = "/usr/bin/git"
 
-    func run(_ args: [String], cwd: String?) async throws -> GitResult {
-        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<GitResult, Error>) in
-            DispatchQueue.global(qos: .userInitiated).async {
-                let proc = Process()
-                proc.executableURL = URL(fileURLWithPath: gitPath)
-                proc.arguments = args
-                if let cwd, !cwd.isEmpty {
-                    proc.currentDirectoryURL =
-                        URL(fileURLWithPath: (cwd as NSString).expandingTildeInPath)
-                }
-                var env = ProcessInfo.processInfo.environment
-                env["GIT_TERMINAL_PROMPT"] = "0"   // never block on a credential prompt
-                env["GIT_PAGER"] = "cat"            // never invoke a pager
-                env["GIT_OPTIONAL_LOCKS"] = "0"     // don't take index.lock just to read status
-                proc.environment = env
-
-                let outPipe = Pipe(), errPipe = Pipe()
-                proc.standardOutput = outPipe
-                proc.standardError = errPipe
-
-                do {
-                    try proc.run()
-                } catch {
-                    cont.resume(throwing: GitError.launchFailed(error.localizedDescription))
-                    return
-                }
-
-                var outData = Data(), errData = Data()
-                let group = DispatchGroup()
-                let q = DispatchQueue(label: "app.glint.git.read", attributes: .concurrent)
-                q.async(group: group) { outData = outPipe.fileHandleForReading.readDataToEndOfFile() }
-                q.async(group: group) { errData = errPipe.fileHandleForReading.readDataToEndOfFile() }
-                group.wait()
-                proc.waitUntilExit()
-
-                cont.resume(returning: GitResult(
-                    exitCode: proc.terminationStatus,
-                    stdout: String(decoding: outData, as: UTF8.self),
-                    stderr: String(decoding: errData, as: UTF8.self)))
-            }
-        }
+    func run(_ args: [String], cwd: String?, timeout: TimeInterval?) async throws -> GitResult {
+        try await captureProcess(executable: gitPath, arguments: args,
+                                 cwd: cwd, env: gitQuietEnv(), timeout: timeout)
     }
 }
 
@@ -154,10 +194,13 @@ struct SSHGitRunner: GitRunner {
             .appendingPathComponent("glint-ssh-\(safe).sock").path
     }
 
-    func run(_ args: [String], cwd: String?) async throws -> GitResult {
+    func run(_ args: [String], cwd: String?, timeout: TimeInterval?) async throws -> GitResult {
         let argv = Self.commandArgs(target: target, port: port,
                                     controlPath: controlPath, cwd: cwd, gitArgs: args)
-        return try await Self.spawn(argv)
+        // cwd is baked into the remote `git -C` argv; the local Process just
+        // runs ssh from the app's cwd, so no local cwd here.
+        return try await captureProcess(executable: "/usr/bin/ssh", arguments: argv,
+                                        cwd: nil, env: gitQuietEnv(), timeout: timeout)
     }
 
     /// Pure: the full `ssh … git -C <cwd> <args>` argv. Split out so the wire
@@ -178,7 +221,14 @@ struct SSHGitRunner: GitRunner {
                             cwd: String?, gitArgs: [String]) -> [String] {
         var a = ["-o", "BatchMode=yes",
                  "-o", "ControlMaster=auto", "-o", "ControlPersist=10m",
-                 "-o", "ControlPath=\(controlPath)"]
+                 "-o", "ControlPath=\(controlPath)",
+                 // Bound the connection so a dead/unreachable host fails fast
+                 // instead of parking the call on the OS's ~75s TCP default.
+                 // BatchMode only blocks password PROMPTS — not DNS / connect /
+                 // key-exchange / a silent remote, which otherwise hung Review
+                 // and stacked dispatch threads until the 64-thread ceiling.
+                 "-o", "ConnectTimeout=10",
+                 "-o", "ServerAliveInterval=5", "-o", "ServerAliveCountMax=3"]
         if let port { a += ["-p", "\(port)"] }
         a.append(target)
         a.append("git")
@@ -227,41 +277,6 @@ struct SSHGitRunner: GitRunner {
         return tildePart + posixShellQuoted(String(cwd[slash...]))
     }
 
-    /// Spawn `/usr/bin/ssh <args>` and capture stdout/stderr — mirrors
-    /// `LocalGitRunner`'s concurrent-read layout so neither fixed pipe buffer
-    /// can deadlock on large diff output.
-    private static func spawn(_ sshArgs: [String]) async throws -> GitResult {
-        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<GitResult, Error>) in
-            DispatchQueue.global(qos: .userInitiated).async {
-                let proc = Process()
-                proc.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
-                proc.arguments = sshArgs
-                var env = ProcessInfo.processInfo.environment
-                env["GIT_TERMINAL_PROMPT"] = "0"
-                env["GIT_PAGER"] = "cat"
-                env["GIT_OPTIONAL_LOCKS"] = "0"
-                proc.environment = env
-                let outPipe = Pipe(), errPipe = Pipe()
-                proc.standardOutput = outPipe
-                proc.standardError = errPipe
-                do { try proc.run() } catch {
-                    cont.resume(throwing: GitError.launchFailed(error.localizedDescription))
-                    return
-                }
-                var outData = Data(), errData = Data()
-                let group = DispatchGroup()
-                let q = DispatchQueue(label: "app.glint.git.read", attributes: .concurrent)
-                q.async(group: group) { outData = outPipe.fileHandleForReading.readDataToEndOfFile() }
-                q.async(group: group) { errData = errPipe.fileHandleForReading.readDataToEndOfFile() }
-                group.wait()
-                proc.waitUntilExit()
-                cont.resume(returning: GitResult(
-                    exitCode: proc.terminationStatus,
-                    stdout: String(decoding: outData, as: UTF8.self),
-                    stderr: String(decoding: errData, as: UTF8.self)))
-            }
-        }
-    }
 }
 
 // MARK: - High-level git operations
@@ -293,11 +308,21 @@ struct GitStatus: Equatable {
 struct GitService {
     var runner: GitRunner = LocalGitRunner()
 
+    /// Ceiling for mutating git ops (worktree add/remove, branch -D, fetch,
+    /// `git apply`). Generous on purpose: these are user-initiated, and `git
+    /// apply` writes the working tree NON-atomically — a 30s ceiling could
+    /// SIGTERM it mid-flight (or SIGTERM the `git diff --output` feeding it,
+    /// leaving a truncated patch that then half-applies). Still bounded so a
+    /// wedged op can't pin threads literally forever. Read/poll callers keep
+    /// the short 30s default.
+    private static let writeTimeout: TimeInterval = 180
+
     /// Run git, throwing `commandFailed` on a non-zero exit unless `allowFailure`
     /// (used for the many "exit code IS the answer" probes like branch-exists).
     @discardableResult
-    func git(_ args: [String], cwd: String?, allowFailure: Bool = false) async throws -> GitResult {
-        let r = try await runner.run(args, cwd: cwd)
+    func git(_ args: [String], cwd: String?, allowFailure: Bool = false,
+             timeout: TimeInterval? = 30) async throws -> GitResult {
+        let r = try await runner.run(args, cwd: cwd, timeout: timeout)
         if !r.ok && !allowFailure {
             throw GitError.commandFailed(args: args, exitCode: r.exitCode, stderr: r.stderr)
         }
@@ -404,7 +429,7 @@ struct GitService {
         // `--` ends option parsing: without it a path or base ref beginning with
         // `-` (e.g. `--detach`) would be read by git as an option, not a value.
         args += ["--", expanded, base]
-        try await git(args, cwd: repo)
+        try await git(args, cwd: repo, timeout: Self.writeTimeout)
 
         let list = try await worktrees(repo: repo)
         return list.first { ($0.path as NSString).standardizingPath == (expanded as NSString).standardizingPath }
@@ -428,13 +453,15 @@ struct GitService {
         //    `git apply` silently fails. Letting git own the file keeps it exact.
         let patch = NSTemporaryDirectory() + "glint-carry-\(UUID().uuidString).patch"
         defer { try? FileManager.default.removeItem(atPath: patch) }
-        try await git(["diff", "HEAD", "--binary", "--output=\(patch)"], cwd: base)
+        try await git(["diff", "HEAD", "--binary", "--output=\(patch)"], cwd: base,
+                      timeout: Self.writeTimeout)
         // `--output` writes an empty file when there are no tracked changes;
         // skip the apply in that case (and avoid a needless subprocess).
         let attrs = try? FileManager.default.attributesOfItem(atPath: patch)
         let patchSize = (attrs?[.size] as? Int) ?? 0
         if patchSize > 0 {
-            try await git(["apply", "--whitespace=nowarn", "--", patch], cwd: wt)
+            try await git(["apply", "--whitespace=nowarn", "--", patch], cwd: wt,
+                          timeout: Self.writeTimeout)
         }
 
         // 2) Untracked, non-ignored files (build artifacts stay out via
@@ -458,19 +485,19 @@ struct GitService {
         var args = ["worktree", "remove"]
         if force { args.append("--force") }
         args += ["--", (path as NSString).expandingTildeInPath]   // `--`: path may start with `-`
-        try await git(args, cwd: repo)
+        try await git(args, cwd: repo, timeout: Self.writeTimeout)
     }
 
     func deleteBranch(repo: String, name: String, force: Bool) async throws {
-        try await git(["branch", force ? "-D" : "-d", "--", name], cwd: repo)   // `--`: name may start with `-`
+        try await git(["branch", force ? "-D" : "-d", "--", name], cwd: repo, timeout: Self.writeTimeout)   // `--`: name may start with `-`
     }
 
     func prune(repo: String) async throws {
-        try await git(["worktree", "prune"], cwd: repo)
+        try await git(["worktree", "prune"], cwd: repo, timeout: Self.writeTimeout)
     }
 
     func fetch(repo: String, remote: String = "origin") async throws {
-        try await git(["fetch", remote, "--prune"], cwd: repo)
+        try await git(["fetch", remote, "--prune"], cwd: repo, timeout: Self.writeTimeout)
     }
 
     // MARK: status

--- a/Glint/Git/GitService.swift
+++ b/Glint/Git/GitService.swift
@@ -331,6 +331,15 @@ struct GitService {
     /// the short 30s default.
     private static let writeTimeout: TimeInterval = 180
 
+    /// Ceiling for READ ops that can move a lot of data: `git diff` — especially
+    /// `fileDiff`'s `--unified=1000000`, which emits the whole file as context —
+    /// and `--numstat`, particularly over SSH. The 30s `git()` default fits tiny
+    /// probes (status poll, rev-parse, `ls-files` enumeration) but is too tight
+    /// for a large-file diff over a slow link, where it would SIGTERM mid-stream
+    /// and silently yield a blank/truncated result. Internal so GitDiff's read
+    /// callers can opt up; status/poll callers keep the short default.
+    static let readTimeout: TimeInterval = 120
+
     /// Run git, throwing `commandFailed` on a non-zero exit unless `allowFailure`
     /// (used for the many "exit code IS the answer" probes like branch-exists).
     @discardableResult

--- a/Glint/Git/GitService.swift
+++ b/Glint/Git/GitService.swift
@@ -54,6 +54,18 @@ protocol GitRunner: Sendable {
     /// the working tree non-atomically); the SSH runner's ConnectTimeout still
     /// bounds the connect phase. Read/poll callers pass a short ceiling.
     func run(_ args: [String], cwd: String?, timeout: TimeInterval?) async throws -> GitResult
+
+    /// True when `cwd` resolves on a REMOTE host (the SSH runner), so file
+    /// bytes can't be `FileManager`-read — only fetched via a `git` command.
+    /// Lets local fast paths skip a subprocess: e.g. counting untracked-file
+    /// lines by reading the file instead of one `git diff --no-index` spawn
+    /// per file (N untracked files × 4-wide concurrency sat on the Review
+    /// file-list critical path). Defaults to local; `SSHGitRunner` overrides.
+    var isRemote: Bool { get }
+}
+
+extension GitRunner {
+    var isRemote: Bool { false }
 }
 
 /// env flags shared by both runners: never block on a credential prompt, never
@@ -193,6 +205,8 @@ struct SSHGitRunner: GitRunner {
         self.controlPath = FileManager.default.temporaryDirectory
             .appendingPathComponent("glint-ssh-\(safe).sock").path
     }
+
+    var isRemote: Bool { true }
 
     func run(_ args: [String], cwd: String?, timeout: TimeInterval?) async throws -> GitResult {
         let argv = Self.commandArgs(target: target, port: port,

--- a/GlintTests/SSHGitRunnerTests.swift
+++ b/GlintTests/SSHGitRunnerTests.swift
@@ -17,6 +17,8 @@ final class SSHGitRunnerTests: XCTestCase {
             "-o", "BatchMode=yes",
             "-o", "ControlMaster=auto", "-o", "ControlPersist=10m",
             "-o", "ControlPath=/tmp/x.sock",
+            "-o", "ConnectTimeout=10",
+            "-o", "ServerAliveInterval=5", "-o", "ServerAliveCountMax=3",
             "deploy@prod-server",
             "git", "-C", "'/home/deploy/code/api'", "'status'"
         ])


### PR DESCRIPTION
## Review-window git performance: stop hangs + faster file list

### What & why
Opening the Review window could hang the app, and even when it didn't, the changed-file list was slow to appear. Two causes, plus a follow-up that tiers the read timeout and bounds the local fast path:

1. **App hangs** (`2b246d2`) — review's git work had no ceiling: a wedged `git`/`ssh` pinned dispatch threads forever, and one untracked file = one git subprocess fanned out N-wide (3 dispatch threads each), blowing the 64-thread ceiling on a repo with many untracked files.
2. **Slow file list** (`b10613e`) — the list blocked on one `git diff --no-index` subprocess *per untracked file* (bounded to 4 wide) just to badge `+N` line counts. N untracked files ⇒ `ceil(N/4)` serial rounds of process startup before the list rendered.
3. **Follow-up** (`814e2c3`) — the flat 30s read timeout was too tight for data-heavy diffs (a large-file `fileDiff` over SSH could be SIGTERM'd mid-stream into a blank result), and the local byte-count path fanned out unbounded with each whole file read into RAM. Tiered the read timeout (30s probes / 120s data-heavy reads) and bounded the local path (8-wide + 20MB/file cap → degrade to 0 like a binary).

### How
- **Hard process timeout** in `captureProcess`: SIGTERM at the deadline, SIGKILL after a 2s grace, so a stuck git/ssh can't pin threads forever. Timeouts are tiered — tiny probes (status poll, rev-parse, `ls-files`) keep a 30s default; data-heavy reads (`changedFiles`' diff/numstat, `fileDiff` — incl. the whole-file-context `--unified=1000000`) get 120s; mutating ops (`git apply`, worktree add/remove, fetch) get a generous 180s since they must not be interrupted mid-flight.
- **Bounded fan-out**: untracked counting is capped — 4 concurrent git subprocesses on the remote path (each pins 3 dispatch threads), 8 wide on the local byte-read path.
- **SSH fails fast**: `ConnectTimeout=10` + `ServerAliveInterval=5` so a dead/unreachable remote returns instead of parking on the OS's ~75s TCP default.
- **Local fast path**: new `GitRunner.isRemote` (default `false`, `SSHGitRunner` → `true`). Local repos read each untracked file's bytes directly and count in a `TaskGroup` — no `Process`, no thread pinning — so the list is no longer gated on `ceil(N/4)` rounds of process startup. Bounded to 8 wide with a 20MB-per-file cap (over that, degrade to 0 like a binary) so a repo with many large untracked files can't spike RAM. Remote keeps the bounded git spawn (the path only resolves on the far host).

The local line count matches `git diff --numstat` exactly: newline count + a trailing-line rule, with NUL-byte or bad-UTF8 ⇒ binary ⇒ 0 (same as numstat's `-`).

### Testing / verification
- `xcodebuild -sdk macosx -arch arm64` — builds clean.
- Local count formula checked against `git diff --no-index --numstat` for all 45 untracked files in this repo (incl. binary + empty): **0 mismatches**.
- Launched the Debug build; app stays alive, no launch crash.

## 中文

### 是什么 / 为什么
打开 Review 窗口可能卡死 app;就算没卡,改动文件列表也出得很慢。两个原因,加一个 follow-up(读超时分档 + 限流本地快路径):

1. **卡死**(`2b246d2`)—— review 的 git 操作没有上限:卡住的 git/ssh 会永远占着 dispatch 线程;而每个 untracked 文件起一个 git 子进程,N 个一起 fan-out(每个占 3 个 dispatch 线程),untracked 多的仓库会撑爆 64 线程上限。
2. **文件列表慢**(`b10613e`)—— 列表被「每个 untracked 文件起一个 `git diff --no-index` 数行数」卡住(并发只有 4)。N 个 untracked = `ceil(N/4)` 轮串行的进程启动,列表要等它跑完才出来。
3. **Follow-up**(`814e2c3`)—— 原来 30s 的读超时对数据量大的 diff 太紧(SSH 上大文件 `fileDiff` 会被中途 SIGTERM 成空白结果),且本地字节读路径无上限、每个文件整文件读进 RAM。于是:读超时分档(30s 探测 / 120s 大读);本地路径限流(8 并发 + 单文件 20MB 上限,超了当二进制返回 0)。

### 怎么做
- **进程硬超时**:`captureProcess` 到点 SIGTERM,2s 宽限后 SIGKILL,卡住的 git/ssh 不会再钉死线程。超时分档 —— 小探测(status 轮询、rev-parse、`ls-files`)保持 30s 默认;数据量大的读(`changedFiles` 的 diff/numstat、`fileDiff` —— 含整文件 context 的 `--unified=1000000`)给 120s;写操作(`git apply`、worktree add/remove、fetch)给宽裕的 180s,避免半途被打断。
- **限流 fan-out**:untracked 计数限流 —— 远程路径最多 4 个并发 git 子进程(每个占 3 个 dispatch 线程),本地字节读路径 8 并发。
- **SSH 快速失败**:`ConnectTimeout=10` + `ServerAliveInterval=5`,远程死了/不可达时直接返回,不在 OS 默认的 ~75s TCP 上挂着。
- **本地快路径**:新增 `GitRunner.isRemote`(默认 `false`,`SSHGitRunner` → `true`)。本地仓库直接读 untracked 文件字节、在 `TaskGroup` 里数行数 —— 无 `Process`、不占线程 —— 列表不再被 `ceil(N/4)` 轮进程启动卡住。限流到 8 并发、单文件超 20MB 当二进制返回 0,untracked 多/大的仓库不会撑爆内存。远程保持限流的 git 子进程(路径只在远端能解析)。

本地行数与 `git diff --numstat` 完全一致:换行数 + 尾行规则,NUL 字节或 UTF-8 解码失败 ⇒ 二进制 ⇒ 0(等同 numstat 的 `-`)。

### 测试 / 验证
- `xcodebuild -sdk macosx -arch arm64` 编译通过。
- 本地行数公式对这 45 个 untracked 文件(含二进制、空文件)逐个对比 `git diff --no-index --numstat`:**0 处不一致**。
- Debug 构建启动,app 保持存活,无启动崩溃。
