### PR TITLE
Attention & sidebar: ⌘⇧A jump-to-attention, sidebar sort + drag / 关注与侧边栏:⌘⇧A 跳转、排序与拖拽

### DIFF
--- a/Glint/Agent/PaneAgentState.swift
+++ b/Glint/Agent/PaneAgentState.swift
@@ -86,6 +86,29 @@ enum PaneAgentStatus: String, Codable {
     case compacting        // auto-compacting context window
     case justCompleted     // turn just finished — transient, fades to idle
     case failed            // turn ended in an API/transport error (StopFailure)
+
+    /// "Float to top" / "jump to next" priority — the single source of truth
+    /// shared by the sidebar sort (`SidebarView`) and ⌘⇧A
+    /// (`WorkspaceStore.jumpToAttention`) so the two always land on the same
+    /// "most worth seeing next" pane. A blocking `.needsPermission` outranks
+    /// unread results (a turn that `.failed` or `.justCompleted`), which both
+    /// float above everything else. Exhaustive, so adding a new case is a
+    /// compile error here — decide its rank in one place, not at every call
+    /// site. This is a coarser axis than `WorkspaceStore.statusRank` (the
+    /// status-dot ranking, which ranks `.failed` above `.justCompleted`);
+    /// here they're peers, so a local just-completed pane can win a tie
+    /// against a remote one.
+    var attentionRank: Int {
+        switch self {
+        case .needsPermission:                          return 0   // blocking → top
+        case .failed, .justCompleted:                   return 1   // unread results
+        case .idle, .thinking, .tool, .compacting:      return Self.sinkAttentionRank
+        }
+    }
+
+    /// The rank at which a status stops floating / no longer counts as "needs
+    /// you". `jumpToAttention` ignores panes at this rank or higher.
+    static let sinkAttentionRank = 2
 }
 
 struct PaneAgentState: Codable, Equatable {

--- a/Glint/App/GlintApp.swift
+++ b/Glint/App/GlintApp.swift
@@ -150,6 +150,12 @@ struct GlintApp: App {
                     workspaceStore.copyCurrentPath()
                 }
                 .keyboardShortcut("c", modifiers: [.command, .shift])
+                // Jump to the next pane needing attention (permission / done /
+                // failed). Multi-agent muscle memory; beeps if none.
+                Button("Jump to Attention") {
+                    workspaceStore.jumpToAttention()
+                }
+                .keyboardShortcut("a", modifiers: [.command, .shift])
             }
             // Hijack the App menu's Settings… so ⌘, opens our in-window
             // sheet instead of trying to summon a separate scene.

--- a/Glint/App/GlintApp.swift
+++ b/Glint/App/GlintApp.swift
@@ -144,6 +144,12 @@ struct GlintApp: App {
                     workspaceStore.revealCurrentInFinder()
                 }
                 .keyboardShortcut("f", modifiers: [.command, .shift])
+                // Copy the focused pane's cwd (⌘⇧C) — cwd-first, so it works
+                // outside a git repo too. Never disabled; beeps if unknown.
+                Button("Copy Path") {
+                    workspaceStore.copyCurrentPath()
+                }
+                .keyboardShortcut("c", modifiers: [.command, .shift])
             }
             // Hijack the App menu's Settings… so ⌘, opens our in-window
             // sheet instead of trying to summon a separate scene.

--- a/Glint/Chrome/CommandPalette.swift
+++ b/Glint/Chrome/CommandPalette.swift
@@ -362,6 +362,14 @@ struct CommandPalette: View {
             tint: actionTint,
             action: { store.settingsOpen = true }
         ))
+        items.append(.action(
+            title: "Jump to Attention",
+            subtitle: "Focus the next pane that needs you",
+            symbol: "exclamationmark.bubble",
+            shortcut: "⌘⇧A",
+            tint: actionTint,
+            action: { store.jumpToAttention() }
+        ))
 
         return items
     }

--- a/Glint/Chrome/CommandPalette.swift
+++ b/Glint/Chrome/CommandPalette.swift
@@ -324,6 +324,14 @@ struct CommandPalette: View {
             tint: actionTint,
             action: { store.sidebarCollapsed.toggle() }
         ))
+        items.append(.action(
+            title: "Copy Path",
+            subtitle: "Copy the focused pane's directory",
+            symbol: "doc.on.doc",
+            shortcut: "⌘⇧C",
+            tint: actionTint,
+            action: { store.copyCurrentPath() }
+        ))
 
         return items
     }

--- a/Glint/Chrome/CommandPalette.swift
+++ b/Glint/Chrome/CommandPalette.swift
@@ -332,6 +332,36 @@ struct CommandPalette: View {
             tint: actionTint,
             action: { store.copyCurrentPath() }
         ))
+        // The remaining global menu commands, surfaced in the palette so the
+        // keyboard hub can reach every affordance without remembering its
+        // shortcut. Review Changes is gated the same way its menu item is
+        // (only when the focused workspace resolves a git path).
+        items.append(.action(
+            title: "Reveal in Finder",
+            subtitle: "Open the focused pane's directory in Finder",
+            symbol: "folder",
+            shortcut: "⌘⇧F",
+            tint: actionTint,
+            action: { store.revealCurrentInFinder() }
+        ))
+        if let ws = store.selectedWorkspace, store.effectiveGitPath(for: ws) != nil {
+            items.append(.action(
+                title: "Review Changes…",
+                subtitle: "Review this workspace's changes",
+                symbol: "eye",
+                shortcut: "⌘⇧R",
+                tint: actionTint,
+                action: { store.openReview(for: ws) }
+            ))
+        }
+        items.append(.action(
+            title: "Settings",
+            subtitle: "Open Glint settings",
+            symbol: "gearshape",
+            shortcut: "⌘,",
+            tint: actionTint,
+            action: { store.settingsOpen = true }
+        ))
 
         return items
     }

--- a/Glint/Chrome/ContentView.swift
+++ b/Glint/Chrome/ContentView.swift
@@ -850,6 +850,16 @@ private struct TabChip: View {
         .paneSummaryPopover(paneInfos.count >= 2 ? paneInfos : [], store: store,
                             suppressed: isDragging || reordering)
         .contextMenu {
+            Button("New Tab") { store.newTab() }
+            Divider()
+            Button("Close Tab") { store.closeTab(tab.id) }
+                .disabled(ws.tabs.count <= 1)
+            Button("Close Other Tabs") { store.closeOtherTabs(keeping: tab.id) }
+                .disabled(ws.tabs.count <= 1)
+            Divider()
+            Button("Copy Path") { store.copyTabPath(tab.id) }
+            Button("Reveal in Finder") { store.revealTabInFinder(tab.id) }
+            Divider()
             Button("Rename") { startEditing() }
         }
         // Lift the dragged chip above its neighbours — same shape as the

--- a/Glint/Chrome/SettingsView.swift
+++ b/Glint/Chrome/SettingsView.swift
@@ -2116,6 +2116,8 @@ private struct ShortcutsPane: View {
             SettingsDivider()
             shortcutRow("Copy Path", keys: ["⌘", "⇧", "C"])
             SettingsDivider()
+            shortcutRow("Jump to Attention", keys: ["⌘", "⇧", "A"])
+            SettingsDivider()
             shortcutRow("Settings", keys: ["⌘", ","])
             SettingsDivider()
             shortcutRow("Minimize", keys: ["⌘", "M"])

--- a/Glint/Chrome/SettingsView.swift
+++ b/Glint/Chrome/SettingsView.swift
@@ -2114,6 +2114,8 @@ private struct ShortcutsPane: View {
             SettingsDivider()
             shortcutRow("Reveal in Finder", keys: ["⌘", "⇧", "F"])
             SettingsDivider()
+            shortcutRow("Copy Path", keys: ["⌘", "⇧", "C"])
+            SettingsDivider()
             shortcutRow("Settings", keys: ["⌘", ","])
             SettingsDivider()
             shortcutRow("Minimize", keys: ["⌘", "M"])

--- a/Glint/Chrome/SidebarView.swift
+++ b/Glint/Chrome/SidebarView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import AppKit
 import ImageIO
+import UniformTypeIdentifiers
 
 struct SidebarView: View {
     @EnvironmentObject var store: WorkspaceStore
@@ -108,6 +109,26 @@ struct SidebarView: View {
             // gap between cards).
             .background(NoDragSurface())
         }
+        // Drag a folder from Finder onto the sidebar → open it as a workspace,
+        // the same path as dropping it on the dock icon (WorkspaceStore.openURL
+        // → openFolder). Files are ignored: drop a file on the terminal pane to
+        // paste its path instead. The sidebar's internal reorder is a SwiftUI
+        // DragGesture, not system drag-and-drop, so this doesn't clash with it.
+        .onDrop(of: [.fileURL], isTargeted: nil) { providers in
+            for provider in providers {
+                provider.loadObject(ofClass: NSURL.self) { obj, _ in
+                    guard let url = obj as? URL, Self.isDirectory(url) else { return }
+                    DispatchQueue.main.async { store.openURL(url) }
+                }
+            }
+            // Accept iff at least one provider can yield a file URL, so a
+            // non-file drag (text, the sidebar's own cards) isn't swallowed.
+            return providers.contains { $0.canLoadObject(ofClass: NSURL.self) }
+        }
+    }
+
+    private static func isDirectory(_ url: URL) -> Bool {
+        (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
     }
 
     // MARK: drag-to-reorder (manual gesture, deterministic pointer hit-test)

--- a/Glint/Chrome/SidebarView.swift
+++ b/Glint/Chrome/SidebarView.swift
@@ -178,18 +178,22 @@ struct SidebarView: View {
             }
         }
         guard applySort, store.sortCompletedFirst else { return base }
-        // Stable partition: `.justCompleted` first, preserving the user's
-        // drag-assigned order within each group. Using enumerated() +
-        // offset as the tiebreaker keeps the sort deterministic regardless
-        // of `sorted(by:)` stability guarantees.
-        func attention(_ e: Workspace) -> Bool {
-            let s = store.agentSummary(for: e)?.status
-            return s == .justCompleted || s == .failed   // both float: finished or errored
+        // Stable 3-tier partition, preserving the user's drag-assigned order
+        // within each tier. enumerated() + offset tiebreaker keeps the sort
+        // deterministic regardless of `sorted(by:)` stability guarantees. A
+        // blocking `.needsPermission` outranks unread results (a turn that
+        // finished or errored) — both float above everything else. A workspace
+        // waiting on approval is the one you most need to see next.
+        func rank(_ ws: Workspace) -> Int {
+            switch store.agentSummary(for: ws)?.status {
+            case .needsPermission:                  return 0   // blocking → top
+            case .justCompleted, .failed:           return 1   // unread results
+            default:                                return 2
+            }
         }
         return base.enumerated().sorted { lhs, rhs in
-            let lhsDone = attention(lhs.element)
-            let rhsDone = attention(rhs.element)
-            if lhsDone != rhsDone { return lhsDone }
+            let lr = rank(lhs.element), rr = rank(rhs.element)
+            if lr != rr { return lr < rr }
             return lhs.offset < rhs.offset
         }.map(\.element)
     }

--- a/Glint/Chrome/SidebarView.swift
+++ b/Glint/Chrome/SidebarView.swift
@@ -201,16 +201,11 @@ struct SidebarView: View {
         guard applySort, store.sortCompletedFirst else { return base }
         // Stable 3-tier partition, preserving the user's drag-assigned order
         // within each tier. enumerated() + offset tiebreaker keeps the sort
-        // deterministic regardless of `sorted(by:)` stability guarantees. A
-        // blocking `.needsPermission` outranks unread results (a turn that
-        // finished or errored) — both float above everything else. A workspace
-        // waiting on approval is the one you most need to see next.
+        // deterministic regardless of `sorted(by:)` stability guarantees. The
+        // ranking itself is shared with ⌘⇧A via `PaneAgentStatus.attentionRank`,
+        // so the sidebar sort and the jump-to-attention target always agree.
         func rank(_ ws: Workspace) -> Int {
-            switch store.agentSummary(for: ws)?.status {
-            case .needsPermission:                  return 0   // blocking → top
-            case .justCompleted, .failed:           return 1   // unread results
-            default:                                return 2
-            }
+            store.agentSummary(for: ws)?.status.attentionRank ?? PaneAgentStatus.sinkAttentionRank
         }
         return base.enumerated().sorted { lhs, rhs in
             let lr = rank(lhs.element), rr = rank(rhs.element)

--- a/Glint/Resources/Localizable.xcstrings
+++ b/Glint/Resources/Localizable.xcstrings
@@ -1132,6 +1132,17 @@
         }
       }
     },
+    "Copy the focused pane's directory": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拷贝当前面板所在目录"
+          }
+        }
+      }
+    },
     "Could not create the Codex Home directory: %@": {
       "extractionState": "manual",
       "localizations": {

--- a/Glint/Resources/Localizable.xcstrings
+++ b/Glint/Resources/Localizable.xcstrings
@@ -1756,6 +1756,17 @@
         }
       }
     },
+    "Focus the next pane that needs you": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "聚焦到下一个需要你的面板"
+          }
+        }
+      }
+    },
     "Follow system": {
       "extractionState": "stale",
       "localizations": {
@@ -2316,6 +2327,17 @@
           "stringUnit": {
             "state": "translated",
             "value": "隔离的分支"
+          }
+        }
+      }
+    },
+    "Jump to Attention": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跳转到待处理项"
           }
         }
       }

--- a/Glint/Resources/Localizable.xcstrings
+++ b/Glint/Resources/Localizable.xcstrings
@@ -3031,6 +3031,28 @@
         }
       }
     },
+    "Open Glint settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开 Glint 设置"
+          }
+        }
+      }
+    },
+    "Open the focused pane's directory in Finder": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在访达中打开当前面板所在目录"
+          }
+        }
+      }
+    },
     "Open with": {
       "extractionState": "manual",
       "localizations": {
@@ -3617,6 +3639,17 @@
           "stringUnit": {
             "state": "translated",
             "value": "审阅改动…"
+          }
+        }
+      }
+    },
+    "Review this workspace's changes": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "审阅此工作区的改动"
           }
         }
       }

--- a/Glint/Resources/Localizable.xcstrings
+++ b/Glint/Resources/Localizable.xcstrings
@@ -859,7 +859,40 @@
         }
       }
     },
+    "Close Other Tabs": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭其他标签页"
+          }
+        }
+      }
+    },
+    "Close other tabs?": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭其他标签页?"
+          }
+        }
+      }
+    },
     "Close Tab": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭标签页"
+          }
+        }
+      }
+    },
+    "Close Tabs": {
       "extractionState": "manual",
       "localizations": {
         "zh-Hans": {
@@ -3940,6 +3973,17 @@
     },
     "Something is still running in it and will be terminated.": {
       "extractionState": "stale",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "其中仍有任务在运行,关闭后会被终止。"
+          }
+        }
+      }
+    },
+    "Something is still running in them and will be terminated.": {
+      "extractionState": "manual",
       "localizations": {
         "zh-Hans": {
           "stringUnit": {

--- a/Glint/Review/ReviewWindow.swift
+++ b/Glint/Review/ReviewWindow.swift
@@ -17,6 +17,10 @@ final class ReviewModel: ObservableObject {
     /// or nil for the whole repo. See `reload`'s prefix filter.
     let subdir: String?
     let availableScopes: [DiffScope]
+    /// True when the review runs over SSH (SSHGitRunner). File-level actions
+    /// (Copy Path / Reveal / Open) target the LOCAL filesystem, so the file
+    /// list hides them for a remote repo — the paths don't exist locally.
+    let isRemote: Bool
 
     @Published var scope: DiffScope { didSet { Task { await reload() } } }
     // Whitespace-only changes treated as non-changes (--ignore-all-space). A
@@ -46,10 +50,12 @@ final class ReviewModel: ObservableObject {
     private var diffLoadToken = 0   // guards against out-of-order diff loads
 
     init(repo: String, title: String, subdir: String? = nil, scopes: [DiffScope],
+         isRemote: Bool = false,
          runner: GitRunner = LocalGitRunner()) {
         self.repo = repo
         self.title = title
         self.subdir = subdir
+        self.isRemote = isRemote
         self.availableScopes = scopes.isEmpty ? [.workingTree] : scopes
         self.scope = scopes.first ?? .workingTree
         self.git = GitService(runner: runner)
@@ -562,7 +568,7 @@ private struct FileListView: View {
 
     private func fileRow(_ file: GitFileChange, indent: CGFloat, showDir: Bool) -> some View {
         let selected = model.selected?.path == file.path
-        return Button {
+        let row = Button {
             Task { await model.select(file) }
         } label: {
             HStack(spacing: 7) {
@@ -598,6 +604,49 @@ private struct FileListView: View {
         }
         .buttonStyle(.plain)
         .help(Text(file.path))
+
+        // Right-click → filesystem actions on the file's full local path.
+        // Hidden for remote reviews (paths don't exist locally). A deleted
+        // file isn't on disk, so Reveal falls back to its parent folder and
+        // Open is omitted entirely.
+        return Group {
+            if model.isRemote {
+                row
+            } else {
+                row.contextMenu {
+                    Button("Copy Path") { copyFilePath(file) }
+                    Button("Reveal in Finder") { revealFile(file) }
+                    if FileManager.default.fileExists(atPath: fullPath(for: file)) {
+                        Button("Open") { openFile(file) }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Full local path of a reviewed file: repo root + its root-relative path.
+    private func fullPath(for file: GitFileChange) -> String {
+        (model.repo as NSString).appendingPathComponent(file.path)
+    }
+
+    private func copyFilePath(_ file: GitFileChange) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(fullPath(for: file), forType: .string)
+    }
+
+    private func revealFile(_ file: GitFileChange) {
+        let full = fullPath(for: file)
+        let url = URL(fileURLWithPath: full)
+        // A deleted file isn't on disk — reveal its containing folder instead.
+        let target = FileManager.default.fileExists(atPath: full) ? url
+            : url.deletingLastPathComponent()
+        NSWorkspace.shared.activateFileViewerSelecting([target])
+    }
+
+    private func openFile(_ file: GitFileChange) {
+        let full = fullPath(for: file)
+        guard FileManager.default.fileExists(atPath: full) else { return }
+        NSWorkspace.shared.open(URL(fileURLWithPath: full))
     }
 
     @ViewBuilder
@@ -1518,7 +1567,8 @@ final class ReviewWindowController: NSObject, NSWindowDelegate {
     func present(repo: String, title: String, subdir: String? = nil,
                  scopes: [DiffScope], store: WorkspaceStore,
                  runner: GitRunner = LocalGitRunner()) {
-        let model = ReviewModel(repo: repo, title: title, subdir: subdir, scopes: scopes, runner: runner)
+        let model = ReviewModel(repo: repo, title: title, subdir: subdir, scopes: scopes,
+                                isRemote: runner is SSHGitRunner, runner: runner)
         self.model = model
         let root = ReviewView(model: model)
             .frame(minWidth: 780, minHeight: 480)

--- a/Glint/Review/ReviewWindow.swift
+++ b/Glint/Review/ReviewWindow.swift
@@ -630,8 +630,7 @@ private struct FileListView: View {
     }
 
     private func copyFilePath(_ file: GitFileChange) {
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(fullPath(for: file), forType: .string)
+        WorkspaceStore.copyPath(fullPath(for: file))
     }
 
     private func revealFile(_ file: GitFileChange) {

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -2356,30 +2356,38 @@ final class WorkspaceStore: ObservableObject {
         refreshGitStatusNow(for: workspace)
     }
 
-    /// ⌘⇧A: jump to the next pane that needs you. A pane waiting for permission
-    /// (blocking) outranks one that just finished or failed (unread results).
-    /// The current workspace is scanned first so a local attention pane wins,
-    /// then every other active (non-archived) workspace. Reuses `revealPane`
-    /// (the notification-click path): it switches workspace, selects the pane's
-    /// tab, focuses it, and clears the unread / dock-badge state. Nothing needs
+    /// ⌘⇧A: jump to the next pane that needs you. `PaneAgentStatus.attentionRank`
+    /// is the shared ordering, so ⌘⇧A lands on the same pane that floats to the
+    /// top of the sidebar. The current workspace is walked first (so a local
+    /// attention pane wins ties against a remote one), then panes in display
+    /// order (tab → leaves) — never `panes.keys`, whose order is unspecified and
+    /// would make the target non-deterministic. Reuses `revealPane` (the
+    /// notification-click path): it switches workspace, selects the pane's tab,
+    /// focuses it, and clears the unread / dock-badge state. Nothing needs
     /// attention ⇒ beep.
     func jumpToAttention() {
-        let priority: [PaneAgentStatus] = [.needsPermission, .justCompleted, .failed]
         let current = selectedWorkspaceID
-        let active = workspaces.filter { !$0.archived }
-        let ordered = active.filter { $0.id == current }
-            + active.filter { $0.id != current }
-        for status in priority {
-            for ws in ordered {
-                for paneID in ws.panes.keys {
+        let ordered = workspaces.filter { !$0.archived && $0.id == current }
+            + workspaces.filter { !$0.archived && $0.id != current }
+        // Walk panes in display order and keep the FIRST pane at the best
+        // (lowest) attentionRank. `< bestRank` (not `<=`) preserves the
+        // current-workspace-first / tab-order winner among equal ranks.
+        var bestRank = Int.max
+        var best: (ws: UUID, pane: PaneID)?
+        for ws in ordered {
+            for tab in ws.tabs {
+                for paneID in tab.root.leaves {
                     let key = WorkspacePaneKey(workspace: ws.id, pane: paneID)
-                    guard paneAgentState[key]?.status == status else { continue }
-                    revealPane(workspace: ws.id, pane: paneID)
-                    return
+                    guard let rank = paneAgentState[key]?.status.attentionRank,
+                          rank < PaneAgentStatus.sinkAttentionRank,   // ignore sinks (idle/thinking/…)
+                          rank < bestRank else { continue }
+                    bestRank = rank
+                    best = (ws.id, paneID)
                 }
             }
         }
-        NSSound.beep()
+        guard let target = best else { NSSound.beep(); return }
+        revealPane(workspace: target.ws, pane: target.pane)
     }
 
     // MARK: - external control (control.sock)
@@ -3697,6 +3705,13 @@ extension WorkspaceStore {
         }
     }
 
+    /// Attention ranking shared by the status merge and the icon pick.
+    /// Which status to SHOW (the tab chip's dot) when a tab has panes at
+    /// different statuses — NOT the "float to top" ordering. A different axis
+    /// from `PaneAgentStatus.attentionRank` (which ranks what the sidebar
+    /// floats and ⌘⇧A jumps to, and treats `.failed`/`.justCompleted` as
+    /// peers); here `.failed` outranks `.justCompleted` because an error dot
+    /// should win the chip. Don't "fix" one to match the other.
     private func statusRank(_ s: PaneAgentStatus) -> Int {
         switch s {
         case .needsPermission: return 5

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -3074,6 +3074,25 @@ final class WorkspaceStore: ObservableObject {
         NSSound.beep()
     }
 
+    /// Global ⌘⇧C: copy the focused pane's cwd to the clipboard — the
+    /// "where am I right now" path, useful to paste into chat/docs/another
+    /// terminal. Cwd-first; when no cwd has been reported yet (fresh pane)
+    /// falls back to the workspace's known root. Unlike Reveal in Finder it
+    /// deliberately ignores `revealAtRepoRoot`: "copy path" should give the
+    /// literal current directory, never silently jump to the repo root.
+    /// Beeps when nothing resolves.
+    func copyCurrentPath() {
+        guard let ws = selectedWorkspace else { NSSound.beep(); return }
+        let paneCwd = (ws.selectedTab?.focusedPane).flatMap { ws.panes[$0]?.workingDirectory }
+        if let path = paneCwd ?? ws.source.worktreePath ?? ws.source.repoRoot
+            ?? ws.source.gitPath ?? effectiveGitPath(for: ws) {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(path, forType: .string)
+        } else {
+            NSSound.beep()
+        }
+    }
+
     /// Open the read-only Review window for a workspace. Always offers the
     /// working-tree scope; for a worktree with a known base branch it also offers
     /// the whole-branch (`base...HEAD`) scope, so the segmented control appears.

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -456,7 +456,10 @@ extension Workspace {
         return "\(display)\n\(cwd)"
     }
 
-    private func tabCwd(_ tab: WorkspaceTab) -> String? {
+    /// Focused pane's cwd for a tab, falling back to the first pane that has
+    /// reported one. Internal so `WorkspaceStore`'s per-tab Copy Path /
+    /// Reveal-in-Finder can resolve the same cwd the chip label shows.
+    func tabCwd(_ tab: WorkspaceTab) -> String? {
         panes[tab.focusedPane]?.workingDirectory
             ?? tab.root.leaves.compactMap { panes[$0]?.workingDirectory }.first
     }
@@ -2508,6 +2511,52 @@ final class WorkspaceStore: ObservableObject {
             return
         }
         let wasSelected = workspaces[i].selectedTabID == tabID
+        teardownTab(at: t, in: i, wsID: wsID)
+        if wasSelected {
+            let nextIdx = min(t, workspaces[i].tabs.count - 1)
+            workspaces[i].selectedTabID = workspaces[i].tabs[nextIdx].id
+        }
+    }
+
+    /// Close every tab in the current workspace except `keepID`. Confirms once
+    /// if any pane in a doomed tab is still running something, then tears them
+    /// down without re-prompting (per-tab `closeTab` would re-ask and shift
+    /// indices mid-loop). Leaves the kept tab selected. Mirrors `closeTab`'s
+    /// no-op-when-empty + busy-confirmation shape.
+    func closeOtherTabs(keeping keepID: TabID) {
+        guard let i = currentIndex,
+              workspaces[i].tabs.contains(where: { $0.id == keepID }) else { return }
+        let doomed = workspaces[i].tabs.indices
+            .filter { workspaces[i].tabs[$0].id != keepID }
+        guard !doomed.isEmpty else { NSSound.beep(); return }
+        let wsID = workspaces[i].id
+        let doomedPanes = doomed.flatMap { workspaces[i].tabs[$0].root.leaves }
+        let busy = doomedPanes.contains {
+            paneNeedsCloseConfirmation(WorkspacePaneKey(workspace: wsID, pane: $0))
+        }
+        if busy,
+           !Self.confirmDestruction(
+               message: String(localized: "Close other tabs?"),
+               informative: String(localized: "Something is still running in them and will be terminated."),
+               confirmTitle: String(localized: "Close Tabs"),
+               suppressionKey: "glint.suppressCloseTabConfirm"
+           ) {
+            return
+        }
+        // Tear down highest index first so earlier indices stay valid as we
+        // remove — `teardownTab` removes at the given position.
+        for t in doomed.sorted(by: >) {
+            teardownTab(at: t, in: i, wsID: wsID)
+        }
+        workspaces[i].selectedTabID = keepID
+    }
+
+    /// Remove one tab (at `index` in `workspaces[i]`) and tear down every pane
+    /// it owns — surfaces, scrollback, agent/process state, dock badge. No
+    /// confirmation and no selection fixup: `closeTab`/`closeOtherTabs` own
+    /// those. Caller guarantees `index` is valid at call time.
+    private func teardownTab(at index: Int, in i: Int, wsID: UUID) {
+        let panes = workspaces[i].tabs[index].root.leaves
         for pane in panes {
             let key = WorkspacePaneKey(workspace: wsID, pane: pane)
             workspaces[i].panes.removeValue(forKey: pane)
@@ -2518,11 +2567,7 @@ final class WorkspaceStore: ObservableObject {
             paneProcesses.removeValue(forKey: key)
             clearDockBadge(for: key)
         }
-        workspaces[i].tabs.remove(at: t)
-        if wasSelected {
-            let nextIdx = min(t, workspaces[i].tabs.count - 1)
-            workspaces[i].selectedTabID = workspaces[i].tabs[nextIdx].id
-        }
+        workspaces[i].tabs.remove(at: index)
     }
 
     func selectTab(_ tabID: TabID) {
@@ -2998,6 +3043,35 @@ final class WorkspaceStore: ObservableObject {
         } else {
             Self.openInFinder(base)
         }
+    }
+
+    /// Per-tab "Copy Path": copies the tab's focused-pane cwd — the same value
+    /// the chip's tooltip shows — so a background tab's directory is reachable
+    /// without first selecting it. Works outside git repos. Beeps when no cwd
+    /// has been reported yet (fresh pane), mirroring the no-op guards elsewhere.
+    func copyTabPath(_ tabID: TabID) {
+        guard let ws = selectedWorkspace,
+              let tab = ws.tabs.first(where: { $0.id == tabID }),
+              let cwd = ws.tabCwd(tab) else { NSSound.beep(); return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(cwd, forType: .string)
+    }
+
+    /// Per-tab "Reveal in Finder": reveals the tab's focused-pane cwd, falling
+    /// back to the workspace's known root when the pane hasn't reported a cwd
+    /// yet (fresh pane). Beeps when nothing resolves — including remote-SSH
+    /// panes, where there's no local directory to reveal.
+    func revealTabInFinder(_ tabID: TabID) {
+        guard let ws = selectedWorkspace,
+              let tab = ws.tabs.first(where: { $0.id == tabID }) else { return }
+        if remoteContext(for: ws) != nil { NSSound.beep(); return }
+        if let cwd = ws.tabCwd(tab) { Self.openInFinder(cwd); return }
+        if let root = ws.source.worktreePath ?? ws.source.repoRoot
+            ?? ws.source.gitPath ?? effectiveGitPath(for: ws) {
+            Self.openInFinder(root)
+            return
+        }
+        NSSound.beep()
     }
 
     /// Open the read-only Review window for a workspace. Always offers the

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -2539,7 +2539,10 @@ final class WorkspaceStore: ObservableObject {
                message: String(localized: "Close other tabs?"),
                informative: String(localized: "Something is still running in them and will be terminated."),
                confirmTitle: String(localized: "Close Tabs"),
-               suppressionKey: "glint.suppressCloseTabConfirm"
+               // Separate from the single-tab key: a user who suppressed the
+               // low-stakes one-tab prompt hasn't consented to silently
+               // terminating every running agent across the other tabs.
+               suppressionKey: "glint.suppressCloseOtherTabsConfirm"
            ) {
             return
         }
@@ -3048,26 +3051,29 @@ final class WorkspaceStore: ObservableObject {
     /// Per-tab "Copy Path": copies the tab's focused-pane cwd — the same value
     /// the chip's tooltip shows — so a background tab's directory is reachable
     /// without first selecting it. Works outside git repos. Beeps when no cwd
-    /// has been reported yet (fresh pane), mirroring the no-op guards elsewhere.
+    /// has been reported yet (fresh pane) or the tab is a remote-SSH session
+    /// (no local path to copy), mirroring the no-op guards elsewhere.
     func copyTabPath(_ tabID: TabID) {
         guard let ws = selectedWorkspace,
-              let tab = ws.tabs.first(where: { $0.id == tabID }),
-              let cwd = ws.tabCwd(tab) else { NSSound.beep(); return }
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(cwd, forType: .string)
+              let tab = ws.tabs.first(where: { $0.id == tabID }) else { return }
+        if isRemotePane(wsID: ws.id, pane: tab.focusedPane) { NSSound.beep(); return }
+        guard let cwd = ws.tabCwd(tab) else { NSSound.beep(); return }
+        Self.copyPath(cwd)
     }
 
     /// Per-tab "Reveal in Finder": reveals the tab's focused-pane cwd, falling
     /// back to the workspace's known root when the pane hasn't reported a cwd
-    /// yet (fresh pane). Beeps when nothing resolves — including remote-SSH
-    /// panes, where there's no local directory to reveal.
+    /// yet (fresh pane). Remote-ness is checked per-pane on the tab's focused
+    /// pane (not `remoteContext(for:)`, which reads the SELECTED tab and would
+    /// guard the wrong tab when right-clicking a background tab). Beeps when
+    /// nothing resolves — including remote-SSH panes, where there's no local
+    /// directory to reveal.
     func revealTabInFinder(_ tabID: TabID) {
         guard let ws = selectedWorkspace,
               let tab = ws.tabs.first(where: { $0.id == tabID }) else { return }
-        if remoteContext(for: ws) != nil { NSSound.beep(); return }
+        if isRemotePane(wsID: ws.id, pane: tab.focusedPane) { NSSound.beep(); return }
         if let cwd = ws.tabCwd(tab) { Self.openInFinder(cwd); return }
-        if let root = ws.source.worktreePath ?? ws.source.repoRoot
-            ?? ws.source.gitPath ?? effectiveGitPath(for: ws) {
+        if let root = knownRoot(for: ws) {
             Self.openInFinder(root)
             return
         }
@@ -3077,17 +3083,18 @@ final class WorkspaceStore: ObservableObject {
     /// Global ⌘⇧C: copy the focused pane's cwd to the clipboard — the
     /// "where am I right now" path, useful to paste into chat/docs/another
     /// terminal. Cwd-first; when no cwd has been reported yet (fresh pane)
-    /// falls back to the workspace's known root. Unlike Reveal in Finder it
-    /// deliberately ignores `revealAtRepoRoot`: "copy path" should give the
-    /// literal current directory, never silently jump to the repo root.
-    /// Beeps when nothing resolves.
+    /// falls back to the workspace's known root. A remote-SSH focused pane
+    /// beeps (its `workingDirectory` is the ssh client's local launch dir, not
+    /// a useful path to copy) — consistent with Reveal in Finder. Unlike
+    /// Reveal it deliberately ignores `revealAtRepoRoot`: "copy path" should
+    /// give the literal current directory, never silently jump to the repo
+    /// root. Beeps when nothing resolves.
     func copyCurrentPath() {
         guard let ws = selectedWorkspace else { NSSound.beep(); return }
+        if let fp = ws.selectedTab?.focusedPane, isRemotePane(wsID: ws.id, pane: fp) { NSSound.beep(); return }
         let paneCwd = (ws.selectedTab?.focusedPane).flatMap { ws.panes[$0]?.workingDirectory }
-        if let path = paneCwd ?? ws.source.worktreePath ?? ws.source.repoRoot
-            ?? ws.source.gitPath ?? effectiveGitPath(for: ws) {
-            NSPasteboard.general.clearContents()
-            NSPasteboard.general.setString(path, forType: .string)
+        if let path = paneCwd ?? knownRoot(for: ws) {
+            Self.copyPath(path)
         } else {
             NSSound.beep()
         }
@@ -3282,10 +3289,29 @@ final class WorkspaceStore: ObservableObject {
         return (ctx.target, ctx.port, ctx.remotePath, view.remoteHost)
     }
 
+    /// True iff this pane's live surface is a capturable SSH session with a
+    /// known remote path — i.e. there's no LOCAL directory to reveal or copy
+    /// (the pane's `workingDirectory` snapshot is just the ssh client's stale
+    /// local launch dir). Per-pane, unlike `remoteContext(for:)` which reads
+    /// the SELECTED tab; tab-scoped actions (right-click a background tab's
+    /// Copy/Reveal) pass that tab's focused pane so they guard the right tab.
+    private func isRemotePane(wsID: UUID, pane: PaneID) -> Bool {
+        surfaceViews[WorkspacePaneKey(workspace: wsID, pane: pane)]?.remoteReviewContext != nil
+    }
+
     func effectiveGitPath(for ws: Workspace) -> String? {
         if let p = ws.source.gitPath { return p }
         return (ws.selectedTab?.focusedPane).flatMap { ws.panes[$0]?.workingDirectory }
             ?? ws.panes.values.compactMap(\.workingDirectory).first
+    }
+
+    /// Best-known LOCAL root for a workspace — the last-resort fallback when a
+    /// pane hasn't reported a cwd yet (fresh pane). Shared by the per-tab /
+    /// global Copy Path and Reveal-in-Finder so both resolve the same root.
+    /// `effectiveGitPath(for:)` already checks `gitPath` first, so no separate
+    /// `gitPath ??` coalesce is needed (it was a dead branch).
+    private func knownRoot(for ws: Workspace) -> String? {
+        ws.source.worktreePath ?? ws.source.repoRoot ?? effectiveGitPath(for: ws)
     }
 
     /// Root-relative path of `cwd` under `root`, or nil if `cwd` is the root
@@ -3316,6 +3342,14 @@ final class WorkspaceStore: ObservableObject {
     /// parent). Shared by every Reveal-in-Finder path.
     static func openInFinder(_ path: String) {
         NSWorkspace.shared.open(URL(fileURLWithPath: (path as NSString).expandingTildeInPath))
+    }
+
+    /// Copy a filesystem path to the clipboard, clearing first. Shared by every
+    /// Copy Path entry point (⌘⇧C, the tab/surface context menus, the Review
+    /// file list) so pasteboard behavior lives in one place.
+    static func copyPath(_ path: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(path, forType: .string)
     }
 
     func gitStatus(for id: UUID) -> GitStatus? { gitStatuses[id] }
@@ -3637,7 +3671,6 @@ extension WorkspaceStore {
         }
     }
 
-    /// Attention ranking shared by the status merge and the icon pick.
     private func statusRank(_ s: PaneAgentStatus) -> Int {
         switch s {
         case .needsPermission: return 5

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -2356,6 +2356,32 @@ final class WorkspaceStore: ObservableObject {
         refreshGitStatusNow(for: workspace)
     }
 
+    /// ⌘⇧A: jump to the next pane that needs you. A pane waiting for permission
+    /// (blocking) outranks one that just finished or failed (unread results).
+    /// The current workspace is scanned first so a local attention pane wins,
+    /// then every other active (non-archived) workspace. Reuses `revealPane`
+    /// (the notification-click path): it switches workspace, selects the pane's
+    /// tab, focuses it, and clears the unread / dock-badge state. Nothing needs
+    /// attention ⇒ beep.
+    func jumpToAttention() {
+        let priority: [PaneAgentStatus] = [.needsPermission, .justCompleted, .failed]
+        let current = selectedWorkspaceID
+        let active = workspaces.filter { !$0.archived }
+        let ordered = active.filter { $0.id == current }
+            + active.filter { $0.id != current }
+        for status in priority {
+            for ws in ordered {
+                for paneID in ws.panes.keys {
+                    let key = WorkspacePaneKey(workspace: ws.id, pane: paneID)
+                    guard paneAgentState[key]?.status == status else { continue }
+                    revealPane(workspace: ws.id, pane: paneID)
+                    return
+                }
+            }
+        }
+        NSSound.beep()
+    }
+
     // MARK: - external control (control.sock)
     //
     // Command dispatch for ControlBridge. Each method runs on the main thread


### PR DESCRIPTION
## Attention & sidebar: jump to what needs you, and a smarter sidebar

- **⌘⇧A Jump to Attention** — focus the next pane that needs you: a permission request (blocking), or a turn that just finished or failed. Scans the current workspace first, then others; reuses the notification-click path to switch workspace/tab and clear the unread / dock-badge state.
- **Sidebar sort** — with "completed first" on, a workspace waiting on permission floats above completed/failed ones — the one you most need to see next.
- **Sidebar drag** — drag a folder from Finder onto the sidebar to open it as a workspace (files are ignored; drop those on a terminal to paste the path).

Includes review fixes:
- Attention ordering hoisted to `PaneAgentStatus.attentionRank`, shared by the sidebar sort **and** ⌘⇧A; the `switch` is exhaustive so adding a status case is a compile error in one place.
- ⌘⇧A walks panes in **display order** (tab → leaves), current workspace first — so the jump target is deterministic and matches what floats to the top, never `panes.keys` (unspecified order).

> 🔗 Stacked on #77 — that PR's commits are included here so there are no merge conflicts between the two. **Merge #77 first**; this PR's diff then shrinks to just the attention/sidebar commits. (Branch `feat/attention-sidebar` is based on `feat/path-actions`.)

## 关注与侧边栏:跳到需要你的地方,侧边栏也更聪明

- **⌘⇧A 跳转待处理** — 聚焦下一个需要你的面板:待审批(阻塞),或刚结束/失败的轮次。先扫当前工作区,再扫其他;复用通知点击的路径切换工作区/标签并清掉未读/角标状态。
- **侧边栏排序** — 开启「完成的置顶」时,待审批的工作区会浮到已完成/失败之上——下一个最该看的。
- **侧边栏拖拽** — 从访达拖文件夹到侧边栏即可作为工作区打开(文件会被忽略;拖到终端上才会粘贴路径)。

含 review 修复:
- 关注排序提升为 `PaneAgentStatus.attentionRank`,侧边栏排序**与** ⌘⇧A 共用;`switch` 穷举,新增状态只在一处编译报错。
- ⌘⇧A 按**显示顺序**(标签 → 叶子)遍历面板、当前工作区优先——跳转目标确定且与置顶项一致,不再用 `panes.keys`(顺序不定)。

> 🔗 基于 #77(stack)——本分支包含了 #77 的提交,两者之间零合并冲突。**请先合并 #77**,之后本 PR 的 diff 会自动收缩到只剩关注/侧边栏的提交。(分支 `feat/attention-sidebar` 基于 `feat/path-actions`。)
