### PR TITLE
feat(open): accept folder/file/glint:// path args / 接收 文件夹/文件/glint:// 路径参数

### DIFF
--- a/Glint.xcodeproj/project.pbxproj
+++ b/Glint.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		B1DE20B081ACC4536DBD2089 /* GitStatusPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54663E213FE879B96C0D80E7 /* GitStatusPopover.swift */; };
 		B70CAFEBB2416E25B0FFED97 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = C48F9D3C512A0ABE8369D0F4 /* Sparkle */; };
 		BFF9A1736CA029241BB0622D /* SSHGitRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B8EDEAA2D0EAD42ED6F1915 /* SSHGitRunnerTests.swift */; };
+		C0667FA434EF07D98DED44D1 /* AEBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D5B5D0462A1225A56E6EE85 /* AEBridge.m */; };
 		C0E8D97C08BA3F0FA33F31E7 /* CommandPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 235E2D958A2244483CAA0812 /* CommandPalette.swift */; };
 		C11ED5034D6EF2BA539846AD /* FontCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = C753FB652599A4C7900F8AA4 /* FontCatalog.swift */; };
 		C41119D04864077E5B554F59 /* CodexHomeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AB338782EF6F22B7B381DA8 /* CodexHomeStoreTests.swift */; };
@@ -90,12 +91,14 @@
 		08FC2FBC9E8729A5ECBF857C /* PaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneView.swift; sourceTree = "<group>"; };
 		0C5FD3EEA1ECD40F78394862 /* AgentLaunchChooser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLaunchChooser.swift; sourceTree = "<group>"; };
 		0D29C0D2447094B07854C193 /* NewWorkspaceSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorkspaceSheet.swift; sourceTree = "<group>"; };
+		0D5B5D0462A1225A56E6EE85 /* AEBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AEBridge.m; sourceTree = "<group>"; };
 		0F58E2127BAE2C9F5155CF07 /* DevinHookInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevinHookInstallerTests.swift; sourceTree = "<group>"; };
 		0FBF22AEC81DBE92987A8CB4 /* CodexUsageReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexUsageReaderTests.swift; sourceTree = "<group>"; };
 		150EEF32284061D527E51866 /* GlintTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlintTheme.swift; sourceTree = "<group>"; };
 		16137B405E48DBE262A15B6D /* PaneSurfaceRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneSurfaceRepresentable.swift; sourceTree = "<group>"; };
 		1E646AABA8ADCE8A2A5C6F55 /* PaneTreeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneTreeView.swift; sourceTree = "<group>"; };
 		21868C7211897C87A6CAD7C3 /* ControlBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlBridge.swift; sourceTree = "<group>"; };
+		223D9249D7FF29F87D9DE3A4 /* Glint-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Glint-Bridging-Header.h"; sourceTree = "<group>"; };
 		235E2D958A2244483CAA0812 /* CommandPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPalette.swift; sourceTree = "<group>"; };
 		25DADCEBA9C483C729B69388 /* Glint.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Glint.entitlements; sourceTree = "<group>"; };
 		26141150D2DB4C0589558ECC /* CodexHookInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexHookInstallerTests.swift; sourceTree = "<group>"; };
@@ -318,7 +321,9 @@
 		CE6E633968E3B9EE7F187610 /* App */ = {
 			isa = PBXGroup;
 			children = (
+				0D5B5D0462A1225A56E6EE85 /* AEBridge.m */,
 				9E67CF5D8552AE1F51386161 /* AppDelegate.swift */,
+				223D9249D7FF29F87D9DE3A4 /* Glint-Bridging-Header.h */,
 				7CB74659D174004C620D538A /* GlintApp.swift */,
 				407B3A9D15F4B9E613DA1CF8 /* ReleaseNotes.swift */,
 				DB20921E3CAC1006A8FBD3AE /* SettingsSafety.swift */,
@@ -478,6 +483,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C0667FA434EF07D98DED44D1 /* AEBridge.m in Sources */,
 				E464D0233508CD31C1235054 /* AgentBridge.swift in Sources */,
 				9F605AB2DC185A94ED28E6D4 /* AgentChoice.swift in Sources */,
 				3932A4CFEFF6FB81AE283645 /* AgentHookInstaller.swift in Sources */,
@@ -592,6 +598,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = app.glint.Glint;
 				PRODUCT_NAME = Glint;
 				SDKROOT = macosx;
+				SWIFT_OBJC_BRIDGING_HEADER = "Glint/App/Glint-Bridging-Header.h";
 			};
 			name = Release;
 		};
@@ -720,6 +727,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = app.glint.Glint.dev;
 				PRODUCT_NAME = Glint;
 				SDKROOT = macosx;
+				SWIFT_OBJC_BRIDGING_HEADER = "Glint/App/Glint-Bridging-Header.h";
 			};
 			name = Debug;
 		};

--- a/Glint/App/AEBridge.m
+++ b/Glint/App/AEBridge.m
@@ -1,0 +1,11 @@
+// One ObjC shim: `NSAppleEventDescriptor.descriptorAtIndex:` isn't bridged to
+// Swift on the current SDK, and `perform(_:with:)`/`NSInvocation` can't pass a
+// primitive NSInteger index. This is the clean way around it — a plain C entry
+// point the Swift side reaches through the bridging header. See
+// AppDelegate.descriptorList / glint_aeDescriptorAtIndex.
+
+#import "Glint-Bridging-Header.h"
+
+NSAppleEventDescriptor *glint_aeDescriptorAtIndex(NSAppleEventDescriptor *list, NSInteger index) {
+    return [list descriptorAtIndex:index];
+}

--- a/Glint/App/AppDelegate.swift
+++ b/Glint/App/AppDelegate.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CoreServices
 import CoreText
 import UserNotifications
 
@@ -47,6 +48,92 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             DispatchQueue.global(qos: .utility).async {
                 FontCatalog.warmCache()
             }
+        }
+    }
+
+    /// Intercept folder / file / `glint://` opens at the raw Apple-Event level,
+    /// BEFORE NSApplication's default dispatch sees them.
+    ///
+    /// Why not `application(_:open:)` or `.onOpenURL`: Glint declares
+    /// `CFBundleDocumentTypes` so Launch Services will deliver an `odoc` event
+    /// for a folder/file — but on a running single-`Window` SwiftUI app, when
+    /// SwiftUI/NSApplication's default handler processes that `odoc`, it tears
+    /// the window down, and `applicationShouldTerminateAfterLastWindowClosed`
+    /// then quits the app. Registering our own `kAEOpenDocuments` / `kAEOpenURLs`
+    /// handlers pre-empts that: NSApplication sees a handler is already set and
+    /// skips its default dispatch, so SwiftUI never reacts and the window stays.
+    /// We route the paths to `WorkspaceStore` ourselves.
+    ///
+    /// Must run in `applicationWillFinishLaunching` (before NSApplication
+    /// installs its own handlers during finishLaunching). Cold-launch timing is
+    /// handled by the `pendingOpenURLs` queue + `WorkspaceStore.init` drain.
+    func applicationWillFinishLaunching(_ notification: Notification) {
+        let aem = NSAppleEventManager.shared()
+        aem.setEventHandler(self, andSelector: #selector(appleEventOpenDocuments(_:withReplyEvent:)),
+                            forEventClass: kCoreEventClass, andEventID: kAEOpenDocuments)
+        aem.setEventHandler(self, andSelector: #selector(appleEventOpenURLs(_:withReplyEvent:)),
+                            forEventClass: AEEventClass(kInternetEventClass),
+                            andEventID: AEEventID(kAEGetURL))
+    }
+
+    /// `kAEOpenDocuments` (odoc): Finder "Open With", dock drop, `open -a Glint
+    /// <folder>`. The direct object is a list of file-ref descriptors; coerce
+    /// each to a `file://` URL.
+    @objc private func appleEventOpenDocuments(_ event: NSAppleEventDescriptor, withReplyEvent replyEvent: NSAppleEventDescriptor) {
+        Self.deliver(extractFileURLs(from: event))
+    }
+
+    /// `kAEGetURL` (GURL): a `glint://` link.
+    @objc private func appleEventOpenURLs(_ event: NSAppleEventDescriptor, withReplyEvent replyEvent: NSAppleEventDescriptor) {
+        Self.deliver(extractURLStrings(from: event))
+    }
+
+    private func extractFileURLs(from event: NSAppleEventDescriptor) -> [URL] {
+        guard let direct = event.paramDescriptor(forKeyword: keyDirectObject) else { return [] }
+        // fileURLValue coerces each item (alias / file-ref descriptor) to a URL.
+        return descriptorList(direct).compactMap { $0.fileURLValue }
+    }
+
+    private func extractURLStrings(from event: NSAppleEventDescriptor) -> [URL] {
+        guard let direct = event.paramDescriptor(forKeyword: keyDirectObject) else { return [] }
+        // GURL's direct object is a URL string (sometimes a list of them).
+        return descriptorList(direct).compactMap { $0.stringValue.flatMap(URL.init(string:)) }
+    }
+
+    /// Treat `desc` as a list of descriptors, or a single-element list if it
+    /// isn't an AEList. `descriptorAtIndex:` isn't bridged to Swift on this SDK
+    /// (and `perform(_:with:)`/`NSInvocation` can't pass a primitive NSInteger),
+    /// so reach it through the `glint_aeDescriptorAtIndex` ObjC shim in
+    /// AEBridge.m. Items are 1-indexed.
+    private func descriptorList(_ desc: NSAppleEventDescriptor) -> [NSAppleEventDescriptor] {
+        guard desc.descriptorType == typeAEList else { return [desc] }
+        let n = desc.numberOfItems
+        guard n > 0 else { return [] }
+        return (1...n).compactMap { glint_aeDescriptorAtIndex(desc, $0) }
+    }
+
+    private static var pendingOpenURLs: [URL] = []
+    /// Re-entry guard: `openURL` may run a modal (the execute-file confirm)
+    /// whose nested run loop delivers more Apple Events → `deliver` → `flush`.
+    /// The guard makes re-entrant calls a no-op; the outer `flush` loop keeps
+    /// draining `pendingOpenURLs` after each modal returns, so confirms never
+    /// stack on top of each other.
+    private static var isFlushing = false
+    private static func deliver(_ urls: [URL]) {
+        guard !urls.isEmpty else { return }
+        pendingOpenURLs.append(contentsOf: urls)
+        flush()
+    }
+    /// Drain anything queued before the store existed. Called from `deliver`
+    /// (warm) and from `WorkspaceStore.init` (cold, once `current` is set).
+    static func flush() {
+        guard let store = WorkspaceStore.current, !pendingOpenURLs.isEmpty else { return }
+        guard !isFlushing else { return }
+        isFlushing = true
+        defer { isFlushing = false }
+        while let url = pendingOpenURLs.first {
+            pendingOpenURLs.removeFirst()
+            store.openURL(url)
         }
     }
 

--- a/Glint/App/Glint-Bridging-Header.h
+++ b/Glint/App/Glint-Bridging-Header.h
@@ -1,0 +1,11 @@
+#ifndef Glint_Bridging_Header_h
+#define Glint_Bridging_Header_h
+
+#import <Foundation/Foundation.h>
+
+/// `-[NSAppleEventDescriptor descriptorAtIndex:]` isn't bridged to Swift on the
+/// current SDK (its indexed-list access is missing from the Swift overlay), so
+/// expose it via this one-line helper. Items are 1-indexed.
+NSAppleEventDescriptor *glint_aeDescriptorAtIndex(NSAppleEventDescriptor *list, NSInteger index);
+
+#endif /* Glint_Bridging_Header_h */

--- a/Glint/Resources/Info.plist
+++ b/Glint/Resources/Info.plist
@@ -41,5 +41,46 @@
 	<string>https://raw.githubusercontent.com/chenbstack/glint/main/appcast.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>H8aS+y7VAi2SyldeYcNAHur5C4JqM4eLetjOXKYOaQc=</string>
+	<!-- Receiving paths: folders open as a workspace, plain files execute after
+	     a confirm, and glint:// URLs carry a path query param. Alternate rank so
+	     Glint never steals Finder's default — it only appears in "Open With". -->
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Folder</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.folder</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>File</string>
+			<key>CFBundleTypeRole</key>
+			<string>Shell</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.item</string>
+			</array>
+		</dict>
+	</array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>app.glint.Glint</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>glint</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/Glint/Resources/Localizable.xcstrings
+++ b/Glint/Resources/Localizable.xcstrings
@@ -1,6 +1,17 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "\"%@\" is not executable.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\" 不是可执行文件。"
+          }
+        }
+      }
+    },
     "%@": {},
     "%@ used": {
       "extractionState": "manual",
@@ -560,6 +571,28 @@
           "stringUnit": {
             "state": "translated",
             "value": "构建通道"
+          }
+        }
+      }
+    },
+    "Allow": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "允许"
+          }
+        }
+      }
+    },
+    "Allow Glint to execute \"%@\"?": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "允许 Glint 执行 \"%@\"?"
           }
         }
       }
@@ -1821,6 +1854,17 @@
         }
       }
     },
+    "Glint can only run files with the executable bit set.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Glint 只能运行设置了可执行权限的文件。"
+          }
+        }
+      }
+    },
     "Glint can register a small hook with Claude Code (~/.claude/settings.json) and Codex (~/.codex/hooks.json) that reports when an agent is thinking, finished, or waiting for approval. It only sends events to Glint on this Mac. You can uninstall it anytime in Settings → Agents.": {
       "extractionState": "manual",
       "localizations": {
@@ -1891,6 +1935,17 @@
           "stringUnit": {
             "state": "translated",
             "value": "Glint 会在后台查找新版本。"
+          }
+        }
+      }
+    },
+    "Glint will run this file in a shell at its parent directory.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Glint 将在其父目录的 shell 中运行此文件。"
           }
         }
       }
@@ -2578,6 +2633,17 @@
           "stringUnit": {
             "state": "translated",
             "value": "新建工作区 · %@"
+          }
+        }
+      }
+    },
+    "New workspace": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新建工作区"
           }
         }
       }

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -1357,6 +1357,10 @@ final class WorkspaceStore: ObservableObject {
         }
         self.sidebarCollapsed = loaded.sidebarCollapsed
         Self.current = self
+        // Drain paths Launch Services handed us before the store existed (cold
+        // launch with a folder/file/glint:// URL). No-op when nothing's pending;
+        // AppDelegate.deliver also calls flush() for warm-launch opens.
+        DispatchQueue.main.async { AppDelegate.flush() }
 
         // Reconcile the zsh-side inline-suggestion install on every launch:
         // first-ever launch installs from the current default; subsequent
@@ -2459,13 +2463,13 @@ final class WorkspaceStore: ObservableObject {
     /// Open a new tab in the current workspace, inheriting the focused pane's
     /// cwd (terminal convention: a new tab opens "here"). Inserts it right
     /// after the current tab and selects it.
-    func newTab(agentCommand: String? = nil, codexHome: String? = nil) {
+    func newTab(cwd: String? = nil, agentCommand: String? = nil, codexHome: String? = nil) {
         guard let i = currentIndex else { return }
         let inheritedCwd = (workspaces[i].selectedTab?.focusedPane)
             .flatMap { workspaces[i].panes[$0]?.workingDirectory }
         let pane = PaneID(value: workspaces[i].nextPaneSeq)
         workspaces[i].nextPaneSeq += 1
-        workspaces[i].panes[pane] = Pane(id: pane, title: "zsh", workingDirectory: inheritedCwd)
+        workspaces[i].panes[pane] = Pane(id: pane, title: "zsh", workingDirectory: cwd ?? inheritedCwd)
         let tab = WorkspaceTab(id: TabID(value: workspaces[i].nextTabSeq), name: nil,
                                root: .leaf(pane), focusedPane: pane)
         workspaces[i].nextTabSeq += 1
@@ -2720,18 +2724,135 @@ final class WorkspaceStore: ObservableObject {
         ]
         let pick = palette[workspaces.count % palette.count]
         // Auto-named: fallback label is "New workspace" until the shell reports a cwd.
-        let ws = Workspace.fresh(name: "New workspace", accentHex: pick.0, symbol: pick.1)
+        let ws = Workspace.fresh(name: String(localized: "New workspace"), accentHex: pick.0, symbol: pick.1)
         workspaces.append(ws)
         selectedWorkspaceID = ws.id
         // Workspace.fresh seeds a single pane at PaneID 0.
         queueInitialInput(agentCommand, codexHome: codexHome, workspace: ws.id, pane: PaneID(value: 0))
     }
 
-    /// Open a workspace anchored at `directory` (the "Local Repo" source). The
-    /// shell is seeded there immediately so it opens in the right place — the old
-    /// stub called `addWorkspace()` and dropped the path, landing the user in
-    /// their home dir. If the directory is inside a git repo, the source is then
-    /// upgraded to `.localRepo` so the git button / worktree actions light up.
+    // MARK: - Open via path (Launch Services: folders / files / glint://)
+
+    /// Route a URL handed to Glint by Launch Services (`open -a Glint <path>`,
+    /// Finder "Open With", a dock drop, an external launcher, a `glint://` link).
+    /// File URLs and `glint://open?path=…` both bottom out in `openPath`. Entry
+    /// point: raw `odoc`/`GURL` Apple-Event handlers registered in
+    /// `AppDelegate.applicationWillFinishLaunching` (intercepted there because
+    /// SwiftUI's default handling tears the single-`Window` scene down on a warm
+    /// odoc); the cold-launch queue + drain live in `AppDelegate.flush`.
+    func openURL(_ url: URL) {
+        if url.isFileURL {
+            openPath(url.path)
+        } else if url.scheme == "glint" {
+            // glint://open?path=<percent-encoded absolute path>. Query form so
+            // slashes / special chars in the path survive URLComponents intact.
+            guard let comps = URLComponents(url: url, resolvingAgainstBaseURL: false),
+                  let raw = comps.queryItems?.first(where: { $0.name == "path" })?.value,
+                  !raw.isEmpty else { return }
+            openPath((raw as NSString).expandingTildeInPath)
+        }
+    }
+
+    /// Dispatch a filesystem path to folder- or file-handling by what's on disk.
+    private func openPath(_ path: String) {
+        let standardized = (path as NSString).standardizingPath
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: standardized, isDirectory: &isDir) else { return }
+        if isDir.boolValue { openFolder(standardized) } else { openFile(standardized) }
+    }
+
+    /// Open a workspace anchored at `directory`. If a workspace already anchored
+    /// there exists, switch to it and open a new tab; otherwise append a new one.
+    /// The append runs synchronously so a concurrent open of the same folder
+    /// dedupes instead of racing into a duplicate; the source is upgraded to
+    /// `.localRepo` in place once git reports the repo root.
+    private func openFolder(_ directory: String) {
+        if let existing = workspaces.first(where: { isAnchoredAt($0, directory) }) {
+            selectedWorkspaceID = existing.id
+            newTab(cwd: directory)
+            return
+        }
+        let dirName = (directory as NSString).lastPathComponent
+        let wsID = appendWorkspace(cwd: directory, source: .plain,
+                                   name: dirName.isEmpty ? String(localized: "New workspace") : dirName)
+        Task {
+            if let root = await git.repoRoot(at: directory),
+               let i = workspaces.firstIndex(where: { $0.id == wsID }) {
+                workspaces[i].source = WorkspaceSource(kind: .localRepo, repoRoot: root)
+            }
+            await refreshGitStatus(for: wsID)
+        }
+    }
+
+    /// True if `ws` opens into `directory` — for deduping folder opens. Matches
+    /// the bound repo root (or, for a worktree, its worktree path — a worktree
+    /// shares `repoRoot` with the main checkout, so matching on repoRoot would
+    /// wrongly absorb a main-repo open into a worktree workspace) OR the focused
+    /// pane's cwd (covers a workspace opened at a repo subdir).
+    private func isAnchoredAt(_ ws: Workspace, _ directory: String) -> Bool {
+        let boundPath = (ws.source.kind == .localWorktree) ? ws.source.worktreePath : ws.source.repoRoot
+        if boundPath == directory { return true }
+        let cwd = (ws.selectedTab?.focusedPane).flatMap { ws.panes[$0]?.workingDirectory }
+            ?? ws.panes.values.compactMap(\.workingDirectory).first
+        return cwd == directory
+    }
+
+    /// Execute a plain file in a shell (mirrors Ghostty's openFile): confirm,
+    /// then run `'<path>'; exit` with the parent directory as cwd. Non-executable
+    /// files are refused upfront (otherwise the pane just dies with "permission
+    /// denied"). Always asks — no "don't ask again" — because executing an
+    /// arbitrary file is a trust boundary.
+    private func openFile(_ path: String) {
+        guard FileManager.default.isExecutableFile(atPath: path) else {
+            let alert = NSAlert()
+            alert.messageText = String(format: String(localized: "\"%@\" is not executable."),
+                                       (path as NSString).lastPathComponent)
+            alert.informativeText = String(localized: "Glint can only run files with the executable bit set.")
+            alert.alertStyle = .informational
+            alert.addButton(withTitle: String(localized: "OK"))
+            alert.runModal()
+            return
+        }
+        let alert = NSAlert()
+        alert.messageText = String(format: String(localized: "Allow Glint to execute \"%@\"?"), path)
+        alert.informativeText = String(localized: "Glint will run this file in a shell at its parent directory.")
+        alert.alertStyle = .warning
+        // Cancel is the default button (Enter) so executing the file takes an
+        // explicit click on Allow rather than a reflexive ⏎.
+        alert.addButton(withTitle: String(localized: "Cancel"))
+        alert.addButton(withTitle: String(localized: "Allow"))
+        guard alert.runModal() == .alertSecondButtonReturn else { return }
+        let cmd = posixShellQuoted(path) + "; exit\n"
+        appendWorkspace(cwd: (path as NSString).deletingLastPathComponent,
+                        source: .plain,
+                        name: (path as NSString).lastPathComponent,
+                        initialInput: cmd)
+    }
+
+    /// Append a fresh single-pane workspace anchored at `cwd`, select it,
+    /// optionally seed the first pane's shell input (and Codex home), and return
+    /// its id. The single factory for "create an empty workspace" — used by
+    /// `openFolder`, `openFile`, and `createWorktreeWorkspace`.
+    @discardableResult
+    private func appendWorkspace(cwd: String, source: WorkspaceSource,
+                                 name: String, initialInput: String? = nil,
+                                 codexHome: String? = nil) -> UUID {
+        let first = PaneID(value: 0)
+        let pane = Pane(id: first, title: "zsh", workingDirectory: cwd)
+        let tab = WorkspaceTab(id: TabID(value: 0), name: nil, root: .leaf(first), focusedPane: first)
+        let ws = Workspace(
+            id: UUID(), name: name, userNamed: false,
+            accentHex: nextAccentHex(), symbol: "•",
+            tabs: [tab], selectedTabID: tab.id, nextTabSeq: 1,
+            panes: [first: pane], nextPaneSeq: 1,
+            source: source)
+        workspaces.append(ws)
+        selectedWorkspaceID = ws.id
+        // queueInitialInput also persists codexHome onto the pane (restart path).
+        queueInitialInput(initialInput, codexHome: codexHome, workspace: ws.id, pane: first)
+        return ws.id
+    }
+
     // MARK: - Worktree (Plan B: out-of-band git, never via the terminal)
 
     private func nextAccentHex() -> String {
@@ -2783,27 +2904,17 @@ final class WorkspaceStore: ObservableObject {
             catch { carryFailed = true }
         }
 
-        let first = PaneID(value: 0)
-        var pane = Pane(id: first, title: "zsh", workingDirectory: expanded)
-        pane.codexHome = codexHome
-        let tab = WorkspaceTab(id: TabID(value: 0), name: nil, root: .leaf(first), focusedPane: first)
-        let ws = Workspace(
-            id: UUID(), name: "New workspace", userNamed: false,
-            accentHex: nextAccentHex(), symbol: "•",
-            tabs: [tab], selectedTabID: tab.id, nextTabSeq: 1,
-            panes: [first: pane], nextPaneSeq: 1,
+        let wsID = appendWorkspace(
+            cwd: expanded,
             source: WorkspaceSource(kind: .localWorktree, repoRoot: repoRoot,
                                     branch: branch, baseBranch: baseBranch,
-                                    worktreePath: expanded))
-        if let cmd = agentCommand, !cmd.isEmpty {
-            let key = WorkspacePaneKey(workspace: ws.id, pane: first)
-            pendingInitialInput[key] = cmd.hasSuffix("\n") ? cmd : cmd + "\n"
-        }
-        workspaces.append(ws)
-        selectedWorkspaceID = ws.id
+                                    worktreePath: expanded),
+            name: String(localized: "New workspace"),
+            initialInput: agentCommand,
+            codexHome: codexHome)
         if carryFailed { worktreeCarryFailed = true }
-        await refreshGitStatus(for: ws.id)
-        return ws.id
+        await refreshGitStatus(for: wsID)
+        return wsID
     }
 
     /// Remove a worktree from disk (`git worktree remove`) and close its

--- a/project.yml
+++ b/project.yml
@@ -35,6 +35,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: app.glint.Glint
         INFOPLIST_FILE: Glint/Resources/Info.plist
         CODE_SIGN_ENTITLEMENTS: Glint/Resources/Glint.entitlements
+        SWIFT_OBJC_BRIDGING_HEADER: Glint/App/Glint-Bridging-Header.h
         CODE_SIGN_STYLE: Automatic
         CODE_SIGN_IDENTITY: "-"
         DEVELOPMENT_TEAM: ""


### PR DESCRIPTION
## What & why

Glint couldn't receive paths from Launch Services — an external launcher / Finder "Open With" / dock drop / `open -a Glint <path>` produced *"glint.app cannot open the specified document or URL"* because `Info.plist` declared no document types and there was no open handler. This adds folder / file / `glint://` reception and routes them into workspaces.

## Behavior

- **Folder** → new workspace anchored there; `source` becomes `.localRepo` if it's inside a git repo (git button / worktree actions light up). Reopening the **same** folder switches to the existing workspace + opens a tab instead of duplicating.
- **Plain file** → confirm dialog, then run `'<path>'; exit` at the file's parent dir. **Cancel is the default button** (executing an arbitrary file must take an explicit click), and non-executable files are refused upfront instead of spawning a pane that dies with "permission denied".
- **`glint://open?path=<percent-encoded>`** → resolved and treated as folder-or-file by what's on disk.

## How

`Info.plist` declares `CFBundleDocumentTypes` (`public.folder` Viewer + `public.item` Shell, both `Alternate` rank so Glint never steals Finder's default) and a `glint` URL scheme.

The open events are intercepted as **raw Apple Events** in `applicationWillFinishLaunching` (`kAEOpenDocuments` / `kAEGetURL`). Why not `application(_:open:)` or `.onOpenURL`: on a running single-`Window` SwiftUI app, the default `odoc` handler tears the window down, and `applicationShouldTerminateAfterLastWindowClosed` then quits the app — and neither the delegate method nor `.onOpenURL` can prevent it (verified). Registering our own handlers pre-empts NSApplication's default dispatch, so SwiftUI never reacts and the window stays. Cold-launch opens (which arrive before the `WorkspaceStore` exists) queue in `AppDelegate.pendingOpenURLs` and drain from `WorkspaceStore.init`.

`NSAppleEventDescriptor.descriptorAtIndex:` isn't Swift-bridged on the current SDK (and `perform`/`NSInvocation` can't pass a primitive `NSInteger`), so a 2-line ObjC shim (`AEBridge.m`) exposes it via a bridging header.

A few correctness details worth noting:
- `openFolder` appends the workspace **synchronously** (placeholder `.plain`) so concurrent opens of the same folder dedupe instead of racing into duplicates; the source is upgraded to `.localRepo` in place once git reports the repo root.
- Dedupe (`isAnchoredAt`) matches the bound repo root — or, for a worktree, its worktree path (a worktree shares `repoRoot` with the main checkout, so matching on `repoRoot` would wrongly absorb a main-repo open into a worktree workspace) — or the focused pane's cwd (covers a workspace opened at a repo subdir).
- `AppDelegate.flush` has a re-entry guard so an `odoc` delivered during the execute-file `runModal` can't stack a second modal.

All new user-facing strings are localized (en + zh-Hans). New files: `Glint/App/AEBridge.m`, `Glint/App/Glint-Bridging-Header.h`; `project.yml` sets `SWIFT_OBJC_BRIDGING_HEADER`.

## Testing / verification

`xcodebuild -sdk macosx -arch arm64` — **BUILD SUCCEEDED**. Drove the built app end-to-end (verified via the persisted `state.json` + liveness):

- Cold `open -a Glint <repo>` → workspace created, `.localRepo`, pane cwd = the repo.
- Warm open of a **new** folder → new workspace, app stays alive.
- Warm reopen of the **same** folder → switches + new tab (no duplicate).
- Open a **subdir** of an already-open repo → separate workspace (not absorbed); reopening that subdir dedupes.
- Rapid double-open of the same folder → **1** workspace (no TOCTOU duplicate).
- `glint://open?path=…` → routed correctly.
- No quit-on-second-open regression (the original bug).

Reviewed the diff before opening this PR; 8 findings (dedupe predicate, default button, non-executable handling, TOCTOU race, duplicated workspace construction, an un-localized "New workspace" literal, modal stacking, a stale doc reference) were all addressed in this same change.

## 中文

### 是什么 & 为什么

Glint 之前收不到 Launch Services 传来的路径 —— 外部启动器 / Finder「打开方式」/ dock 拖入 / `open -a Glint <路径>` 都会报「应用程序 glint.app 无法打开指定的文稿或 url」,因为 `Info.plist` 没声明文档类型、也没有 open handler。本 PR 加上 文件夹 / 文件 / `glint://` 的接收,并把它们开成工作区。

### 行为

- **文件夹** → 新建工作区锚定在该目录;在 git 仓库内则 `source` 升为 `.localRepo`(侧栏 git 按钮 / worktree 操作亮起)。**再次打开同一路径** → 切到现有工作区 + 新开 tab,不重复建。
- **普通文件** → 确认弹窗后,在父目录里执行 `'<路径>'; exit`。**Cancel 是默认按钮**(执行任意文件必须显式点击),非可执行文件直接前置拒绝,不再建出「permission denied 即死」的工作区。
- **`glint://open?path=<百分号编码>`** → 解析后按磁盘实际类型走文件夹/文件。

### 实现

`Info.plist` 声明 `CFBundleDocumentTypes`(`public.folder` Viewer + `public.item` Shell,都 `Alternate` rank,不抢 Finder 默认)和 `glint` URL scheme。

开打事件在 `applicationWillFinishLaunching` 里以**原生 Apple Event** 拦截(`kAEOpenDocuments` / `kAEGetURL`)。为什么不用 `application(_:open:)` 或 `.onOpenURL`:在运行中的单 `Window` SwiftUI app 上,默认 `odoc` 处理会**销毁窗口**,然后 `applicationShouldTerminateAfterLastWindowClosed` 把 app 退出 —— delegate 方法和 `.onOpenURL` 都拦不住(已实测)。自己抢注 handler 后 NSApplication 跳过默认分发,SwiftUI 根本收不到这个事件,窗口就不会被销毁。冷启动时(事件到达时 `WorkspaceStore` 还没建好)进 `AppDelegate.pendingOpenURLs` 队列,由 `WorkspaceStore.init` 排空。

`NSAppleEventDescriptor.descriptorAtIndex:` 在当前 SDK 没桥接给 Swift(`perform`/`NSInvocation` 又传不了原始 `NSInteger`),所以用 2 行 ObjC shim(`AEBridge.m`)经 bridging header 暴露。

几个正确性细节:`openFolder` **同步** append 占位工作区(防 TOCTOU,再在 Task 里把 source 升为 `.localRepo`);去重(`isAnchoredAt`)对 worktree 用 worktreePath(否则开主 repo 会被 worktree 工作区错误吸进去)+ pane cwd(覆盖在 repo 子目录打开的情况);`AppDelegate.flush` 有重入守卫,防止 runModal 期间再投递的 odoc 叠出第二个弹窗。

所有新增面向用户文案均本地化(en + zh-Hans)。新增文件:`Glint/App/AEBridge.m`、`Glint/App/Glint-Bridging-Header.h`;`project.yml` 加 `SWIFT_OBJC_BRIDGING_HEADER`。

### 测试 / 验证

`xcodebuild -sdk macosx -arch arm64` —— **BUILD SUCCEEDED**。对构建产物跑通端到端(经持久化 `state.json` + 进程存活验证):

- 冷启动 `open -a Glint <repo>` → 建工作区,`.localRepo`,pane cwd 为该 repo。
- 热启动开**新**文件夹 → 新工作区,app 不退。
- 热启动**再次**开同一文件夹 → 切过去 + 新 tab,不重复建。
- 在已开 repo 的**子目录**上开 → 独立工作区(不被吸进去);再次开该子目录会去重。
- 连点同一文件夹两次 → **1** 个工作区(无 TOCTOU 重复)。
- `glint://open?path=…` → 正确路由。
- 无「开第二个就退出」的回归。

开 PR 前已自审 diff;8 条 finding(去重谓词、默认按钮、非可执行文件处理、TOCTOU 竞态、重复的工作区构造、未本地化的 "New workspace" 字面量、模态叠层、过期文档引用)均在本变更内修复。
