### PR TITLE
Path actions: tab context menu, ⌘⇧C Copy Path, review-file right-click / 路径操作:标签右键菜单、⌘⇧C 拷贝路径、审阅右键

### DIFF
--- a/Glint/App/GlintApp.swift
+++ b/Glint/App/GlintApp.swift
@@ -144,6 +144,12 @@ struct GlintApp: App {
                     workspaceStore.revealCurrentInFinder()
                 }
                 .keyboardShortcut("f", modifiers: [.command, .shift])
+                // Copy the focused pane's cwd (⌘⇧C) — cwd-first, so it works
+                // outside a git repo too. Never disabled; beeps if unknown.
+                Button("Copy Path") {
+                    workspaceStore.copyCurrentPath()
+                }
+                .keyboardShortcut("c", modifiers: [.command, .shift])
             }
             // Hijack the App menu's Settings… so ⌘, opens our in-window
             // sheet instead of trying to summon a separate scene.

--- a/Glint/Chrome/CommandPalette.swift
+++ b/Glint/Chrome/CommandPalette.swift
@@ -324,6 +324,14 @@ struct CommandPalette: View {
             tint: actionTint,
             action: { store.sidebarCollapsed.toggle() }
         ))
+        items.append(.action(
+            title: "Copy Path",
+            subtitle: "Copy the focused pane's directory",
+            symbol: "doc.on.doc",
+            shortcut: "⌘⇧C",
+            tint: actionTint,
+            action: { store.copyCurrentPath() }
+        ))
 
         return items
     }

--- a/Glint/Chrome/CommandPalette.swift
+++ b/Glint/Chrome/CommandPalette.swift
@@ -332,6 +332,36 @@ struct CommandPalette: View {
             tint: actionTint,
             action: { store.copyCurrentPath() }
         ))
+        // The remaining global menu commands, surfaced in the palette so the
+        // keyboard hub can reach every affordance without remembering its
+        // shortcut. Review Changes is gated the same way its menu item is
+        // (only when the focused workspace resolves a git path).
+        items.append(.action(
+            title: "Reveal in Finder",
+            subtitle: "Open the focused pane's directory in Finder",
+            symbol: "folder",
+            shortcut: "⌘⇧F",
+            tint: actionTint,
+            action: { store.revealCurrentInFinder() }
+        ))
+        if let ws = store.selectedWorkspace, store.effectiveGitPath(for: ws) != nil {
+            items.append(.action(
+                title: "Review Changes…",
+                subtitle: "Review this workspace's changes",
+                symbol: "eye",
+                shortcut: "⌘⇧R",
+                tint: actionTint,
+                action: { store.openReview(for: ws) }
+            ))
+        }
+        items.append(.action(
+            title: "Settings",
+            subtitle: "Open Glint settings",
+            symbol: "gearshape",
+            shortcut: "⌘,",
+            tint: actionTint,
+            action: { store.settingsOpen = true }
+        ))
 
         return items
     }

--- a/Glint/Chrome/ContentView.swift
+++ b/Glint/Chrome/ContentView.swift
@@ -850,6 +850,16 @@ private struct TabChip: View {
         .paneSummaryPopover(paneInfos.count >= 2 ? paneInfos : [], store: store,
                             suppressed: isDragging || reordering)
         .contextMenu {
+            Button("New Tab") { store.newTab() }
+            Divider()
+            Button("Close Tab") { store.closeTab(tab.id) }
+                .disabled(ws.tabs.count <= 1)
+            Button("Close Other Tabs") { store.closeOtherTabs(keeping: tab.id) }
+                .disabled(ws.tabs.count <= 1)
+            Divider()
+            Button("Copy Path") { store.copyTabPath(tab.id) }
+            Button("Reveal in Finder") { store.revealTabInFinder(tab.id) }
+            Divider()
             Button("Rename") { startEditing() }
         }
         // Lift the dragged chip above its neighbours — same shape as the

--- a/Glint/Chrome/SettingsView.swift
+++ b/Glint/Chrome/SettingsView.swift
@@ -2114,6 +2114,8 @@ private struct ShortcutsPane: View {
             SettingsDivider()
             shortcutRow("Reveal in Finder", keys: ["⌘", "⇧", "F"])
             SettingsDivider()
+            shortcutRow("Copy Path", keys: ["⌘", "⇧", "C"])
+            SettingsDivider()
             shortcutRow("Settings", keys: ["⌘", ","])
             SettingsDivider()
             shortcutRow("Minimize", keys: ["⌘", "M"])

--- a/Glint/Resources/Localizable.xcstrings
+++ b/Glint/Resources/Localizable.xcstrings
@@ -1132,6 +1132,17 @@
         }
       }
     },
+    "Copy the focused pane's directory": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拷贝当前面板所在目录"
+          }
+        }
+      }
+    },
     "Could not create the Codex Home directory: %@": {
       "extractionState": "manual",
       "localizations": {

--- a/Glint/Resources/Localizable.xcstrings
+++ b/Glint/Resources/Localizable.xcstrings
@@ -3031,6 +3031,28 @@
         }
       }
     },
+    "Open Glint settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开 Glint 设置"
+          }
+        }
+      }
+    },
+    "Open the focused pane's directory in Finder": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在访达中打开当前面板所在目录"
+          }
+        }
+      }
+    },
     "Open with": {
       "extractionState": "manual",
       "localizations": {
@@ -3617,6 +3639,17 @@
           "stringUnit": {
             "state": "translated",
             "value": "审阅改动…"
+          }
+        }
+      }
+    },
+    "Review this workspace's changes": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "审阅此工作区的改动"
           }
         }
       }

--- a/Glint/Resources/Localizable.xcstrings
+++ b/Glint/Resources/Localizable.xcstrings
@@ -859,7 +859,40 @@
         }
       }
     },
+    "Close Other Tabs": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭其他标签页"
+          }
+        }
+      }
+    },
+    "Close other tabs?": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭其他标签页?"
+          }
+        }
+      }
+    },
     "Close Tab": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭标签页"
+          }
+        }
+      }
+    },
+    "Close Tabs": {
       "extractionState": "manual",
       "localizations": {
         "zh-Hans": {
@@ -3940,6 +3973,17 @@
     },
     "Something is still running in it and will be terminated.": {
       "extractionState": "stale",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "其中仍有任务在运行,关闭后会被终止。"
+          }
+        }
+      }
+    },
+    "Something is still running in them and will be terminated.": {
+      "extractionState": "manual",
       "localizations": {
         "zh-Hans": {
           "stringUnit": {

--- a/Glint/Review/ReviewWindow.swift
+++ b/Glint/Review/ReviewWindow.swift
@@ -17,6 +17,10 @@ final class ReviewModel: ObservableObject {
     /// or nil for the whole repo. See `reload`'s prefix filter.
     let subdir: String?
     let availableScopes: [DiffScope]
+    /// True when the review runs over SSH (SSHGitRunner). File-level actions
+    /// (Copy Path / Reveal / Open) target the LOCAL filesystem, so the file
+    /// list hides them for a remote repo — the paths don't exist locally.
+    let isRemote: Bool
 
     @Published var scope: DiffScope { didSet { Task { await reload() } } }
     // Whitespace-only changes treated as non-changes (--ignore-all-space). A
@@ -46,10 +50,12 @@ final class ReviewModel: ObservableObject {
     private var diffLoadToken = 0   // guards against out-of-order diff loads
 
     init(repo: String, title: String, subdir: String? = nil, scopes: [DiffScope],
+         isRemote: Bool = false,
          runner: GitRunner = LocalGitRunner()) {
         self.repo = repo
         self.title = title
         self.subdir = subdir
+        self.isRemote = isRemote
         self.availableScopes = scopes.isEmpty ? [.workingTree] : scopes
         self.scope = scopes.first ?? .workingTree
         self.git = GitService(runner: runner)
@@ -562,7 +568,7 @@ private struct FileListView: View {
 
     private func fileRow(_ file: GitFileChange, indent: CGFloat, showDir: Bool) -> some View {
         let selected = model.selected?.path == file.path
-        return Button {
+        let row = Button {
             Task { await model.select(file) }
         } label: {
             HStack(spacing: 7) {
@@ -598,6 +604,49 @@ private struct FileListView: View {
         }
         .buttonStyle(.plain)
         .help(Text(file.path))
+
+        // Right-click → filesystem actions on the file's full local path.
+        // Hidden for remote reviews (paths don't exist locally). A deleted
+        // file isn't on disk, so Reveal falls back to its parent folder and
+        // Open is omitted entirely.
+        return Group {
+            if model.isRemote {
+                row
+            } else {
+                row.contextMenu {
+                    Button("Copy Path") { copyFilePath(file) }
+                    Button("Reveal in Finder") { revealFile(file) }
+                    if FileManager.default.fileExists(atPath: fullPath(for: file)) {
+                        Button("Open") { openFile(file) }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Full local path of a reviewed file: repo root + its root-relative path.
+    private func fullPath(for file: GitFileChange) -> String {
+        (model.repo as NSString).appendingPathComponent(file.path)
+    }
+
+    private func copyFilePath(_ file: GitFileChange) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(fullPath(for: file), forType: .string)
+    }
+
+    private func revealFile(_ file: GitFileChange) {
+        let full = fullPath(for: file)
+        let url = URL(fileURLWithPath: full)
+        // A deleted file isn't on disk — reveal its containing folder instead.
+        let target = FileManager.default.fileExists(atPath: full) ? url
+            : url.deletingLastPathComponent()
+        NSWorkspace.shared.activateFileViewerSelecting([target])
+    }
+
+    private func openFile(_ file: GitFileChange) {
+        let full = fullPath(for: file)
+        guard FileManager.default.fileExists(atPath: full) else { return }
+        NSWorkspace.shared.open(URL(fileURLWithPath: full))
     }
 
     @ViewBuilder
@@ -1518,7 +1567,8 @@ final class ReviewWindowController: NSObject, NSWindowDelegate {
     func present(repo: String, title: String, subdir: String? = nil,
                  scopes: [DiffScope], store: WorkspaceStore,
                  runner: GitRunner = LocalGitRunner()) {
-        let model = ReviewModel(repo: repo, title: title, subdir: subdir, scopes: scopes, runner: runner)
+        let model = ReviewModel(repo: repo, title: title, subdir: subdir, scopes: scopes,
+                                isRemote: runner is SSHGitRunner, runner: runner)
         self.model = model
         let root = ReviewView(model: model)
             .frame(minWidth: 780, minHeight: 480)

--- a/Glint/Review/ReviewWindow.swift
+++ b/Glint/Review/ReviewWindow.swift
@@ -630,8 +630,7 @@ private struct FileListView: View {
     }
 
     private func copyFilePath(_ file: GitFileChange) {
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(fullPath(for: file), forType: .string)
+        WorkspaceStore.copyPath(fullPath(for: file))
     }
 
     private func revealFile(_ file: GitFileChange) {

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -3074,6 +3074,25 @@ final class WorkspaceStore: ObservableObject {
         NSSound.beep()
     }
 
+    /// Global ⌘⇧C: copy the focused pane's cwd to the clipboard — the
+    /// "where am I right now" path, useful to paste into chat/docs/another
+    /// terminal. Cwd-first; when no cwd has been reported yet (fresh pane)
+    /// falls back to the workspace's known root. Unlike Reveal in Finder it
+    /// deliberately ignores `revealAtRepoRoot`: "copy path" should give the
+    /// literal current directory, never silently jump to the repo root.
+    /// Beeps when nothing resolves.
+    func copyCurrentPath() {
+        guard let ws = selectedWorkspace else { NSSound.beep(); return }
+        let paneCwd = (ws.selectedTab?.focusedPane).flatMap { ws.panes[$0]?.workingDirectory }
+        if let path = paneCwd ?? ws.source.worktreePath ?? ws.source.repoRoot
+            ?? ws.source.gitPath ?? effectiveGitPath(for: ws) {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(path, forType: .string)
+        } else {
+            NSSound.beep()
+        }
+    }
+
     /// Open the read-only Review window for a workspace. Always offers the
     /// working-tree scope; for a worktree with a known base branch it also offers
     /// the whole-branch (`base...HEAD`) scope, so the segmented control appears.

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -456,7 +456,10 @@ extension Workspace {
         return "\(display)\n\(cwd)"
     }
 
-    private func tabCwd(_ tab: WorkspaceTab) -> String? {
+    /// Focused pane's cwd for a tab, falling back to the first pane that has
+    /// reported one. Internal so `WorkspaceStore`'s per-tab Copy Path /
+    /// Reveal-in-Finder can resolve the same cwd the chip label shows.
+    func tabCwd(_ tab: WorkspaceTab) -> String? {
         panes[tab.focusedPane]?.workingDirectory
             ?? tab.root.leaves.compactMap { panes[$0]?.workingDirectory }.first
     }
@@ -2508,6 +2511,52 @@ final class WorkspaceStore: ObservableObject {
             return
         }
         let wasSelected = workspaces[i].selectedTabID == tabID
+        teardownTab(at: t, in: i, wsID: wsID)
+        if wasSelected {
+            let nextIdx = min(t, workspaces[i].tabs.count - 1)
+            workspaces[i].selectedTabID = workspaces[i].tabs[nextIdx].id
+        }
+    }
+
+    /// Close every tab in the current workspace except `keepID`. Confirms once
+    /// if any pane in a doomed tab is still running something, then tears them
+    /// down without re-prompting (per-tab `closeTab` would re-ask and shift
+    /// indices mid-loop). Leaves the kept tab selected. Mirrors `closeTab`'s
+    /// no-op-when-empty + busy-confirmation shape.
+    func closeOtherTabs(keeping keepID: TabID) {
+        guard let i = currentIndex,
+              workspaces[i].tabs.contains(where: { $0.id == keepID }) else { return }
+        let doomed = workspaces[i].tabs.indices
+            .filter { workspaces[i].tabs[$0].id != keepID }
+        guard !doomed.isEmpty else { NSSound.beep(); return }
+        let wsID = workspaces[i].id
+        let doomedPanes = doomed.flatMap { workspaces[i].tabs[$0].root.leaves }
+        let busy = doomedPanes.contains {
+            paneNeedsCloseConfirmation(WorkspacePaneKey(workspace: wsID, pane: $0))
+        }
+        if busy,
+           !Self.confirmDestruction(
+               message: String(localized: "Close other tabs?"),
+               informative: String(localized: "Something is still running in them and will be terminated."),
+               confirmTitle: String(localized: "Close Tabs"),
+               suppressionKey: "glint.suppressCloseTabConfirm"
+           ) {
+            return
+        }
+        // Tear down highest index first so earlier indices stay valid as we
+        // remove — `teardownTab` removes at the given position.
+        for t in doomed.sorted(by: >) {
+            teardownTab(at: t, in: i, wsID: wsID)
+        }
+        workspaces[i].selectedTabID = keepID
+    }
+
+    /// Remove one tab (at `index` in `workspaces[i]`) and tear down every pane
+    /// it owns — surfaces, scrollback, agent/process state, dock badge. No
+    /// confirmation and no selection fixup: `closeTab`/`closeOtherTabs` own
+    /// those. Caller guarantees `index` is valid at call time.
+    private func teardownTab(at index: Int, in i: Int, wsID: UUID) {
+        let panes = workspaces[i].tabs[index].root.leaves
         for pane in panes {
             let key = WorkspacePaneKey(workspace: wsID, pane: pane)
             workspaces[i].panes.removeValue(forKey: pane)
@@ -2518,11 +2567,7 @@ final class WorkspaceStore: ObservableObject {
             paneProcesses.removeValue(forKey: key)
             clearDockBadge(for: key)
         }
-        workspaces[i].tabs.remove(at: t)
-        if wasSelected {
-            let nextIdx = min(t, workspaces[i].tabs.count - 1)
-            workspaces[i].selectedTabID = workspaces[i].tabs[nextIdx].id
-        }
+        workspaces[i].tabs.remove(at: index)
     }
 
     func selectTab(_ tabID: TabID) {
@@ -2998,6 +3043,35 @@ final class WorkspaceStore: ObservableObject {
         } else {
             Self.openInFinder(base)
         }
+    }
+
+    /// Per-tab "Copy Path": copies the tab's focused-pane cwd — the same value
+    /// the chip's tooltip shows — so a background tab's directory is reachable
+    /// without first selecting it. Works outside git repos. Beeps when no cwd
+    /// has been reported yet (fresh pane), mirroring the no-op guards elsewhere.
+    func copyTabPath(_ tabID: TabID) {
+        guard let ws = selectedWorkspace,
+              let tab = ws.tabs.first(where: { $0.id == tabID }),
+              let cwd = ws.tabCwd(tab) else { NSSound.beep(); return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(cwd, forType: .string)
+    }
+
+    /// Per-tab "Reveal in Finder": reveals the tab's focused-pane cwd, falling
+    /// back to the workspace's known root when the pane hasn't reported a cwd
+    /// yet (fresh pane). Beeps when nothing resolves — including remote-SSH
+    /// panes, where there's no local directory to reveal.
+    func revealTabInFinder(_ tabID: TabID) {
+        guard let ws = selectedWorkspace,
+              let tab = ws.tabs.first(where: { $0.id == tabID }) else { return }
+        if remoteContext(for: ws) != nil { NSSound.beep(); return }
+        if let cwd = ws.tabCwd(tab) { Self.openInFinder(cwd); return }
+        if let root = ws.source.worktreePath ?? ws.source.repoRoot
+            ?? ws.source.gitPath ?? effectiveGitPath(for: ws) {
+            Self.openInFinder(root)
+            return
+        }
+        NSSound.beep()
     }
 
     /// Open the read-only Review window for a workspace. Always offers the

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -2539,7 +2539,10 @@ final class WorkspaceStore: ObservableObject {
                message: String(localized: "Close other tabs?"),
                informative: String(localized: "Something is still running in them and will be terminated."),
                confirmTitle: String(localized: "Close Tabs"),
-               suppressionKey: "glint.suppressCloseTabConfirm"
+               // Separate from the single-tab key: a user who suppressed the
+               // low-stakes one-tab prompt hasn't consented to silently
+               // terminating every running agent across the other tabs.
+               suppressionKey: "glint.suppressCloseOtherTabsConfirm"
            ) {
             return
         }
@@ -3048,26 +3051,29 @@ final class WorkspaceStore: ObservableObject {
     /// Per-tab "Copy Path": copies the tab's focused-pane cwd — the same value
     /// the chip's tooltip shows — so a background tab's directory is reachable
     /// without first selecting it. Works outside git repos. Beeps when no cwd
-    /// has been reported yet (fresh pane), mirroring the no-op guards elsewhere.
+    /// has been reported yet (fresh pane) or the tab is a remote-SSH session
+    /// (no local path to copy), mirroring the no-op guards elsewhere.
     func copyTabPath(_ tabID: TabID) {
         guard let ws = selectedWorkspace,
-              let tab = ws.tabs.first(where: { $0.id == tabID }),
-              let cwd = ws.tabCwd(tab) else { NSSound.beep(); return }
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(cwd, forType: .string)
+              let tab = ws.tabs.first(where: { $0.id == tabID }) else { return }
+        if isRemotePane(wsID: ws.id, pane: tab.focusedPane) { NSSound.beep(); return }
+        guard let cwd = ws.tabCwd(tab) else { NSSound.beep(); return }
+        Self.copyPath(cwd)
     }
 
     /// Per-tab "Reveal in Finder": reveals the tab's focused-pane cwd, falling
     /// back to the workspace's known root when the pane hasn't reported a cwd
-    /// yet (fresh pane). Beeps when nothing resolves — including remote-SSH
-    /// panes, where there's no local directory to reveal.
+    /// yet (fresh pane). Remote-ness is checked per-pane on the tab's focused
+    /// pane (not `remoteContext(for:)`, which reads the SELECTED tab and would
+    /// guard the wrong tab when right-clicking a background tab). Beeps when
+    /// nothing resolves — including remote-SSH panes, where there's no local
+    /// directory to reveal.
     func revealTabInFinder(_ tabID: TabID) {
         guard let ws = selectedWorkspace,
               let tab = ws.tabs.first(where: { $0.id == tabID }) else { return }
-        if remoteContext(for: ws) != nil { NSSound.beep(); return }
+        if isRemotePane(wsID: ws.id, pane: tab.focusedPane) { NSSound.beep(); return }
         if let cwd = ws.tabCwd(tab) { Self.openInFinder(cwd); return }
-        if let root = ws.source.worktreePath ?? ws.source.repoRoot
-            ?? ws.source.gitPath ?? effectiveGitPath(for: ws) {
+        if let root = knownRoot(for: ws) {
             Self.openInFinder(root)
             return
         }
@@ -3077,17 +3083,18 @@ final class WorkspaceStore: ObservableObject {
     /// Global ⌘⇧C: copy the focused pane's cwd to the clipboard — the
     /// "where am I right now" path, useful to paste into chat/docs/another
     /// terminal. Cwd-first; when no cwd has been reported yet (fresh pane)
-    /// falls back to the workspace's known root. Unlike Reveal in Finder it
-    /// deliberately ignores `revealAtRepoRoot`: "copy path" should give the
-    /// literal current directory, never silently jump to the repo root.
-    /// Beeps when nothing resolves.
+    /// falls back to the workspace's known root. A remote-SSH focused pane
+    /// beeps (its `workingDirectory` is the ssh client's local launch dir, not
+    /// a useful path to copy) — consistent with Reveal in Finder. Unlike
+    /// Reveal it deliberately ignores `revealAtRepoRoot`: "copy path" should
+    /// give the literal current directory, never silently jump to the repo
+    /// root. Beeps when nothing resolves.
     func copyCurrentPath() {
         guard let ws = selectedWorkspace else { NSSound.beep(); return }
+        if let fp = ws.selectedTab?.focusedPane, isRemotePane(wsID: ws.id, pane: fp) { NSSound.beep(); return }
         let paneCwd = (ws.selectedTab?.focusedPane).flatMap { ws.panes[$0]?.workingDirectory }
-        if let path = paneCwd ?? ws.source.worktreePath ?? ws.source.repoRoot
-            ?? ws.source.gitPath ?? effectiveGitPath(for: ws) {
-            NSPasteboard.general.clearContents()
-            NSPasteboard.general.setString(path, forType: .string)
+        if let path = paneCwd ?? knownRoot(for: ws) {
+            Self.copyPath(path)
         } else {
             NSSound.beep()
         }
@@ -3282,10 +3289,29 @@ final class WorkspaceStore: ObservableObject {
         return (ctx.target, ctx.port, ctx.remotePath, view.remoteHost)
     }
 
+    /// True iff this pane's live surface is a capturable SSH session with a
+    /// known remote path — i.e. there's no LOCAL directory to reveal or copy
+    /// (the pane's `workingDirectory` snapshot is just the ssh client's stale
+    /// local launch dir). Per-pane, unlike `remoteContext(for:)` which reads
+    /// the SELECTED tab; tab-scoped actions (right-click a background tab's
+    /// Copy/Reveal) pass that tab's focused pane so they guard the right tab.
+    private func isRemotePane(wsID: UUID, pane: PaneID) -> Bool {
+        surfaceViews[WorkspacePaneKey(workspace: wsID, pane: pane)]?.remoteReviewContext != nil
+    }
+
     func effectiveGitPath(for ws: Workspace) -> String? {
         if let p = ws.source.gitPath { return p }
         return (ws.selectedTab?.focusedPane).flatMap { ws.panes[$0]?.workingDirectory }
             ?? ws.panes.values.compactMap(\.workingDirectory).first
+    }
+
+    /// Best-known LOCAL root for a workspace — the last-resort fallback when a
+    /// pane hasn't reported a cwd yet (fresh pane). Shared by the per-tab /
+    /// global Copy Path and Reveal-in-Finder so both resolve the same root.
+    /// `effectiveGitPath(for:)` already checks `gitPath` first, so no separate
+    /// `gitPath ??` coalesce is needed (it was a dead branch).
+    private func knownRoot(for ws: Workspace) -> String? {
+        ws.source.worktreePath ?? ws.source.repoRoot ?? effectiveGitPath(for: ws)
     }
 
     /// Root-relative path of `cwd` under `root`, or nil if `cwd` is the root
@@ -3316,6 +3342,14 @@ final class WorkspaceStore: ObservableObject {
     /// parent). Shared by every Reveal-in-Finder path.
     static func openInFinder(_ path: String) {
         NSWorkspace.shared.open(URL(fileURLWithPath: (path as NSString).expandingTildeInPath))
+    }
+
+    /// Copy a filesystem path to the clipboard, clearing first. Shared by every
+    /// Copy Path entry point (⌘⇧C, the tab/surface context menus, the Review
+    /// file list) so pasteboard behavior lives in one place.
+    static func copyPath(_ path: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(path, forType: .string)
     }
 
     func gitStatus(for id: UUID) -> GitStatus? { gitStatuses[id] }
@@ -3637,7 +3671,6 @@ extension WorkspaceStore {
         }
     }
 
-    /// Attention ranking shared by the status merge and the icon pick.
     private func statusRank(_ s: PaneAgentStatus) -> Int {
         switch s {
         case .needsPermission: return 5


### PR DESCRIPTION
## Path actions: copy / reveal a pane's directory from wherever you'd look for it

Gives the tab chip a real context menu and surfaces the focused pane's directory through the places you'd reach for it.

- **Tab context menu** — right-click a tab: New Tab, Close Tab, Close Other Tabs, Copy Path, Reveal in Finder, Rename.
- **⌘⇧C Copy Path** — copy the focused pane's cwd to the clipboard (works outside git repos too).
- **Review-file right-click** — in the Review window's file list: Copy Path / Reveal in Finder / Open (hidden for remote-over-SSH reviews; Open is omitted for deleted files).
- **Command palette** — Reveal in Finder, Review Changes…, Settings surfaced alongside the new actions.

Includes review fixes:
- Per-tab Copy/Reveal judge SSH by the **acted-on tab's** focused pane, not the selected one (right-click ≠ select).
- An SSH pane beeps like ⌘⇧F instead of copying/opening the ssh client's stale local launch dir.
- **Close Other Tabs** gets its own "don't ask again" key, so suppressing the single-tab close can't silently kill running agents across the other tabs.
- Extracts `WorkspaceStore.copyPath` / `knownRoot` and reuses `openInFinder` so every Copy/Reveal path shares one implementation.

## 路径操作:在任何能触达面板的地方拷贝/显示当前目录

给标签补上完整的右键菜单,并把当前面板所在目录推到你会去找它的各个入口。

- **标签右键菜单** — 右键标签:新建/关闭/关闭其他标签、拷贝路径、在访达显示、重命名。
- **⌘⇧C 拷贝路径** — 拷贝当前面板所在目录到剪贴板(非 git 仓库也可用)。
- **审阅文件右键** — 审阅窗口文件列表:拷贝路径/在访达显示/打开(SSH 远程审阅时隐藏;已删除文件不显示「打开」)。
- **命令面板** — 补全「在访达显示」「审阅改动…」「设置」等全局动作。

含 review 修复:
- 按标签的拷贝/显示按**被操作的标签**判定 SSH,而非当前选中标签(右键 ≠ 选中)。
- SSH 面板像 ⌘⇧F 一样蜂鸣,不再拷贝/打开 ssh 客户端陈旧的本地启动目录。
- **关闭其他标签**用独立的「不再询问」键,抑制单标签关闭确认不会误杀其他标签里在运行的 agent。
- 抽取 `WorkspaceStore.copyPath` / `knownRoot`、复用 `openInFinder`,所有拷贝/显示路径共用一套实现。
