### PR TITLE
fix(agent): stop flagging Codex auto-review as needs-permission / Codex 自动审批不再误标为待审批

### DIFF
--- a/Glint/Agent/AgentBridge.swift
+++ b/Glint/Agent/AgentBridge.swift
@@ -152,10 +152,14 @@ final class AgentBridge {
         let hook: String
         let agent: String?
         let sessionB64: String?
+        let transcriptB64: String?
+        let turnB64: String?
 
         private enum CodingKeys: String, CodingKey {
             case pane, hook, agent
             case sessionB64 = "session_b64"
+            case transcriptB64 = "transcript_b64"
+            case turnB64 = "turn_b64"
         }
     }
 
@@ -172,13 +176,70 @@ final class AgentBridge {
            !value.isEmpty {
             result["session"] = value
         }
+        if let encoded = env.transcriptB64,
+           let data = Data(base64Encoded: encoded),
+           let value = String(data: data, encoding: .utf8),
+           !value.isEmpty {
+            result["transcript"] = value
+        }
+        if let encoded = env.turnB64,
+           let data = Data(base64Encoded: encoded),
+           let value = String(data: data, encoding: .utf8),
+           !value.isEmpty {
+            result["turn"] = value
+        }
         return result
     }
 
+    /// Codex runs PermissionRequest hooks before routing the request to its
+    /// user or auto reviewer, and the hook payload does not expose that
+    /// reviewer. The matching turn_context in the supplied rollout does.
+    /// Read only the tail so a long-lived session cannot stall hook routing.
+    static func codexApprovalReviewer(transcriptPath: String, turnID: String) -> String? {
+        guard !turnID.isEmpty else { return nil }
+        let url = URL(fileURLWithPath: transcriptPath).standardizedFileURL
+        guard url.pathExtension == "jsonl",
+              let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+
+        let end = handle.seekToEndOfFile()
+        let maxBytes: UInt64 = 8 * 1024 * 1024
+        let start = end > maxBytes ? end - maxBytes : 0
+        handle.seek(toFileOffset: start)
+        var data = handle.readDataToEndOfFile()
+        if start > 0 {
+            guard let newline = data.firstIndex(of: 0x0A) else { return nil }
+            data.removeSubrange(data.startIndex...newline)
+        }
+
+        for line in data.split(separator: 0x0A).reversed() {
+            guard let object = try? JSONSerialization.jsonObject(with: Data(line)) as? [String: Any],
+                  object["type"] as? String == "turn_context",
+                  let payload = object["payload"] as? [String: Any],
+                  payload["turn_id"] as? String == turnID,
+                  let reviewer = payload["approvals_reviewer"] as? String else { continue }
+            switch reviewer {
+            case "user", "auto_review", "guardian_subagent": return reviewer
+            default: return nil
+            }
+        }
+        return nil
+    }
+
     private func handle(line: Data) {
-        guard let decoded = Self.decodeHookLine(line) else {
+        guard var decoded = Self.decodeHookLine(line) else {
             NSLog("[glint] agent: malformed hook line (\(line.count) bytes)")
             return
+        }
+        if decoded["agent"] == "codex",
+           decoded["hook"] == "PermissionRequest",
+           let transcript = decoded["transcript"],
+           let turn = decoded["turn"],
+           let reviewer = Self.codexApprovalReviewer(
+               transcriptPath: transcript,
+               turnID: turn
+           ) {
+            decoded["approvals_reviewer"] = reviewer
         }
         DispatchQueue.main.async {
             NotificationCenter.default.post(

--- a/Glint/Agent/AgentBridge.swift
+++ b/Glint/Agent/AgentBridge.swift
@@ -195,7 +195,19 @@ final class AgentBridge {
     /// user or auto reviewer, and the hook payload does not expose that
     /// reviewer. The matching turn_context in the supplied rollout does.
     /// Read only the tail so a long-lived session cannot stall hook routing.
-    static func codexApprovalReviewer(transcriptPath: String, turnID: String) -> String? {
+    ///
+    /// `approvals_reviewer` is one of `"user"` (a human approves) or
+    /// `"auto_review"` (Codex's guardian subagent approves) — the only values
+    /// observed in real rollouts. Anything else, or a missing field, yields
+    /// `nil`: the caller treats that as "needs permission", since a false
+    /// alert is safe and silently suppressing a real prompt is not.
+    /// `maxTailBytes` defaults to the production cap and is overridable only
+    /// so the tail-window logic can be exercised without writing megabytes.
+    static func codexApprovalReviewer(
+        transcriptPath: String,
+        turnID: String,
+        maxTailBytes: UInt64 = 8 * 1024 * 1024
+    ) -> String? {
         guard !turnID.isEmpty else { return nil }
         let url = URL(fileURLWithPath: transcriptPath).standardizedFileURL
         guard url.pathExtension == "jsonl",
@@ -203,8 +215,7 @@ final class AgentBridge {
         defer { try? handle.close() }
 
         let end = handle.seekToEndOfFile()
-        let maxBytes: UInt64 = 8 * 1024 * 1024
-        let start = end > maxBytes ? end - maxBytes : 0
+        let start = end > maxTailBytes ? end - maxTailBytes : 0
         handle.seek(toFileOffset: start)
         var data = handle.readDataToEndOfFile()
         if start > 0 {
@@ -219,7 +230,7 @@ final class AgentBridge {
                   payload["turn_id"] as? String == turnID,
                   let reviewer = payload["approvals_reviewer"] as? String else { continue }
             switch reviewer {
-            case "user", "auto_review", "guardian_subagent": return reviewer
+            case "user", "auto_review": return reviewer
             default: return nil
             }
         }

--- a/Glint/Agent/AgentHookInstaller.swift
+++ b/Glint/Agent/AgentHookInstaller.swift
@@ -357,6 +357,8 @@ enum AgentHookInstaller {
     /// instead of `--continue` (issue #45). When extraction fails (older CLI,
     /// non-JSON payload) the field is omitted; the receiver tells "no id
     /// captured" apart from "captured but empty".
+    /// Codex PermissionRequest events also forward transcript_path + turn_id;
+    /// AgentBridge uses that pair to resolve the effective approvals reviewer.
     static let scriptBody: String = """
     #!/bin/sh
     # Glint CLI-agent hook reporter. argv: event, agent kind.
@@ -380,24 +382,38 @@ enum AgentHookInstaller {
     # resume. Dropping the whole event (the old `exit 0`) stalled the pane
     # silently until mktemp recovered.
     SESSION=""
+    TRANSCRIPT=""
+    TURN=""
     if TMP=$(/usr/bin/mktemp "${TMPDIR:-/tmp}/glint-hook.XXXXXX"); then
       trap '/bin/rm -f "$TMP"' EXIT HUP INT TERM
       cat >"$TMP"
       SESSION=$(/usr/bin/plutil -extract session_id raw -o - "$TMP" 2>/dev/null || true)
+      if [ "$HOOK" = "PermissionRequest" ] && [ "$AGENT" = "codex" ]; then
+        TRANSCRIPT=$(/usr/bin/plutil -extract transcript_path raw -o - "$TMP" 2>/dev/null || true)
+        TURN=$(/usr/bin/plutil -extract turn_id raw -o - "$TMP" 2>/dev/null || true)
+      fi
       /bin/rm -f "$TMP"
       trap - EXIT HUP INT TERM
     else
       cat >/dev/null 2>&1
     fi
 
+    APPROVAL_META=""
+    if [ -n "$TRANSCRIPT" ] && [ -n "$TURN" ]; then
+      TRANSCRIPT_B64=$(printf '%s' "$TRANSCRIPT" | /usr/bin/base64 | /usr/bin/tr -d '\\r\\n')
+      TURN_B64=$(printf '%s' "$TURN" | /usr/bin/base64 | /usr/bin/tr -d '\\r\\n')
+      APPROVAL_META=$(printf ',"transcript_b64":"%s","turn_b64":"%s"' \\
+        "$TRANSCRIPT_B64" "$TURN_B64")
+    fi
+
     if [ -n "$SESSION" ]; then
       SESSION_B64=$(printf '%s' "$SESSION" | /usr/bin/base64 | /usr/bin/tr -d '\\r\\n')
-      printf '{"pane":"%s","hook":"%s","agent":"%s","session_b64":"%s"}\\n' \\
-        "$PANE" "$HOOK" "$AGENT" "$SESSION_B64" \\
+      printf '{"pane":"%s","hook":"%s","agent":"%s","session_b64":"%s"%s}\\n' \\
+        "$PANE" "$HOOK" "$AGENT" "$SESSION_B64" "$APPROVAL_META" \\
         | /usr/bin/nc -U -w 1 "$SOCK" >/dev/null 2>&1 || true
     else
-      printf '{"pane":"%s","hook":"%s","agent":"%s"}\\n' \\
-        "$PANE" "$HOOK" "$AGENT" \\
+      printf '{"pane":"%s","hook":"%s","agent":"%s"%s}\\n' \\
+        "$PANE" "$HOOK" "$AGENT" "$APPROVAL_META" \\
         | /usr/bin/nc -U -w 1 "$SOCK" >/dev/null 2>&1 || true
     fi
     exit 0
@@ -418,8 +434,9 @@ enum AgentHookInstaller {
 ///     }
 ///
 /// Codex passes the entire hook payload on stdin, same as Claude. The shared
-/// reporter pulls `session_id` out for restore-on-launch (#45) and forwards
-/// the event name to Glint's local socket using the pane env vars.
+/// reporter pulls `session_id` out for restore-on-launch (#45), adds the
+/// approval context needed for Codex PermissionRequest events, and forwards
+/// the event to Glint's local socket using the pane env vars.
 enum CodexHookInstaller {
     /// Events Glint reacts to. Codex has no Notification event, but it does
     /// expose tool boundaries; PreToolUse is important for clearing a pending

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -1762,8 +1762,12 @@ final class WorkspaceStore: ObservableObject {
         approvalsReviewer: String?
     ) -> PaneAgentStatus {
         guard kind == .codex else { return .needsPermission }
+        // Only `auto_review` (Codex's guardian subagent) approves without the
+        // human. `user`, nil, or any unrecognised reviewer still needs a person
+        // — see AgentBridge.codexApprovalReviewer for why the default is
+        // conservative rather than "anything but user".
         switch approvalsReviewer {
-        case "auto_review", "guardian_subagent": return .thinking
+        case "auto_review": return .thinking
         default: return .needsPermission
         }
     }

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -1757,6 +1757,17 @@ final class WorkspaceStore: ObservableObject {
 
     // MARK: agent hook events
 
+    static func permissionRequestStatus(
+        kind: PaneAgentKind,
+        approvalsReviewer: String?
+    ) -> PaneAgentStatus {
+        guard kind == .codex else { return .needsPermission }
+        switch approvalsReviewer {
+        case "auto_review", "guardian_subagent": return .thinking
+        default: return .needsPermission
+        }
+    }
+
     /// Translate one hook from the AgentBridge into pane state.
     func handleAgentEvent(_ info: [AnyHashable: Any]?) {
         guard let info,
@@ -1825,7 +1836,11 @@ final class WorkspaceStore: ObservableObject {
             }
             state.status = .thinking
         case "Notification":      break   // noisy: background/idle prompts, ignore
-        case "PermissionRequest": state.status = .needsPermission
+        case "PermissionRequest":
+            state.status = Self.permissionRequestStatus(
+                kind: kind,
+                approvalsReviewer: info["approvals_reviewer"] as? String
+            )
         case "PreCompact":        state.status = .compacting
         case "Stop":
             // `.justCompleted` persists until the user actually views this

--- a/GlintTests/AgentHookRoutingTests.swift
+++ b/GlintTests/AgentHookRoutingTests.swift
@@ -86,7 +86,7 @@ final class AgentHookRoutingTests: XCTestCase {
 
         let reporter = Process()
         reporter.executableURL = URL(fileURLWithPath: "/bin/sh")
-        reporter.arguments = [script.path, "UserPromptSubmit", "codex"]
+        reporter.arguments = [script.path, "PermissionRequest", "codex"]
         var environment = ProcessInfo.processInfo.environment
         environment["GLINT_PANE_ID"] = "12345678-1234-1234-1234-123456789ABC:7"
         environment["GLINT_AGENT_SOCK"] = socket.path
@@ -95,7 +95,7 @@ final class AgentHookRoutingTests: XCTestCase {
         reporter.standardInput = input
         try reporter.run()
         input.fileHandleForWriting.write(
-            Data(#"{"session_id":"session-123","cwd":"/tmp/repo"}"#.utf8)
+            Data(#"{"session_id":"session-123","turn_id":"turn-123","transcript_path":"/tmp/codex.jsonl","cwd":"/tmp/repo"}"#.utf8)
         )
         try input.fileHandleForWriting.close()
         reporter.waitUntilExit()
@@ -109,10 +109,77 @@ final class AgentHookRoutingTests: XCTestCase {
         let line = listenerOutput.fileHandleForReading.readDataToEndOfFile()
         XCTAssertEqual(AgentBridge.decodeHookLine(line), [
             "pane": "12345678-1234-1234-1234-123456789ABC:7",
-            "hook": "UserPromptSubmit",
+            "hook": "PermissionRequest",
             "agent": "codex",
             "session": "session-123",
+            "turn": "turn-123",
+            "transcript": "/tmp/codex.jsonl",
         ])
+    }
+
+    func testCodexApprovalReviewerComesFromMatchingTurnContext() throws {
+        let transcript = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-rollout-\(UUID().uuidString).jsonl")
+        let fixture = """
+        {"type":"turn_context","payload":{"turn_id":"turn-user","approvals_reviewer":"user"}}
+        {"type":"turn_context","payload":{"turn_id":"turn-auto","approvals_reviewer":"auto_review"}}
+        """
+        try fixture.write(to: transcript, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: transcript) }
+
+        XCTAssertEqual(
+            AgentBridge.codexApprovalReviewer(
+                transcriptPath: transcript.path,
+                turnID: "turn-auto"
+            ),
+            "auto_review"
+        )
+        XCTAssertEqual(
+            AgentBridge.codexApprovalReviewer(
+                transcriptPath: transcript.path,
+                turnID: "turn-user"
+            ),
+            "user"
+        )
+        XCTAssertNil(
+            AgentBridge.codexApprovalReviewer(
+                transcriptPath: transcript.path,
+                turnID: "turn-missing"
+            )
+        )
+    }
+
+    @MainActor
+    func testCodexAutoReviewPermissionRequestDoesNotWaitForUser() {
+        XCTAssertEqual(
+            WorkspaceStore.permissionRequestStatus(
+                kind: .codex,
+                approvalsReviewer: "auto_review"
+            ),
+            .thinking
+        )
+        XCTAssertEqual(
+            WorkspaceStore.permissionRequestStatus(
+                kind: .codex,
+                approvalsReviewer: "guardian_subagent"
+            ),
+            .thinking
+        )
+        XCTAssertEqual(
+            WorkspaceStore.permissionRequestStatus(kind: .codex, approvalsReviewer: "user"),
+            .needsPermission
+        )
+        XCTAssertEqual(
+            WorkspaceStore.permissionRequestStatus(kind: .codex, approvalsReviewer: nil),
+            .needsPermission
+        )
+        XCTAssertEqual(
+            WorkspaceStore.permissionRequestStatus(
+                kind: .claude,
+                approvalsReviewer: "auto_review"
+            ),
+            .needsPermission
+        )
     }
 
     /// Without PANE/SOCK the reporter must still exit 0 and drain stdin —

--- a/GlintTests/AgentHookRoutingTests.swift
+++ b/GlintTests/AgentHookRoutingTests.swift
@@ -149,6 +149,46 @@ final class AgentHookRoutingTests: XCTestCase {
         )
     }
 
+    /// The tail window must drop turn_context lines older than `maxTailBytes`,
+    /// including a matching one, so a multi-MB session can't stall routing. A
+    /// tiny window keeps the fixture cheap while still exercising the
+    /// partial-first-line drop the production 8 MB cap relies on.
+    func testCodexApprovalReviewerIgnoresTurnContextBeyondTailWindow() throws {
+        let transcript = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-tail-\(UUID().uuidString).jsonl")
+        let decoy = #"{"type":"turn_context","payload":{"turn_id":"turn-x","approvals_reviewer":"user"}}"#
+        let live = #"{"type":"turn_context","payload":{"turn_id":"turn-x","approvals_reviewer":"auto_review"}}"#
+        // One long newline-free line pushes the decoy out of the window; the
+        // read offset lands inside it, so this also covers the
+        // drop-up-to-first-newline branch.
+        let filler = String(repeating: "x", count: 512)
+        let window: UInt64 = 128
+
+        // Decoy sits beyond the window → only the tail `live` line is visible,
+        // so we resolve auto_review rather than the head's user.
+        try "\(decoy)\n\(filler)\n\(live)\n".write(to: transcript, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: transcript) }
+        XCTAssertEqual(
+            AgentBridge.codexApprovalReviewer(
+                transcriptPath: transcript.path,
+                turnID: "turn-x",
+                maxTailBytes: window
+            ),
+            "auto_review"
+        )
+
+        // With no match in the tail, the head decoy must not be seen — a
+        // broken window would return "user" here.
+        try "\(decoy)\n\(filler)\n".write(to: transcript, atomically: true, encoding: .utf8)
+        XCTAssertNil(
+            AgentBridge.codexApprovalReviewer(
+                transcriptPath: transcript.path,
+                turnID: "turn-x",
+                maxTailBytes: window
+            )
+        )
+    }
+
     @MainActor
     func testCodexAutoReviewPermissionRequestDoesNotWaitForUser() {
         XCTAssertEqual(
@@ -158,12 +198,15 @@ final class AgentHookRoutingTests: XCTestCase {
             ),
             .thinking
         )
+        // Any reviewer other than auto_review (incl. future/unknown values)
+        // still surfaces as needs-permission: a false alert is safe, silently
+        // suppressing a real prompt is not.
         XCTAssertEqual(
             WorkspaceStore.permissionRequestStatus(
                 kind: .codex,
-                approvalsReviewer: "guardian_subagent"
+                approvalsReviewer: "some_future_reviewer"
             ),
-            .thinking
+            .needsPermission
         )
         XCTAssertEqual(
             WorkspaceStore.permissionRequestStatus(kind: .codex, approvalsReviewer: "user"),


### PR DESCRIPTION
## What & why

When Codex runs with `approvals_reviewer = "auto_review"` (its guardian subagent), tool calls are approved automatically — no human needed. But Glint treated every Codex `PermissionRequest` hook as `.needsPermission`, so auto-review panes kept getting surfaced by the attention sidebar / `⌘⇧A` jump-to-next as "waiting on you" when they weren't. This stops that false alert.

## How

- The Codex `PermissionRequest` hook payload does **not** expose the reviewer, but the matching `turn_context` line in the rollout JSONL does (`payload.approvals_reviewer`). The hook reporter now also forwards `transcript_path` + `turn_id` for Codex `PermissionRequest` events (base64, same envelope as `session_id`).
- `AgentBridge.codexApprovalReviewer` opens the rollout, reads only the **≤8 MB tail** (so a long-lived session can't stall hook routing), drops the partial first line, and reverse-scans for the `turn_context` whose `turn_id` matches.
- Only `"auto_review"` is mapped to `.thinking` (no human needed). `"user"`, `nil`, or any unrecognised value stays `.needsPermission` — a false alert is safe; silently suppressing a real prompt is not.
- Schema verified against 275 real `turn_context` lines on disk + official docs: `approvals_reviewer` is only ever `"user"` or `"auto_review"`. An earlier draft also handled `"guardian_subagent"`, which never occurs in practice — removed.

## Testing / verification

- `AgentHookRoutingTests`: **9/9 green**. Added `testCodexApprovalReviewerIgnoresTurnContextBeyondTailWindow` covering the partial-first-line drop, the window boundary, and newest-wins ordering — via a tiny injectable `maxTailBytes` so the test does no megabyte-sized I/O.
- Build: `xcodebuild test -scheme Glint -sdk macosx -arch arm64 -only-testing:GlintTests/AgentHookRoutingTests` → `** TEST SUCCEEDED **`.

### Non-blocking follow-up noted in review

`readDataToEndOfFile()` would read unboundedly on a non-regular file (`/dev/zero`, FIFO). The `.jsonl` extension guard + trusted local Codex source make the threat negligible, but a future hardening pass could switch to `readData(ofLength:)` or a regular-file check.

---

## 中文

### 做什么 / 为什么

Codex 在 `approvals_reviewer = "auto_review"`(guardian 子代理)模式下,工具调用由子代理自动审批,根本不需要人。但 Glint 之前把每个 Codex `PermissionRequest` 钩子都标成 `.needsPermission`,导致自动审批中的 pane 一直被关注侧边栏 / `⌘⇧A`「跳到下一个待处理」当成"在等你"。本次消除这个误报。

### 怎么做

- Codex 的 `PermissionRequest` 钩子 payload **不带** reviewer 字段,但 rollout JSONL 里同 turn 的 `turn_context` 带 `payload.approvals_reviewer`。钩子 reporter 现在对 Codex `PermissionRequest` 事件额外转发 `transcript_path` + `turn_id`(base64,与 `session_id` 同一套信封)。
- `AgentBridge.codexApprovalReviewer` 打开 rollout,**只读尾部 ≤8MB**(避免长寿 session 卡住钩子路由),丢掉首段半行,倒序扫描 `turn_id` 匹配的 `turn_context`。
- 只有 `"auto_review"` 映射为 `.thinking`(不需要人);`"user"`、缺省、任何未知值仍是 `.needsPermission` —— 误报安全,漏报(把真需要审批的静默掉)才危险。
- schema 已对照本机 275 条真实 `turn_context` + 官方文档核实:`approvals_reviewer` 只会是 `"user"` 或 `"auto_review"`。早先草稿里的 `"guardian_subagent"` 实际不存在,已删除。

### 测试 / 验证

- `AgentHookRoutingTests`:**9/9 通过**。新增 `testCodexApprovalReviewerIgnoresTurnContextBeyondTailWindow`,覆盖半行丢弃、窗口边界、倒序最新优先 —— 通过可注入的小 `maxTailBytes`,测试不做 MB 级磁盘 I/O。
- 编译:`xcodebuild test -scheme Glint -sdk macosx -arch arm64 -only-testing:GlintTests/AgentHookRoutingTests` → `** TEST SUCCEEDED **`。

#### Review 中记录的非阻塞后续项

`readDataToEndOfFile()` 对非常规文件(`/dev/zero`、命名管道)会无限读。`.jsonl` 扩展名校验 + Codex 是本地受信来源,威胁可忽略,但后续可改用 `readData(ofLength:)` 或加常规文件判断来硬化。
