### PR TITLE
fix(autosuggest): make toggle-off actually strip the .zshrc block / 修复关闭历史命令自动补全后 .zshrc 托管块删不掉

### DIFF
--- a/Glint.xcodeproj/project.pbxproj
+++ b/Glint.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		47BB527385B84454ABF8FC40 /* themes.json in Resources */ = {isa = PBXBuildFile; fileRef = 6860F8F626EFDB9A289FC727 /* themes.json */; };
 		4971664CE7FBF0629C8DD709 /* ReleaseNotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 407B3A9D15F4B9E613DA1CF8 /* ReleaseNotes.swift */; };
 		49DF8EE59313B7CFE29DA303 /* PaneTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E646AABA8ADCE8A2A5C6F55 /* PaneTreeView.swift */; };
+		4ED4428EEC2AFB777092FAEF /* ShellRcBlockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3B91F000C01FEA1C7E61F5A /* ShellRcBlockTests.swift */; };
 		5157C5439862F21202BCC44D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E67CF5D8552AE1F51386161 /* AppDelegate.swift */; };
 		692D1A7D490E07D796535EAA /* UpdaterController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4408F9761E584DE2AB6630E2 /* UpdaterController.swift */; };
 		6D74FE6545631EB8193C82E1 /* PaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FC2FBC9E8729A5ECBF857C /* PaneView.swift */; };
@@ -146,6 +147,7 @@
 		E298AD81B1615CBBFD69F48A /* GhosttySurfaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttySurfaceView.swift; sourceTree = "<group>"; };
 		E94AB23640CA1E6007F8B2B4 /* GlintTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GlintTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EBCC04C19D745AA867D961FD /* PaneAgentKindTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneAgentKindTests.swift; sourceTree = "<group>"; };
+		F3B91F000C01FEA1C7E61F5A /* ShellRcBlockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellRcBlockTests.swift; sourceTree = "<group>"; };
 		F3EB9A1E80F3CC4BCA468774 /* AgentChoice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChoice.swift; sourceTree = "<group>"; };
 		F5A69ACF962AEDE189F98649 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		F8A1F24DAA7220AD4EE961E2 /* UsageStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageStore.swift; sourceTree = "<group>"; };
@@ -208,6 +210,7 @@
 				4A0B24E791FF6CEB30A9DDD5 /* RemoteTitleParserTests.swift */,
 				2CFFB91CE5C44976A6961F1F /* ReviewDiffParsingTests.swift */,
 				D7F8C1899F93B387843907FF /* ReviewScopeTests.swift */,
+				F3B91F000C01FEA1C7E61F5A /* ShellRcBlockTests.swift */,
 				4B8EDEAA2D0EAD42ED6F1915 /* SSHGitRunnerTests.swift */,
 				3FAD36B4BDB22AB47353C569 /* SyntaxHighlighterTests.swift */,
 				83E4DF4C5180D50C381B4976 /* WorkspaceIconKindTests.swift */,
@@ -465,6 +468,7 @@
 				F5AE37B67B17DD61B652E5B6 /* ReviewDiffParsingTests.swift in Sources */,
 				7072B8575DB70B2367A7EE1D /* ReviewScopeTests.swift in Sources */,
 				BFF9A1736CA029241BB0622D /* SSHGitRunnerTests.swift in Sources */,
+				4ED4428EEC2AFB777092FAEF /* ShellRcBlockTests.swift in Sources */,
 				FAB0828152636BBBBC5989CD /* SyntaxHighlighterTests.swift in Sources */,
 				C748DE21F23B49B2FFD73DC7 /* WorkspaceIconKindTests.swift in Sources */,
 			);

--- a/Glint/Agent/ShellRcBlock.swift
+++ b/Glint/Agent/ShellRcBlock.swift
@@ -51,9 +51,14 @@ enum ShellRcBlock {
 
     /// Find the block's full span — `begin` sentinel through `end` sentinel,
     /// including the trailing newline if any. Both sentinels must sit at the
-    /// start of their own line; this stops us from matching the sentinel
-    /// substring embedded in a user's own comment, heredoc, or another
-    /// tool's docs.
+    /// start of their own line, which stops us from matching the sentinel
+    /// substring embedded in a user's comment, heredoc, or another tool's
+    /// docs — and from a block body that itself quotes the sentinels (an
+    /// earlier managed block embedded an opt-out `sed` command containing
+    /// both sentinels). To survive that, after a line-anchored `begin` we
+    /// keep scanning past `end` matches that aren't at the start of their
+    /// own line until we find one that is, instead of trusting the nearest
+    /// `end` hit.
     static func locate(in text: String,
                        begin: String,
                        end: String) -> Range<String.Index>? {
@@ -62,14 +67,19 @@ enum ShellRcBlock {
               let r = text.range(of: begin, range: cursor..<text.endIndex) {
             let beginAtLineStart = r.lowerBound == text.startIndex ||
                 text[text.index(before: r.lowerBound)] == "\n"
-            if beginAtLineStart,
-               let endR = text.range(of: end, range: r.upperBound..<text.endIndex),
-               text[text.index(before: endR.lowerBound)] == "\n" {
-                var upper = endR.upperBound
-                if upper < text.endIndex, text[upper] == "\n" {
-                    upper = text.index(after: upper)
+            if beginAtLineStart {
+                var scan = r.upperBound
+                while scan < text.endIndex,
+                      let endR = text.range(of: end, range: scan..<text.endIndex) {
+                    if text[text.index(before: endR.lowerBound)] == "\n" {
+                        var upper = endR.upperBound
+                        if upper < text.endIndex, text[upper] == "\n" {
+                            upper = text.index(after: upper)
+                        }
+                        return r.lowerBound..<upper
+                    }
+                    scan = endR.upperBound
                 }
-                return r.lowerBound..<upper
             }
             cursor = r.upperBound
         }

--- a/Glint/Pane/InlineSuggestionInstaller.swift
+++ b/Glint/Pane/InlineSuggestionInstaller.swift
@@ -175,9 +175,7 @@ enum InlineSuggestionInstaller {
         let block = """
         \(beginSentinel)
         # Managed by Glint. Toggle in Settings → Terminal → Command suggestions.
-        # To opt out manually, delete this whole block (or run
-        #   sed -i '' '/\(beginSentinel)/,/\(endSentinel)/d' ~/.zshrc
-        # ).
+        # To opt out manually, delete this whole block.
         [ -f "$HOME/.config/glint/inline-suggestions.zsh" ] && source "$HOME/.config/glint/inline-suggestions.zsh"
         \(endSentinel)
         """

--- a/GlintTests/ShellRcBlockTests.swift
+++ b/GlintTests/ShellRcBlockTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import Glint
+
+/// `ShellRcBlock.locate` is the engine behind every managed `~/.zshrc` block's
+/// install / remove (inline suggestions, shell keybinds). The hard case is a
+/// block whose body itself quotes the sentinel text — Glint's own inline
+/// suggestion block used to embed an opt-out `sed` command containing both
+/// sentinels, and the nearest `end` match was that embedded (non-line-anchored)
+/// one, so `locate` returned nil and toggling the setting off never stripped
+/// the block. These tests lock the line-anchored scan that fixed it.
+final class ShellRcBlockTests: XCTestCase {
+
+    private let begin = "# >>> glint inline suggestions >>>"
+    private let end   = "# <<< glint inline suggestions <<<"
+
+    /// The regression: a block body that quotes the sentinels (the old managed
+    /// block, which embedded a sed one-liner referencing both) must still be
+    /// located and fully removed.
+    func testRemoveBlockWhoseBodyQuotesSentinels() {
+        let block = """
+        \(begin)
+        # Managed by Glint. Toggle in Settings → Terminal → Command suggestions.
+        #   sed -i '' '/\(begin)/,/\(end)/d' ~/.zshrc
+        [ -f "$HOME/.config/glint/inline-suggestions.zsh" ] && source "$HOME/.config/glint/inline-suggestions.zsh"
+        \(end)
+        """
+        let text = "alias ss=moshpit\n\n" + block + "\nalias foo=bar\n"
+
+        let removed = ShellRcBlock.remove(from: text, begin: begin, end: end)
+
+        XCTAssertFalse(removed.contains("inline-suggestions"),
+                       "block body should be gone; got:\n\(removed)")
+        XCTAssertTrue(removed.contains("alias ss=moshpit"), "content above must survive")
+        XCTAssertTrue(removed.contains("alias foo=bar"), "content below must survive")
+    }
+
+    func testRemovePlainBlock() {
+        let text = "a\n\(begin)\nsource x\n\(end)\nb\n"
+        XCTAssertEqual(ShellRcBlock.remove(from: text, begin: begin, end: end),
+                       "a\nb\n")
+    }
+
+    func testRemoveIsNoOpWhenNoBlock() {
+        let text = "just user config\n"
+        XCTAssertEqual(ShellRcBlock.remove(from: text, begin: begin, end: end), text)
+    }
+
+    func testRemoveIsNoOpWhenOnlySentinelSubstringInAComment() {
+        // Sentinel text not at line start must not be treated as a block.
+        let text = "# see \(begin) somewhere\nuser config\n"
+        XCTAssertEqual(ShellRcBlock.remove(from: text, begin: begin, end: end), text)
+    }
+
+    func testUpsertReplacesBlockInPlace() {
+        // `upsert` consumes the newline after `end`, so the replacement block
+        // must carry its own trailing newline (the real managed block does).
+        let old = "pre\n\(begin)\nold body\n\(end)\npost\n"
+        let new = "\(begin)\nnew body\n\(end)\n"
+        let result = ShellRcBlock.upsert(in: old, begin: begin, end: end, block: new)
+        XCTAssertEqual(result, "pre\n\(begin)\nnew body\n\(end)\npost\n")
+    }
+
+    func testUpsertAppendsWhenAbsent() {
+        let result = ShellRcBlock.upsert(in: "user config\n",
+                                         begin: begin, end: end,
+                                         block: "\(begin)\nx\n\(end)")
+        XCTAssertEqual(result, "user config\n\n\(begin)\nx\n\(end)\n")
+    }
+
+    func testUpsertReplacesBlockThatQuotesSentinelsInBody() {
+        // Idempotent re-apply on launch must rewrite a block whose body quotes
+        // the sentinels (the regression), not append a second block.
+        let old = "pre\n\(begin)\n#   sed -i '' '/\(begin)/,/\(end)/d' ~/.zshrc\n\(end)\npost\n"
+        let updated = "\(begin)\nnew\n\(end)\n"
+        let result = ShellRcBlock.upsert(in: old, begin: begin, end: end, block: updated)
+        XCTAssertEqual(result, "pre\n\(begin)\nnew\n\(end)\npost\n")
+    }
+}


### PR DESCRIPTION
## What & why

Toggling **Settings → Terminal → Command suggestions** off did not actually disable the feature: the managed block in `~/.zshrc` was never stripped, so every new zsh pane kept loading `zsh-autosuggestions`. The setting read as off in the app (`glint.inlineSuggestion.enabled = 0`) while the shell-side block persisted — the two sides stayed out of sync.

Root cause: `ShellRcBlock.locate` matched only the **first** `end` sentinel after a line-anchored `begin`. The managed block's own comment embedded an opt-out `sed` one-liner that quoted *both* sentinels, so that embedded (non-line-anchored) `end` was treated as the block close, `locate` returned nil, and `removeZshrcBlock` became a no-op. The toggle-off path could never remove the block.

## How

- `ShellRcBlock.locate`: after a line-anchored `begin`, keep scanning past `end` matches that aren't at the start of their own line until the real line-anchored close is found — instead of trusting the nearest `end` hit. Fixes both `remove` and in-place `upsert`. This also auto-heals already-deployed blocks (the ones carrying the old `sed` comment) on the next launch reconcile, since `WorkspaceStore` re-applies the enabled state at startup.
- `InlineSuggestionInstaller.ensureZshrcBlock`: drop the embedded `sed` opt-out one-liner from the block comment (it triggered the bug and was itself broken — `sed` range semantics hit the same sentinel-in-comment problem).

## Testing / verification

- Standalone Swift repro confirmed the old `locate` returned nil for the real block; the new one resolves it.
- New `GlintTests/ShellRcBlockTests.swift` (7 cases): block whose body quotes the sentinels (remove + upsert), plain block, no-block no-op, sentinel-substring-in-comment no-op, append-when-absent. All pass.
- `xcodebuild test -sdk macosx -arch arm64 -only-testing:GlintTests/ShellRcBlockTests` → **TEST SUCCEEDED**.

Note: already-running zsh sessions keep suggesting until restarted (plugin is loaded into the shell process) — documented, by design. Only newly spawned panes are affected by the toggle, which now actually works.

---

## 中文

### 问题与原因
关闭 **Settings → Terminal → Command suggestions** 后并没有真正停用:写在 `~/.zshrc` 里的托管块始终删不掉,新开的 zsh 面板照旧加载 `zsh-autosuggestions`。App 里设置显示已关(`glint.inlineSuggestion.enabled = 0`),但 shell 侧的块还在 —— 两边状态不一致。

根因:`ShellRcBlock.locate` 在行首 `begin` 之后只匹配**第一个** `end` 哨兵。而托管块的注释里嵌了一条"手动退出"的 sed 命令,该命令**同时引用了 begin 和 end 两个哨兵**,于是那个非行首的 `end` 被当成块尾,`locate` 返回 nil,`removeZshrcBlock` 变 no-op —— 关掉开关永远删不掉块。

### 怎么改
- `ShellRcBlock.locate`:行首 `begin` 命中后,跳过所有不在行首的 `end` 匹配,直到找到行首的真正块尾,不再轻信最近的 `end`。`remove` 和原地 `upsert` 一并修好;由于 `WorkspaceStore` 启动时会重新应用启用状态,已部署的旧块(带 sed 注释那种)也会在下次启动 reconcile 时自动清掉。
- `InlineSuggestionInstaller.ensureZshrcBlock`:去掉块注释里那条 sed one-liner(它既触发 bug,自身也是坏的 —— `sed` 范围语义会撞同样的哨兵问题)。

### 测试 / 验证
- 独立 Swift 脚本复现:旧 `locate` 对真实块返回 nil,新版正确解析。
- 新增 `GlintTests/ShellRcBlockTests.swift`(7 条):块体含哨兵文本的删除 / 原地重写、普通块、无块 no-op、纯哨兵注释 no-op、无块时追加。全过。
- `xcodebuild test -sdk macosx -arch arm64 -only-testing:GlintTests/ShellRcBlockTests` → **TEST SUCCEEDED**。

补充:已经开着的 zsh 会话在重启前还会补全(插件已 load 进 shell 进程)—— 这是设计如此、有文档的;开关只影响之后新起的面板,而现在它确实生效了。
