### PR TITLE
perf: event-driven refresh + coalesced git status / 事件驱动刷新 + git status 合并去重

### DIFF
--- a/Glint.xcodeproj/project.pbxproj
+++ b/Glint.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A11D19DF80794F929D548A03 /* GitRepositoryWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11D19DF80794F929D548A04 /* GitRepositoryWatcher.swift */; };
+		A11D19DF80794F929D548A05 /* GitRepositoryWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11D19DF80794F929D548A06 /* GitRepositoryWatcherTests.swift */; };
+		A11D19DF80794F929D548A01 /* GhosttyTickSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11D19DF80794F929D548A02 /* GhosttyTickSchedulerTests.swift */; };
 		04E75EAD5165E8D96C1C5517 /* MascotAssetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349714D49AE52D84995314FD /* MascotAssetTests.swift */; };
 		07817DC6A98F8ED2E236CFA1 /* CodexHome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E3B385162995D0F1F5B72D /* CodexHome.swift */; };
 		0FEECB27EB1ACE11E29ECCEF /* CodexHookInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26141150D2DB4C0589558ECC /* CodexHookInstallerTests.swift */; };
@@ -84,6 +87,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A11D19DF80794F929D548A04 /* GitRepositoryWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepositoryWatcher.swift; sourceTree = "<group>"; };
+		A11D19DF80794F929D548A06 /* GitRepositoryWatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepositoryWatcherTests.swift; sourceTree = "<group>"; };
+		A11D19DF80794F929D548A02 /* GhosttyTickSchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTickSchedulerTests.swift; sourceTree = "<group>"; };
 		050E267AE14712D4D6633B4F /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		05F2CA2243872C8111048EF2 /* AgentBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBridge.swift; sourceTree = "<group>"; };
 		08FC2FBC9E8729A5ECBF857C /* PaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneView.swift; sourceTree = "<group>"; };
@@ -195,6 +201,8 @@
 		5F9010EBEE9DCDE13D866A74 /* GlintTests */ = {
 			isa = PBXGroup;
 			children = (
+				A11D19DF80794F929D548A06 /* GitRepositoryWatcherTests.swift */,
+				A11D19DF80794F929D548A02 /* GhosttyTickSchedulerTests.swift */,
 				FF0082D535969C315B8D75D7 /* AgentHookRoutingTests.swift */,
 				4EEF00CBEF45A9D60423A207 /* AgentKindResolutionTests.swift */,
 				6AB338782EF6F22B7B381DA8 /* CodexHomeStoreTests.swift */,
@@ -239,6 +247,7 @@
 		6A47880D53D0B53681B9E4D3 /* Git */ = {
 			isa = PBXGroup;
 			children = (
+				A11D19DF80794F929D548A04 /* GitRepositoryWatcher.swift */,
 				7039488F4C2F75498E461311 /* GitDiff.swift */,
 				39F54835E4A44EC88236EFBE /* GitService.swift */,
 			);
@@ -451,6 +460,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A11D19DF80794F929D548A05 /* GitRepositoryWatcherTests.swift in Sources */,
+				A11D19DF80794F929D548A01 /* GhosttyTickSchedulerTests.swift in Sources */,
 				A019A2AD685F1407D7E2A7E1 /* AgentHookRoutingTests.swift in Sources */,
 				81532B36FEC3039B8EAD9CB1 /* AgentKindResolutionTests.swift in Sources */,
 				C41119D04864077E5B554F59 /* CodexHomeStoreTests.swift in Sources */,
@@ -474,6 +485,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A11D19DF80794F929D548A03 /* GitRepositoryWatcher.swift in Sources */,
 				E464D0233508CD31C1235054 /* AgentBridge.swift in Sources */,
 				9F605AB2DC185A94ED28E6D4 /* AgentChoice.swift in Sources */,
 				3932A4CFEFF6FB81AE283645 /* AgentHookInstaller.swift in Sources */,

--- a/Glint.xcodeproj/project.pbxproj
+++ b/Glint.xcodeproj/project.pbxproj
@@ -7,17 +7,17 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		A11D19DF80794F929D548A03 /* GitRepositoryWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11D19DF80794F929D548A04 /* GitRepositoryWatcher.swift */; };
-		A11D19DF80794F929D548A05 /* GitRepositoryWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11D19DF80794F929D548A06 /* GitRepositoryWatcherTests.swift */; };
-		A11D19DF80794F929D548A01 /* GhosttyTickSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11D19DF80794F929D548A02 /* GhosttyTickSchedulerTests.swift */; };
 		04E75EAD5165E8D96C1C5517 /* MascotAssetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349714D49AE52D84995314FD /* MascotAssetTests.swift */; };
 		07817DC6A98F8ED2E236CFA1 /* CodexHome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E3B385162995D0F1F5B72D /* CodexHome.swift */; };
+		0FB9792E290FC2A8B527B2D0 /* GitRepositoryWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C888E59D1091BFC22A9EA4 /* GitRepositoryWatcherTests.swift */; };
 		0FEECB27EB1ACE11E29ECCEF /* CodexHookInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26141150D2DB4C0589558ECC /* CodexHookInstallerTests.swift */; };
 		1115F230E14FBE3C1FC754A2 /* GhosttySurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E298AD81B1615CBBFD69F48A /* GhosttySurfaceView.swift */; };
 		11AB712CD3F25FE8A034F205 /* GitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F54835E4A44EC88236EFBE /* GitService.swift */; };
 		164C6F51683CE7942393E816 /* GitDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7039488F4C2F75498E461311 /* GitDiff.swift */; };
 		175E069EE844FB32C6EE51BB /* Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDE0D7C434B8E9C76C4A297 /* Persistence.swift */; };
+		180444BD20493AE4822BD372 /* GhosttyTickSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D751E30DFF2EFA6F705A374 /* GhosttyTickSchedulerTests.swift */; };
 		21C03B3AE912F4D30FA6F92C /* PaneAgentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DDB9C7B5A277B7924270A3 /* PaneAgentState.swift */; };
+		2D9012046800A06555DEA381 /* GitRefreshCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65BE76E8E627A5347D565968 /* GitRefreshCoordinatorTests.swift */; };
 		2DD19A3FDAE094EF32B0B9F0 /* zsh-autosuggestions.zsh in Resources */ = {isa = PBXBuildFile; fileRef = D03AFC613028C5BB0D99238D /* zsh-autosuggestions.zsh */; };
 		2E52C3AC5AD998CD3604D6BE /* GhosttyKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81DADCF27E710CC77846E961 /* GhosttyKit.xcframework */; };
 		3194A1545E36E400BC2C33E6 /* PaneSessionIdMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797C4E86D052EF8A68DD9B39 /* PaneSessionIdMigrationTests.swift */; };
@@ -25,12 +25,14 @@
 		370FA310A4B7CC8489BF51DE /* WhatsNewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712159D2C27AD5B865820384 /* WhatsNewView.swift */; };
 		3932A4CFEFF6FB81AE283645 /* AgentHookInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265A192AC9BD06DB09346E90 /* AgentHookInstaller.swift */; };
 		3CB9F41E3B1CB4A8790D9159 /* GhosttyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC6FFB5185C403F6F44A1687 /* GhosttyManager.swift */; };
+		3EFBC4D177ED22F347A7AFB0 /* GitRepositoryWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6FB2646BF84D9DCBB89FC93 /* GitRepositoryWatcher.swift */; };
 		419DDD815048044125F5FE91 /* ReviewWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E982534C8CF6270BCF39106 /* ReviewWindow.swift */; };
 		456D76955277C3299291BF60 /* SyntaxHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8037A4E0001A21E3224DD798 /* SyntaxHighlighter.swift */; };
 		47BB527385B84454ABF8FC40 /* themes.json in Resources */ = {isa = PBXBuildFile; fileRef = 6860F8F626EFDB9A289FC727 /* themes.json */; };
 		4971664CE7FBF0629C8DD709 /* ReleaseNotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 407B3A9D15F4B9E613DA1CF8 /* ReleaseNotes.swift */; };
 		49DF8EE59313B7CFE29DA303 /* PaneTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E646AABA8ADCE8A2A5C6F55 /* PaneTreeView.swift */; };
 		5157C5439862F21202BCC44D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E67CF5D8552AE1F51386161 /* AppDelegate.swift */; };
+		6290F26DFE2D0D5E1FEB9FA9 /* GitRefreshCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBB695363FAF3A996EF0C9FF /* GitRefreshCoordinator.swift */; };
 		692D1A7D490E07D796535EAA /* UpdaterController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4408F9761E584DE2AB6630E2 /* UpdaterController.swift */; };
 		6D74FE6545631EB8193C82E1 /* PaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FC2FBC9E8729A5ECBF857C /* PaneView.swift */; };
 		7072B8575DB70B2367A7EE1D /* ReviewScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7F8C1899F93B387843907FF /* ReviewScopeTests.swift */; };
@@ -87,14 +89,12 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		A11D19DF80794F929D548A04 /* GitRepositoryWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepositoryWatcher.swift; sourceTree = "<group>"; };
-		A11D19DF80794F929D548A06 /* GitRepositoryWatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepositoryWatcherTests.swift; sourceTree = "<group>"; };
-		A11D19DF80794F929D548A02 /* GhosttyTickSchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTickSchedulerTests.swift; sourceTree = "<group>"; };
 		050E267AE14712D4D6633B4F /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		05F2CA2243872C8111048EF2 /* AgentBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBridge.swift; sourceTree = "<group>"; };
 		08FC2FBC9E8729A5ECBF857C /* PaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneView.swift; sourceTree = "<group>"; };
 		0C5FD3EEA1ECD40F78394862 /* AgentLaunchChooser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLaunchChooser.swift; sourceTree = "<group>"; };
 		0D29C0D2447094B07854C193 /* NewWorkspaceSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorkspaceSheet.swift; sourceTree = "<group>"; };
+		0D751E30DFF2EFA6F705A374 /* GhosttyTickSchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTickSchedulerTests.swift; sourceTree = "<group>"; };
 		0F58E2127BAE2C9F5155CF07 /* DevinHookInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevinHookInstallerTests.swift; sourceTree = "<group>"; };
 		0FBF22AEC81DBE92987A8CB4 /* CodexUsageReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexUsageReaderTests.swift; sourceTree = "<group>"; };
 		150EEF32284061D527E51866 /* GlintTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlintTheme.swift; sourceTree = "<group>"; };
@@ -116,6 +116,7 @@
 		407B3A9D15F4B9E613DA1CF8 /* ReleaseNotes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseNotes.swift; sourceTree = "<group>"; };
 		41DDB9C7B5A277B7924270A3 /* PaneAgentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneAgentState.swift; sourceTree = "<group>"; };
 		4408F9761E584DE2AB6630E2 /* UpdaterController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdaterController.swift; sourceTree = "<group>"; };
+		49C888E59D1091BFC22A9EA4 /* GitRepositoryWatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepositoryWatcherTests.swift; sourceTree = "<group>"; };
 		4A0B24E791FF6CEB30A9DDD5 /* RemoteTitleParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTitleParserTests.swift; sourceTree = "<group>"; };
 		4B8EDEAA2D0EAD42ED6F1915 /* SSHGitRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHGitRunnerTests.swift; sourceTree = "<group>"; };
 		4BE4DBC7E2579823474466E9 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -123,6 +124,7 @@
 		51DE2D7740BD03498A936B62 /* PersistenceRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceRecoveryTests.swift; sourceTree = "<group>"; };
 		54663E213FE879B96C0D80E7 /* GitStatusPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusPopover.swift; sourceTree = "<group>"; };
 		5A8933F67B4B6EEA3FD4E603 /* WorkspaceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceStore.swift; sourceTree = "<group>"; };
+		65BE76E8E627A5347D565968 /* GitRefreshCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRefreshCoordinatorTests.swift; sourceTree = "<group>"; };
 		6860F8F626EFDB9A289FC727 /* themes.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = themes.json; sourceTree = "<group>"; };
 		6AB338782EF6F22B7B381DA8 /* CodexHomeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexHomeStoreTests.swift; sourceTree = "<group>"; };
 		6D3B64992BBD5A190DFE36D2 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
@@ -144,6 +146,7 @@
 		A8C269A6E9AE87961C3356DC /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		C0656F7C1D48AE0429C1888B /* VisualEffectBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualEffectBackground.swift; sourceTree = "<group>"; };
 		C11B3335E47DDAF77A883064 /* ModalOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalOverlay.swift; sourceTree = "<group>"; };
+		C6FB2646BF84D9DCBB89FC93 /* GitRepositoryWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepositoryWatcher.swift; sourceTree = "<group>"; };
 		C753FB652599A4C7900F8AA4 /* FontCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontCatalog.swift; sourceTree = "<group>"; };
 		C9E2B9ADF809766CE4278047 /* SafeJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeJSON.swift; sourceTree = "<group>"; };
 		D03AFC613028C5BB0D99238D /* zsh-autosuggestions.zsh */ = {isa = PBXFileReference; path = "zsh-autosuggestions.zsh"; sourceTree = "<group>"; };
@@ -151,6 +154,7 @@
 		DB20921E3CAC1006A8FBD3AE /* SettingsSafety.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSafety.swift; sourceTree = "<group>"; };
 		E298AD81B1615CBBFD69F48A /* GhosttySurfaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttySurfaceView.swift; sourceTree = "<group>"; };
 		E94AB23640CA1E6007F8B2B4 /* GlintTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GlintTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		EBB695363FAF3A996EF0C9FF /* GitRefreshCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRefreshCoordinator.swift; sourceTree = "<group>"; };
 		EBCC04C19D745AA867D961FD /* PaneAgentKindTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneAgentKindTests.swift; sourceTree = "<group>"; };
 		F3EB9A1E80F3CC4BCA468774 /* AgentChoice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChoice.swift; sourceTree = "<group>"; };
 		F5A69ACF962AEDE189F98649 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -201,14 +205,15 @@
 		5F9010EBEE9DCDE13D866A74 /* GlintTests */ = {
 			isa = PBXGroup;
 			children = (
-				A11D19DF80794F929D548A06 /* GitRepositoryWatcherTests.swift */,
-				A11D19DF80794F929D548A02 /* GhosttyTickSchedulerTests.swift */,
 				FF0082D535969C315B8D75D7 /* AgentHookRoutingTests.swift */,
 				4EEF00CBEF45A9D60423A207 /* AgentKindResolutionTests.swift */,
 				6AB338782EF6F22B7B381DA8 /* CodexHomeStoreTests.swift */,
 				26141150D2DB4C0589558ECC /* CodexHookInstallerTests.swift */,
 				0FBF22AEC81DBE92987A8CB4 /* CodexUsageReaderTests.swift */,
 				0F58E2127BAE2C9F5155CF07 /* DevinHookInstallerTests.swift */,
+				0D751E30DFF2EFA6F705A374 /* GhosttyTickSchedulerTests.swift */,
+				65BE76E8E627A5347D565968 /* GitRefreshCoordinatorTests.swift */,
+				49C888E59D1091BFC22A9EA4 /* GitRepositoryWatcherTests.swift */,
 				349714D49AE52D84995314FD /* MascotAssetTests.swift */,
 				EBCC04C19D745AA867D961FD /* PaneAgentKindTests.swift */,
 				797C4E86D052EF8A68DD9B39 /* PaneSessionIdMigrationTests.swift */,
@@ -247,8 +252,9 @@
 		6A47880D53D0B53681B9E4D3 /* Git */ = {
 			isa = PBXGroup;
 			children = (
-				A11D19DF80794F929D548A04 /* GitRepositoryWatcher.swift */,
 				7039488F4C2F75498E461311 /* GitDiff.swift */,
+				EBB695363FAF3A996EF0C9FF /* GitRefreshCoordinator.swift */,
+				C6FB2646BF84D9DCBB89FC93 /* GitRepositoryWatcher.swift */,
 				39F54835E4A44EC88236EFBE /* GitService.swift */,
 			);
 			path = Git;
@@ -460,14 +466,15 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A11D19DF80794F929D548A05 /* GitRepositoryWatcherTests.swift in Sources */,
-				A11D19DF80794F929D548A01 /* GhosttyTickSchedulerTests.swift in Sources */,
 				A019A2AD685F1407D7E2A7E1 /* AgentHookRoutingTests.swift in Sources */,
 				81532B36FEC3039B8EAD9CB1 /* AgentKindResolutionTests.swift in Sources */,
 				C41119D04864077E5B554F59 /* CodexHomeStoreTests.swift in Sources */,
 				0FEECB27EB1ACE11E29ECCEF /* CodexHookInstallerTests.swift in Sources */,
 				FEBC3158CB471E9ABDF931BB /* CodexUsageReaderTests.swift in Sources */,
 				34997DD4A4F9B64A754FE77F /* DevinHookInstallerTests.swift in Sources */,
+				180444BD20493AE4822BD372 /* GhosttyTickSchedulerTests.swift in Sources */,
+				2D9012046800A06555DEA381 /* GitRefreshCoordinatorTests.swift in Sources */,
+				0FB9792E290FC2A8B527B2D0 /* GitRepositoryWatcherTests.swift in Sources */,
 				04E75EAD5165E8D96C1C5517 /* MascotAssetTests.swift in Sources */,
 				ED46CD7A6E09551A775AD3B8 /* PaneAgentKindTests.swift in Sources */,
 				3194A1545E36E400BC2C33E6 /* PaneSessionIdMigrationTests.swift in Sources */,
@@ -485,7 +492,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A11D19DF80794F929D548A03 /* GitRepositoryWatcher.swift in Sources */,
 				E464D0233508CD31C1235054 /* AgentBridge.swift in Sources */,
 				9F605AB2DC185A94ED28E6D4 /* AgentChoice.swift in Sources */,
 				3932A4CFEFF6FB81AE283645 /* AgentHookInstaller.swift in Sources */,
@@ -501,6 +507,8 @@
 				3CB9F41E3B1CB4A8790D9159 /* GhosttyManager.swift in Sources */,
 				1115F230E14FBE3C1FC754A2 /* GhosttySurfaceView.swift in Sources */,
 				164C6F51683CE7942393E816 /* GitDiff.swift in Sources */,
+				6290F26DFE2D0D5E1FEB9FA9 /* GitRefreshCoordinator.swift in Sources */,
+				3EFBC4D177ED22F347A7AFB0 /* GitRepositoryWatcher.swift in Sources */,
 				11AB712CD3F25FE8A034F205 /* GitService.swift in Sources */,
 				B1DE20B081ACC4536DBD2089 /* GitStatusPopover.swift in Sources */,
 				CEA0A8FF66046FEFA80FAC0C /* GlintApp.swift in Sources */,

--- a/Glint/Ghostty/GhosttyManager.swift
+++ b/Glint/Ghostty/GhosttyManager.swift
@@ -2,6 +2,39 @@ import Foundation
 import AppKit
 import GhosttyKit
 
+/// Coalesces edge-like Ghostty wakeups without losing a wakeup that arrives
+/// while the current tick is draining the mailbox.
+final class GhosttyTickScheduler {
+    typealias Enqueue = (@escaping () -> Void) -> Void
+
+    private let lock = NSLock()
+    private var scheduled = false
+    private let enqueue: Enqueue
+
+    init(enqueue: @escaping Enqueue = { DispatchQueue.main.async(execute: $0) }) {
+        self.enqueue = enqueue
+    }
+
+    func schedule(_ tick: @escaping () -> Void) {
+        lock.lock()
+        guard !scheduled else {
+            lock.unlock()
+            return
+        }
+        scheduled = true
+        lock.unlock()
+
+        enqueue { [self] in
+            // Clear before ticking: a producer can enqueue after the mailbox has
+            // drained, and that wakeup must be allowed to schedule another tick.
+            lock.lock()
+            scheduled = false
+            lock.unlock()
+            tick()
+        }
+    }
+}
+
 /// Owns the single `ghostty_app_t` for the process and drives its tick loop.
 ///
 /// Lifecycle:
@@ -17,6 +50,7 @@ final class GhosttyManager {
     private(set) var app: ghostty_app_t?
     private var config: ghostty_config_t?
     private var appearanceObservation: NSKeyValueObservation?
+    private let tickScheduler = GhosttyTickScheduler()
 
     private init() {
         bootstrap()
@@ -145,7 +179,7 @@ final class GhosttyManager {
     }
 
     private func tickSoon() {
-        DispatchQueue.main.async { [weak self] in
+        tickScheduler.schedule { [weak self] in
             guard let app = self?.app else { return }
             ghostty_app_tick(app)
         }
@@ -371,6 +405,13 @@ final class GhosttyManager {
                 }
             }
 
+        case GHOSTTY_ACTION_COMMAND_FINISHED:
+            if let view {
+                DispatchQueue.main.async {
+                    NotificationCenter.default.post(name: .ghosttyCommandFinished, object: view)
+                }
+            }
+
         case GHOSTTY_ACTION_SET_TITLE:
             // ghostty forwards the shell's OSC 0/2 title verbatim and — unlike
             // OSC 7 — does NOT host-validate it, so a remote shell's
@@ -381,7 +422,10 @@ final class GhosttyManager {
             // titles can't pollute remote state.
             if let view, let cstr = action.action.set_title.title {
                 let title = String(cString: cstr)
-                DispatchQueue.main.async { view.updateRemoteFromTitle(title) }
+                DispatchQueue.main.async {
+                    view.updateRemoteFromTitle(title)
+                    NotificationCenter.default.post(name: .ghosttyRemoteTitleChanged, object: view)
+                }
             }
 
         case GHOSTTY_ACTION_MOUSE_SHAPE:

--- a/Glint/Git/GitRefreshCoordinator.swift
+++ b/Glint/Git/GitRefreshCoordinator.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Coalesces rapid git-status refresh requests for one workspace so a single
+/// logical change can't spawn more than one `git status` subprocess.
+///
+/// Two independent push channels both fire for one change: the shell's
+/// command-finished signal lands first, and the filesystem watcher's callback
+/// follows ~0.5s later (its debounce latency). `WorkspaceStore.gitInFlight`
+/// only de-dupes refreshes that overlap in time — and a fast local `git status`
+/// (~100ms) finishes well before the trailing FSEvents callback arrives, so
+/// one `git commit` spawned two subprocesses. This coordinator closes that gap:
+/// once a refresh has been dispatched for a workspace, further refreshes
+/// requested within `minInterval` coalesce into ONE trailing refresh at the
+/// interval boundary. A sustained storm (build, rebase, checkout) thus
+/// refreshes at most once per `minInterval`, never zero — the trailing refresh
+/// always runs, so a genuine change can't be dropped while the storm throttles.
+///
+/// Only the push-based event channels route through here. Pull-based refreshes
+/// (workspace/pane switch, popover open, the active-only fallback timer) call
+/// `refreshGitStatus` / `refreshGitStatusNow` directly and stay immediate.
+final class GitRefreshCoordinator {
+    private let minInterval: TimeInterval
+    private let queue = DispatchQueue(label: "app.glint.git-refresh")
+    /// Last time a refresh for this workspace was actually dispatched (immediate
+    /// path, or a trailing fire). The elapsed-since guard is what folds a
+    /// trailing FSEvents callback back into the refresh the command-finished
+    /// signal already triggered.
+    private var lastDispatch: [UUID: Date] = [:]
+    /// One in-flight trailing work item per workspace, so a fresher request can
+    /// cancel a not-yet-fired trailing refresh and replace it.
+    private var pending: [UUID: DispatchWorkItem] = [:]
+
+    init(minInterval: TimeInterval = 1.5) {
+        self.minInterval = minInterval
+    }
+
+    /// Request a refresh of `id`. `run` runs on the main actor immediately when
+    /// at least `minInterval` has elapsed since the last dispatch, otherwise
+    /// once at the interval boundary. Repeated requests within the window
+    /// coalesce: a fresher request cancels any not-yet-fired trailing refresh
+    /// and replaces it, so only the most recent request's `run` survives.
+    func request(_ id: UUID, run: @escaping () -> Void) {
+        queue.async { [self] in
+            pending[id]?.cancel()
+            let now = Date()
+            let elapsed = lastDispatch[id].map { now.timeIntervalSince($0) } ?? .infinity
+            if elapsed >= minInterval {
+                lastDispatch[id] = now
+                pending[id] = nil
+                DispatchQueue.main.async(execute: run)
+            } else {
+                let delay = minInterval - elapsed
+                let item = DispatchWorkItem { [self] in
+                    lastDispatch[id] = Date()
+                    pending[id] = nil
+                    DispatchQueue.main.async(execute: run)
+                }
+                pending[id] = item
+                queue.asyncAfter(deadline: .now() + delay, execute: item)
+            }
+        }
+    }
+
+    /// Drop any not-yet-fired trailing refresh for `id` (e.g. its workspace was
+    /// removed). Does not affect a refresh already dispatched to the main queue.
+    func cancel(_ id: UUID) {
+        queue.async { [self] in
+            pending[id]?.cancel()
+            pending[id] = nil
+        }
+    }
+}

--- a/Glint/Git/GitRepositoryWatcher.swift
+++ b/Glint/Git/GitRepositoryWatcher.swift
@@ -1,0 +1,103 @@
+import Foundation
+import CoreServices
+
+/// Debounced recursive filesystem watcher for one repository/worktree.
+/// FSEvents supplies the broad invalidation signal; Git remains the authority.
+final class GitRepositoryWatcher {
+    private let queue = DispatchQueue(label: "app.glint.git-watch", qos: .utility)
+    private let onChange: () -> Void
+    private var stream: FSEventStreamRef?
+    private var pendingRefresh: DispatchWorkItem?
+
+    init(paths: [String], onChange: @escaping () -> Void) {
+        self.onChange = onChange
+        guard !paths.isEmpty else { return }
+
+        var context = FSEventStreamContext(
+            version: 0,
+            info: Unmanaged.passUnretained(self).toOpaque(),
+            retain: nil,
+            release: nil,
+            copyDescription: nil
+        )
+        let callback: FSEventStreamCallback = { _, info, _, _, _, _ in
+            guard let info else { return }
+            Unmanaged<GitRepositoryWatcher>.fromOpaque(info)
+                .takeUnretainedValue().scheduleRefresh()
+        }
+        let flags = FSEventStreamCreateFlags(
+            kFSEventStreamCreateFlagFileEvents
+                | kFSEventStreamCreateFlagWatchRoot
+                | kFSEventStreamCreateFlagNoDefer
+        )
+        guard let stream = FSEventStreamCreate(
+            nil, callback, &context, paths as CFArray,
+            FSEventStreamEventId(kFSEventStreamEventIdSinceNow), 0.5, flags
+        ) else { return }
+        self.stream = stream
+        FSEventStreamSetDispatchQueue(stream, queue)
+        FSEventStreamStart(stream)
+    }
+
+    deinit {
+        // `pendingRefresh` is written from `scheduleRefresh`, which runs on
+        // `queue` (the FSEvent callback target). Serialize the cancel on the
+        // same queue instead of touching it from the main thread that freed
+        // the watcher. Safe to sync from deinit: no task on `queue` ever
+        // blocks on the main thread (the debounce item hops with `main.async`,
+        // fire-and-forget), so there's no lock inversion.
+        queue.sync { pendingRefresh?.cancel() }
+        if let stream {
+            FSEventStreamStop(stream)
+            FSEventStreamInvalidate(stream)
+            FSEventStreamRelease(stream)
+        }
+    }
+
+    private func scheduleRefresh() {
+        pendingRefresh?.cancel()
+        let item = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            DispatchQueue.main.async(execute: self.onChange)
+        }
+        pendingRefresh = item
+        queue.asyncAfter(deadline: .now() + 0.5, execute: item)
+    }
+
+    /// Paths whose changes can affect status: the work tree plus the actual
+    /// per-worktree gitdir and shared common dir referenced by `.git` files.
+    static func watchPaths(for repositoryPath: String) -> [String] {
+        let fm = FileManager.default
+        let root = URL(fileURLWithPath: repositoryPath).standardizedFileURL
+        var paths = Set([root.path])
+        let dotGit = root.appendingPathComponent(".git")
+        var isDirectory: ObjCBool = false
+
+        if fm.fileExists(atPath: dotGit.path, isDirectory: &isDirectory) {
+            if isDirectory.boolValue {
+                paths.insert(dotGit.path)
+            } else if let gitDir = referencedPath(in: dotGit, key: "gitdir", relativeTo: root) {
+                paths.insert(gitDir.path)
+                let commonFile = gitDir.appendingPathComponent("commondir")
+                if let commonDir = referencedPath(in: commonFile, key: nil, relativeTo: gitDir) {
+                    paths.insert(commonDir.path)
+                }
+            }
+        }
+        return paths.sorted()
+    }
+
+    private static func referencedPath(in file: URL, key: String?, relativeTo base: URL) -> URL? {
+        guard var value = try? String(contentsOf: file, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else { return nil }
+        if let key {
+            let prefix = key + ":"
+            guard value.lowercased().hasPrefix(prefix) else { return nil }
+            value = String(value.dropFirst(prefix.count))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        let url = URL(fileURLWithPath: value, relativeTo: base).standardizedFileURL
+        return url
+    }
+}

--- a/Glint/Git/GitService.swift
+++ b/Glint/Git/GitService.swift
@@ -679,7 +679,7 @@ struct GitService {
     func status(at path: String) async throws -> GitStatus {
         // The status and the HEAD-commit lookup are independent — run them
         // concurrently so each poll costs one round-trip, not two sequential
-        // subprocess waits (matters with N workspaces polled every ~5s).
+        // subprocess waits (matters when an event invalidates N workspaces).
         async let statusR = git(["status", "--porcelain=v2", "--branch"], cwd: path, timeout: .poll)
         async let logR = git(["log", "-1", "--format=%s%n%cr"], cwd: path,
                              allowFailure: true, timeout: .poll)

--- a/Glint/Pane/GhosttySurfaceView.swift
+++ b/Glint/Pane/GhosttySurfaceView.swift
@@ -427,7 +427,7 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
     /// queue, which also drops the frame early when the grid hasn't changed.
     func flushScrollbackToDisk() {
         guard let id = scrollbackID, let s = surface else { return }
-        // Per-pane dirty bit. Without it the 5s flush serializes every live
+        // Per-pane dirty bit. Without it each fallback flush serializes every live
         // pane's full grid (viewport + 3000 scrollback rows × per-cell color/
         // attrs) on MainActor under the renderer-state lock every tick, even
         // for occluded background tabs that haven't seen activity in minutes
@@ -451,7 +451,7 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
 
     /// Set whenever something touches the grid we know about: user input
     /// (text_input), our own writes (process_output, scrollback restore), or
-    /// a foreground-pid flip noticed by the cwd poller. Starts true so the
+    /// a foreground-pid flip noticed by an event/fallback capture. Starts true so the
     /// FIRST flush of a session always runs (captures the restored history).
     /// Cleared at the tail of a successful flush.
     private var scrollbackNeedsFlush = true
@@ -460,13 +460,20 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
     /// Called by the per-store flush loop right before `flushScrollbackToDisk`.
     /// Marks the pane dirty when its foreground process changed since the last
     /// successful flush, so a user `cd`ing or a TUI launching shows up even if
-    /// no keystroke was sent in between (cwd polling already notices these
-    /// every tick — we just piggy-back the signal).
+    /// no keystroke was sent in between.
     func noteForegroundPidForScrollback() {
         guard let s = surface else { return }
         let pid = pid_t(ghostty_surface_foreground_pid(s))
         guard pid > 0 else { return }
         if pid != scrollbackLastFlushedPid { scrollbackNeedsFlush = true }
+    }
+
+    /// A completed shell command is a cheap, surface-scoped signal that both
+    /// the foreground process and the rendered grid may have changed.
+    func noteCommandFinishedForScrollback() {
+        scrollbackNeedsFlush = true
+        noteForegroundPidForScrollback()
+        flushScrollbackToDisk()
     }
 
     /// Mark the pane's scrollback dirty so the next flush serializes the grid.

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -132,7 +132,7 @@ struct Pane: Identifiable, Codable {
     /// Remote SSH context for Review-over-SSH — the ssh destination the user
     /// typed, its port, the remote host (display only), and the remote cwd
     /// mined from the terminal title. Transient (NOT persisted): re-derived
-    /// from the live surface on the 1s capture poll, so it's nil until the
+    /// from the live surface on a title/command event, so it's nil until the
     /// remote shell's title reports a cwd. Mirrors `workingDirectory`'s
     /// snapshot-from-surface pattern. Optional → defaults nil, so the custom
     /// Codable below ignores them without a CodingKeys/init/encode change.
@@ -512,12 +512,12 @@ final class WorkspaceStore: ObservableObject {
     @Published var workspaces: [Workspace]
     @Published var selectedWorkspaceID: UUID?
     @Published var sidebarCollapsed: Bool
-    /// Latest foreground-process name per (workspace, pane). Polled every
-    /// few seconds; drives the workspace card icon. Non-persistent.
+    /// Latest foreground-process name per (workspace, pane). Event-driven with
+    /// a slow fallback capture; drives the workspace card icon. Non-persistent.
     @Published var paneProcesses: [WorkspacePaneKey: String] = [:]
     /// CLI-agent state per pane (push-driven via AgentBridge hooks).
     /// Beats `paneProcesses` for icon/state because hooks carry live
-    /// status (thinking/permission/…) the 1s name poll can't know.
+    /// status (thinking/permission/…) a process-name capture can't know.
     /// Non-persistent.
     @Published var paneAgentState: [WorkspacePaneKey: PaneAgentState] = [:]
 
@@ -577,11 +577,11 @@ final class WorkspaceStore: ObservableObject {
     }
 
     /// Lightweight git status per workspace, keyed by workspace id. Refreshed by
-    /// `gitTimer` for non-plain sources and on demand. NON-persistent — it's live
+    /// filesystem/command events plus a slow fallback. NON-persistent — it's live
     /// state, recomputed each launch, never written to state.json.
     @Published var gitStatuses: [UUID: GitStatus] = [:]
     /// Workspaces with a `git status` poll in flight — guards against a slow git
-    /// (large/network repo) letting 5s ticks stack into overlapping subprocesses
+    /// (large/network repo) letting repeated events stack overlapping subprocesses
     /// whose out-of-order results overwrite a newer status.
     private var gitInFlight: Set<UUID> = []
     /// Resolved cwds confirmed (via a `rev-parse` probe) NOT to be inside a git
@@ -1327,11 +1327,15 @@ final class WorkspaceStore: ObservableObject {
     private var dockBadgePaneStatuses: [WorkspacePaneKey: PaneAgentStatus] = [:]
 
     private var saveCancellable: AnyCancellable?
-    private var cwdTimer: Timer?
-    /// Counts 1s cwd ticks so scrollback flushes run at ~5s, not every second.
-    private var scrollbackFlushTick = 0
-    private var gitStatusTick = 0
+    private var gitWatcherCancellable: AnyCancellable?
+    private var fallbackTimer: Timer?
+    private var fallbackGitTick = 0
     private var observerTokens: [NSObjectProtocol] = []
+    private struct GitWatchRegistration {
+        let path: String
+        let watcher: GitRepositoryWatcher
+    }
+    private var gitWatchers: [UUID: GitWatchRegistration] = [:]
 
     /// The app's single live store. AppDelegate consults it for the quit
     /// confirmation (it has no other path to the store — the store is
@@ -1381,26 +1385,28 @@ final class WorkspaceStore: ObservableObject {
         .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
         .sink { [weak self] _ in self?.persist() }
 
-        // Sweep live surface cwds every second so a crash/quit still leaves
-        // recent dirs persisted. The closure captures self weakly so the
-        // repeating timer doesn't retain the store forever.
-        cwdTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+        // Repository bindings change rarely, but workspace model updates are
+        // frequent. Reconcile by path so ordinary cwd/process updates don't
+        // recreate FSEvent streams.
+        gitWatcherCancellable = $workspaces
+            .dropFirst()
+            .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
+            .sink { [weak self] _ in self?.syncGitWatchers() }
+        syncGitWatchers()
+
+        // Shell integration drives normal cwd/process/git updates. This slow,
+        // active-app-only timer is a correctness fallback for shells without
+        // OSC 7 / command-finished integration and for long-running TUIs.
+        fallbackTimer = Timer.scheduledTimer(withTimeInterval: 30.0, repeats: true) { [weak self] _ in
             // scheduledTimer fires on the main run loop, so this is already the
-            // main actor — assumeIsolated avoids allocating a Task every second.
+            // main actor — assumeIsolated avoids allocating a Task per fallback.
             MainActor.assumeIsolated {
-                guard let self else { return }
+                guard let self, NSApp.isActive else { return }
                 self.captureCwdsFromLiveSurfaces()
-                // Snapshot terminal scrollback to disk roughly every 5s (off
-                // the IO/main hot path; skips panes with no new output).
-                self.scrollbackFlushTick += 1
-                if self.scrollbackFlushTick >= 5 {
-                    self.scrollbackFlushTick = 0
-                    self.flushScrollback()
-                }
-                // Refresh git status for repo/worktree workspaces ~every 5s.
-                self.gitStatusTick += 1
-                if self.gitStatusTick >= 5 {
-                    self.gitStatusTick = 0
+                self.flushScrollback()
+                self.fallbackGitTick += 1
+                if self.fallbackGitTick >= 2 {
+                    self.fallbackGitTick = 0
                     self.refreshAllGitStatuses()
                 }
             }
@@ -1447,8 +1453,39 @@ final class WorkspaceStore: ObservableObject {
             forName: .ghosttyCwdChanged,
             object: nil,
             queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor in self?.captureCwdsFromLiveSurfaces() }
+        ) { [weak self] note in
+            Task { @MainActor in
+                guard let view = note.object as? GhosttySurfaceView else { return }
+                self?.captureSurfaceState(from: view)
+            }
+        })
+
+        observerTokens.append(NotificationCenter.default.addObserver(
+            forName: .ghosttyRemoteTitleChanged,
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            Task { @MainActor in
+                guard let view = note.object as? GhosttySurfaceView else { return }
+                self?.captureSurfaceState(from: view)
+            }
+        })
+
+        // Command completion is the high-value event: update the one pane,
+        // persist its scrollback, and refresh only its repository.
+        observerTokens.append(NotificationCenter.default.addObserver(
+            forName: .ghosttyCommandFinished,
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            Task { @MainActor in
+                guard let self, let view = note.object as? GhosttySurfaceView,
+                      let key = self.captureSurfaceState(from: view) else { return }
+                if self.restoreTerminalScrollback {
+                    view.noteCommandFinishedForScrollback()
+                }
+                self.refreshGitStatusNow(for: key.workspace)
+            }
         })
 
         // "✓ done" is an unread badge cleared by *seeing* the workspace.
@@ -1462,6 +1499,9 @@ final class WorkspaceStore: ObservableObject {
             Task { @MainActor in
                 guard let self, let id = self.selectedWorkspaceID else { return }
                 self.acknowledgeCompletionIfNeeded(for: id)
+                self.captureCwdsFromLiveSurfaces()
+                self.flushScrollback()
+                self.refreshAllGitStatuses()
             }
         })
 
@@ -1507,7 +1547,7 @@ final class WorkspaceStore: ObservableObject {
     }
 
     deinit {
-        cwdTimer?.invalidate()
+        fallbackTimer?.invalidate()
         for token in observerTokens {
             NotificationCenter.default.removeObserver(token)
         }
@@ -1614,144 +1654,97 @@ final class WorkspaceStore: ObservableObject {
 
     func captureCwdsFromLiveSurfaces() {
         var newProcesses: [WorkspacePaneKey: String] = [:]
-        for i in workspaces.indices {
-            let wsID = workspaces[i].id
-            for paneID in workspaces[i].panes.keys {
-                let key = WorkspacePaneKey(workspace: wsID, pane: paneID)
-                guard let view = surfaceViews[key] else { continue }
-                // Only write when the value actually changed: an unconditional
-                // subscript write on a @Published array fires objectWillChange
-                // every tick, and since this poll (1s) outpaces the autosave
-                // debounce (0.5s) that meant a JSON encode + disk write every
-                // second for the app's whole lifetime.
-                if let cwd = view.currentCwd(),
-                   workspaces[i].panes[paneID]?.workingDirectory != cwd {
-                    workspaces[i].panes[paneID]?.workingDirectory = cwd
-                }
-                // Snapshot the remote SSH context (Review-over-SSH). Same
-                // write-only-on-change discipline as cwd — an unconditional
-                // write would fire objectWillChange every tick.
-                let rctx = view.remoteReviewContext
-                let rhost = view.remoteHost
-                if workspaces[i].panes[paneID]?.remoteTarget != rctx?.target
-                    || workspaces[i].panes[paneID]?.remotePort != rctx?.port
-                    || workspaces[i].panes[paneID]?.remotePath != rctx?.remotePath
-                    || workspaces[i].panes[paneID]?.remoteHost != rhost {
-                    workspaces[i].panes[paneID]?.remoteTarget = rctx?.target
-                    workspaces[i].panes[paneID]?.remotePort = rctx?.port
-                    workspaces[i].panes[paneID]?.remotePath = rctx?.remotePath
-                    workspaces[i].panes[paneID]?.remoteHost = rhost
-                }
-                if let name = view.foregroundProcessName() {
-                    newProcesses[key] = name
-                    // Track CURRENT claude/codex/opencode foreground so the
-                    // next launch can optionally `--continue` / `resume --last`
-                    // (gated by the per-agent setting). Cleared the moment the
-                    // foreground is a benign shell — i.e. the user actually
-                    // exited the agent — NOT when a tool subprocess (vim, git,
-                    // rg, npm, …) briefly fronts the foreground pid mid-turn.
-                    // Without this guard, a `Bash(vim …)` from inside a live
-                    // Claude/Codex turn would wipe lastAgent + sessionIds, and
-                    // a quit during the vim window would persist an empty map
-                    // → restart loses the #45 multi-pane resume entirely. A
-                    // *nil* foreground (no live surface / transient empty pid)
-                    // is unknown, not an exit — leave the hint alone.
-                    let agentKind = Self.agentKind(forProcessName: name)
-                    let agentToken = agentKind?.rawValue
-                    let foregroundIsExit = agentKind == nil && Self.isBenignShellProcessName(name)
-                    // Update lastAgent when foreground is a known agent OR the
-                    // pane is genuinely back at a shell. A transient tool
-                    // subprocess leaves lastAgent (and sessionIds below)
-                    // untouched.
-                    if agentKind != nil || foregroundIsExit {
-                        if workspaces[i].panes[paneID]?.lastAgent != agentToken {
-                            workspaces[i].panes[paneID]?.lastAgent = agentToken
-                        }
-                    }
-                    // A session id is only meaningful while its agent is the
-                    // foreground. Filter to the current foreground (or wipe
-                    // when foreground is a shell, i.e. agent exited) so a
-                    // future restart can't try to resume a session the user
-                    // has moved on from. Comparing against `agentKind?.rawValue`
-                    // (not a free-form String) is what structurally guarantees
-                    // the writer here and the reader at `surfaceView`'s
-                    // `pane.sessionIds[kind.rawValue]` can't drift on spelling.
-                    // SKIPPED when the foreground is a transient tool subproc
-                    // (same reason as lastAgent above).
-                    if (agentKind != nil || foregroundIsExit),
-                       let existing = workspaces[i].panes[paneID]?.sessionIds,
-                       !existing.isEmpty {
-                        let kept = existing.filter { $0.key == agentToken }
-                        if kept.count != existing.count {
-                            workspaces[i].panes[paneID]?.sessionIds = kept
-                        }
-                    }
-                    // codexHome is only meaningful while Codex is the
-                    // foreground. Clear it ONLY when the pane is back at a
-                    // benign shell — i.e. the user actually exited Codex — not
-                    // when a Codex tool subprocess (git/npm/vim/…) briefly takes
-                    // the foreground pid. Unlike sessionIds (re-stashed by every
-                    // UserPromptSubmit hook above), codexHome has no writer but
-                    // launch, so a premature clear permanently breaks the
-                    // non-default-home resume (#45 multi-home regression) until
-                    // the pane is relaunched. A stale home can't leak anyway:
-                    // the next launch always rewrites codexHome via
-                    // queueInitialInput.
-                    if workspaces[i].panes[paneID]?.codexHome != nil,
-                       Self.isBenignShellProcessName(name) {
-                        workspaces[i].panes[paneID]?.codexHome = nil
-                    }
-                }
+        for (key, view) in surfaceViews {
+            if let name = captureSurfaceState(for: key, view: view) {
+                newProcesses[key] = name
             }
         }
         if newProcesses != paneProcesses {
-            for (k, v) in newProcesses where paneProcesses[k] != v {
-                NSLog("[glint] pane process changed: ws=\(k.workspace.uuidString.prefix(8)) pane=\(k.pane.value) -> \(v)")
+            for (key, name) in newProcesses where paneProcesses[key] != name {
+                logProcessChange(key: key, name: name)
             }
             paneProcesses = newProcesses
         }
-        // Reconcile stale hook state. Hooks are the only writer of
-        // paneAgentState and no hook fires when an agent quits, so after
-        // e.g. claude → exit → shell the pane can keep kind == .claude and
-        // iconKind (which prefers hook state over pid polling) stays stuck.
-        // Reconcile ONLY panes we actually observed a foreground process for
-        // this tick (i.e. present in newProcesses). A pane with no live
-        // surface (background tab) or a transient empty foreground pid is
-        // *unknown*, not exited — its absence here leaves its state untouched
-        // rather than wiping a still-live session and flickering its icon.
-        for (key, processName) in newProcesses {
-            guard var state = paneAgentState[key] else { continue }
-            guard let runningKind = Self.agentKind(named: processName) else {
-                // Foreground is a non-agent process. Only a recognized benign
-                // shell proves the session exited; a live agent that shells out
-                // to a tool briefly foregrounds a child (vim/git/bash/…), so
-                // clearing on any non-agent name would drop the session
-                // mid-turn (the next hook would have to rebuild it, flickering
-                // the icon). Clear only when the pane is idle AND genuinely
-                // back at a shell. An unread .justCompleted/.failed badge —
-                // e.g. Claude's sticky StopFailure after the CLI exits — must
-                // also survive until the user acknowledges it.
-                if state.status == .idle, Self.isBenignShellProcessName(processName) {
-                    paneAgentState.removeValue(forKey: key)
+        for (key, name) in newProcesses {
+            reconcileAgentState(key: key, processName: name)
+        }
+    }
+
+    /// Capture only the surface named by a Ghostty event instead of rescanning
+    /// every pane. Returns its model key for event-specific follow-up work.
+    @discardableResult
+    private func captureSurfaceState(from view: GhosttySurfaceView) -> WorkspacePaneKey? {
+        guard let key = surfaceViews.first(where: { $0.value === view })?.key else { return nil }
+        guard let name = captureSurfaceState(for: key, view: view) else { return key }
+        if paneProcesses[key] != name {
+            logProcessChange(key: key, name: name)
+            paneProcesses[key] = name
+        }
+        reconcileAgentState(key: key, processName: name)
+        return key
+    }
+
+    private func captureSurfaceState(for key: WorkspacePaneKey,
+                                     view: GhosttySurfaceView) -> String? {
+        guard let i = workspaces.firstIndex(where: { $0.id == key.workspace }),
+              workspaces[i].panes[key.pane] != nil else { return nil }
+
+        if let cwd = view.currentCwd(),
+           workspaces[i].panes[key.pane]?.workingDirectory != cwd {
+            workspaces[i].panes[key.pane]?.workingDirectory = cwd
+        }
+        let rctx = view.remoteReviewContext
+        let rhost = view.remoteHost
+        if workspaces[i].panes[key.pane]?.remoteTarget != rctx?.target
+            || workspaces[i].panes[key.pane]?.remotePort != rctx?.port
+            || workspaces[i].panes[key.pane]?.remotePath != rctx?.remotePath
+            || workspaces[i].panes[key.pane]?.remoteHost != rhost {
+            workspaces[i].panes[key.pane]?.remoteTarget = rctx?.target
+            workspaces[i].panes[key.pane]?.remotePort = rctx?.port
+            workspaces[i].panes[key.pane]?.remotePath = rctx?.remotePath
+            workspaces[i].panes[key.pane]?.remoteHost = rhost
+        }
+
+        guard let name = view.foregroundProcessName() else { return nil }
+        let agentKind = Self.agentKind(forProcessName: name)
+        let agentToken = agentKind?.rawValue
+        let foregroundIsExit = agentKind == nil && Self.isBenignShellProcessName(name)
+        if agentKind != nil || foregroundIsExit {
+            if workspaces[i].panes[key.pane]?.lastAgent != agentToken {
+                workspaces[i].panes[key.pane]?.lastAgent = agentToken
+            }
+            if let existing = workspaces[i].panes[key.pane]?.sessionIds, !existing.isEmpty {
+                let kept = existing.filter { $0.key == agentToken }
+                if kept.count != existing.count {
+                    workspaces[i].panes[key.pane]?.sessionIds = kept
                 }
-                continue
             }
-            // A known agent owns the pane. If it differs from the recorded
-            // kind, reattribute — but only while genuinely idle. Hook state is
-            // authoritative while a turn/approval/tool is active (some agent
-            // CLIs foreground helper or wrapper processes whose names look like
-            // another agent — don't flip OpenCode to Claude mid-turn), and an
-            // unread .justCompleted/.failed badge must survive until
-            // acknowledged rather than being wiped by a coincidental foreground
-            // name. A real hand-off re-establishes state from the new agent's
-            // first explicit hook, so the poller need not force it here.
-            if runningKind != state.kind, state.status == .idle {
-                state.kind = runningKind
-                state.status = .idle
-                state.detail = nil
-                state.updatedAt = Date()
-                paneAgentState[key] = state
+        }
+        if workspaces[i].panes[key.pane]?.codexHome != nil,
+           Self.isBenignShellProcessName(name) {
+            workspaces[i].panes[key.pane]?.codexHome = nil
+        }
+        return name
+    }
+
+    private func logProcessChange(key: WorkspacePaneKey, name: String) {
+        NSLog("[glint] pane process changed: ws=\(key.workspace.uuidString.prefix(8)) pane=\(key.pane.value) -> \(name)")
+    }
+
+    private func reconcileAgentState(key: WorkspacePaneKey, processName: String) {
+        guard var state = paneAgentState[key] else { return }
+        guard let runningKind = Self.agentKind(named: processName) else {
+            if state.status == .idle, Self.isBenignShellProcessName(processName) {
+                paneAgentState.removeValue(forKey: key)
             }
+            return
+        }
+        if runningKind != state.kind, state.status == .idle {
+            state.kind = runningKind
+            state.status = .idle
+            state.detail = nil
+            state.updatedAt = Date()
+            paneAgentState[key] = state
         }
     }
 
@@ -1773,7 +1766,7 @@ final class WorkspaceStore: ObservableObject {
         // (status badge, detail text, kind = .claude as a safe display default
         // — see `kind` below), but a nil resolvedKind MUST NOT be used to key a
         // sessionId write: stashing a Codex/OpenCode/Devin uuid under "claude"
-        // sticks until the next poll tick (~1s race window) and a quit in that
+        // could stick until the next capture and a quit in that
         // window persists a misrouted resume map — restart would run
         // `claude --resume <foreign-uuid>` and fail. Every Glint-installed
         // reporter sets `agent` already, so this nil-path is normally
@@ -1799,8 +1792,7 @@ final class WorkspaceStore: ObservableObject {
         }
 
         // Note: we deliberately do NOT force-write paneProcesses here. The
-        // 1s poller owns that dictionary and replaces it wholesale, so any
-        // value written from this path lived at most one tick. Icon/state
+        // surface capture owns that dictionary. Icon/state
         // already prefer paneAgentState (set below), which this event keeps
         // authoritative.
 
@@ -1925,8 +1917,16 @@ final class WorkspaceStore: ObservableObject {
     func handlePaneReturn(_ info: [AnyHashable: Any]?) {
         guard let info,
               let paneStr = info["pane"] as? String,
-              let key = Self.parsePaneKey(paneStr),
-              var state = paneAgentState[key],
+              let key = Self.parsePaneKey(paneStr) else { return }
+        // Return commonly launches a foreground process. Query this pane once
+        // after the shell has had time to exec instead of polling every pane.
+        if let view = surfaceViews[key] {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self, weak view] in
+                guard let self, let view else { return }
+                self.captureSurfaceState(from: view)
+            }
+        }
+        guard var state = paneAgentState[key],
               state.status == .needsPermission else { return }
         let now = Date()
         state.status = .tool
@@ -3068,7 +3068,7 @@ final class WorkspaceStore: ObservableObject {
     private func remoteContext(for ws: Workspace) -> (target: String, port: Int?, remotePath: String, host: String?)? {
         guard let paneID = ws.selectedTab?.focusedPane else { return nil }
         // Read the LIVE surface rather than the Pane snapshot. The snapshot
-        // (Pane.remotePath) lags up to the 1s capture poll, so pressing ⌘⇧R
+        // (Pane.remotePath) can lag until the next title/capture event, so pressing ⌘⇧R
         // right after a remote `cd` would otherwise review the previous
         // directory (e.g. `~` → "not a git repo" → empty Review). The surface's
         // remotePath is updated immediately when the remote shell's title fires.
@@ -3114,6 +3114,31 @@ final class WorkspaceStore: ObservableObject {
     }
 
     func gitStatus(for id: UUID) -> GitStatus? { gitStatuses[id] }
+
+    private func syncGitWatchers() {
+        var desired: [UUID: String] = [:]
+        for ws in workspaces {
+            switch ws.source.kind {
+            case .localRepo, .localWorktree:
+                if let path = ws.source.gitPath { desired[ws.id] = path }
+            default:
+                break
+            }
+        }
+
+        for id in gitWatchers.keys.filter({ desired[$0] == nil }) {
+            gitWatchers.removeValue(forKey: id)
+        }
+        for (id, path) in desired {
+            if gitWatchers[id]?.path == path { continue }
+            let paths = GitRepositoryWatcher.watchPaths(for: path)
+            let watcher = GitRepositoryWatcher(paths: paths) { [weak self] in
+                guard NSApp.isActive else { return }
+                self?.refreshGitStatusNow(for: id)
+            }
+            gitWatchers[id] = GitWatchRegistration(path: path, watcher: watcher)
+        }
+    }
 
     func refreshGitStatus(for id: UUID) async {
         guard let ws = workspaces.first(where: { $0.id == id }) else {
@@ -3166,7 +3191,7 @@ final class WorkspaceStore: ObservableObject {
         }
     }
 
-    /// Which workspaces the 5s timer fans out to. Bound repo/worktree sources
+    /// Which workspaces an event or fallback refresh fans out to. Bound sources
     /// keep their dirty badge live; the selected workspace is what the user is
     /// looking at. Other plain shells are NOT timer-polled — they refresh on
     /// demand via `refreshGitStatusNow` when switched/focused, which avoids
@@ -3182,7 +3207,7 @@ final class WorkspaceStore: ObservableObject {
 
     /// Fire-and-forget single refresh, used when the *displayed* terminal
     /// changes (workspace / tab / pane switch) so the tab's git button updates
-    /// right away instead of waiting up to ~5s for the next poll.
+    /// right away instead of waiting for a filesystem/fallback event.
     func refreshGitStatusNow(for id: UUID) {
         Task { await refreshGitStatus(for: id) }
     }
@@ -3539,6 +3564,11 @@ extension Notification.Name {
     /// Posted by GhosttyManager when ghostty reports a new cwd for some
     /// surface (via OSC 7 / GHOSTTY_ACTION_PWD).
     static let ghosttyCwdChanged = Notification.Name("ghostty.cwd.changed")
+    /// Posted after a title updates remote SSH state for one surface.
+    static let ghosttyRemoteTitleChanged = Notification.Name("ghostty.remote-title.changed")
+    /// Posted when shell integration reports that a command completed on a
+    /// specific surface. Consumers can refresh only that pane/repository.
+    static let ghosttyCommandFinished = Notification.Name("ghostty.command.finished")
 }
 
 // MARK: - Color hex helpers

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -1336,6 +1336,10 @@ final class WorkspaceStore: ObservableObject {
         let watcher: GitRepositoryWatcher
     }
     private var gitWatchers: [UUID: GitWatchRegistration] = [:]
+    /// Coalesces the command-finished and FSEvents channels so one logical
+    /// change spawns at most one `git status` (see its own doc comment for the
+    /// gap it closes vs `gitInFlight`).
+    private let gitRefreshCoordinator = GitRefreshCoordinator()
 
     /// The app's single live store. AppDelegate consults it for the quit
     /// confirmation (it has no other path to the store — the store is
@@ -1484,7 +1488,14 @@ final class WorkspaceStore: ObservableObject {
                 if self.restoreTerminalScrollback {
                     view.noteCommandFinishedForScrollback()
                 }
-                self.refreshGitStatusNow(for: key.workspace)
+                let wsID = key.workspace
+                // Route through the refresh coordinator so the FSEvents
+                // callback that follows this same change ~0.5s later doesn't
+                // spawn a second `git status` (gitInFlight only merges runs
+                // that overlap in time; a fast git finishes first).
+                self.gitRefreshCoordinator.request(wsID) { [weak self] in
+                    self?.refreshGitStatusNow(for: wsID)
+                }
             }
         })
 
@@ -3128,13 +3139,16 @@ final class WorkspaceStore: ObservableObject {
 
         for id in gitWatchers.keys.filter({ desired[$0] == nil }) {
             gitWatchers.removeValue(forKey: id)
+            gitRefreshCoordinator.cancel(id)
         }
         for (id, path) in desired {
             if gitWatchers[id]?.path == path { continue }
             let paths = GitRepositoryWatcher.watchPaths(for: path)
             let watcher = GitRepositoryWatcher(paths: paths) { [weak self] in
                 guard NSApp.isActive else { return }
-                self?.refreshGitStatusNow(for: id)
+                self?.gitRefreshCoordinator.request(id) { [weak self] in
+                    self?.refreshGitStatusNow(for: id)
+                }
             }
             gitWatchers[id] = GitWatchRegistration(path: path, watcher: watcher)
         }

--- a/GlintTests/GhosttyTickSchedulerTests.swift
+++ b/GlintTests/GhosttyTickSchedulerTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import Glint
+
+final class GhosttyTickSchedulerTests: XCTestCase {
+    func testCoalescesWakeupsBeforeQueuedTickRuns() {
+        var queued: [() -> Void] = []
+        let scheduler = GhosttyTickScheduler { queued.append($0) }
+        var ticks = 0
+
+        for _ in 0..<100 {
+            scheduler.schedule { ticks += 1 }
+        }
+
+        XCTAssertEqual(queued.count, 1)
+        XCTAssertEqual(ticks, 0)
+        queued.removeFirst()()
+        XCTAssertEqual(ticks, 1)
+    }
+
+    func testWakeupDuringTickSchedulesAnotherTick() {
+        var queued: [() -> Void] = []
+        let scheduler = GhosttyTickScheduler { queued.append($0) }
+        var ticks = 0
+
+        scheduler.schedule {
+            ticks += 1
+            scheduler.schedule { ticks += 1 }
+        }
+
+        queued.removeFirst()()
+        XCTAssertEqual(ticks, 1)
+        XCTAssertEqual(queued.count, 1)
+        queued.removeFirst()()
+        XCTAssertEqual(ticks, 2)
+    }
+
+    func testConcurrentWakeupsStillEnqueueOnce() {
+        let queuedLock = NSLock()
+        var queued: [() -> Void] = []
+        let scheduler = GhosttyTickScheduler { block in
+            queuedLock.lock()
+            queued.append(block)
+            queuedLock.unlock()
+        }
+
+        DispatchQueue.concurrentPerform(iterations: 1_000) { _ in
+            scheduler.schedule {}
+        }
+
+        queuedLock.lock()
+        let count = queued.count
+        queuedLock.unlock()
+        XCTAssertEqual(count, 1)
+    }
+}

--- a/GlintTests/GitRefreshCoordinatorTests.swift
+++ b/GlintTests/GitRefreshCoordinatorTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import Glint
+
+final class GitRefreshCoordinatorTests: XCTestCase {
+    /// First request for a workspace dispatches immediately (no trailing delay).
+    func testFirstRequestRunsImmediately() {
+        let coordinator = GitRefreshCoordinator(minInterval: 0.3)
+        let id = UUID()
+        let ran = expectation(description: "immediate run")
+
+        coordinator.request(id) { ran.fulfill() }
+
+        // timeout < minInterval: a trailing path would still be pending here.
+        wait(for: [ran], timeout: 0.15)
+    }
+
+    /// Repeated requests inside the window collapse into the initial immediate
+    /// dispatch plus exactly one trailing refresh (not one per request).
+    func testCoalescesRapidRequestsIntoOneTrailing() {
+        let coordinator = GitRefreshCoordinator(minInterval: 0.3)
+        let id = UUID()
+        var count = 0
+        let immediate = expectation(description: "immediate")
+
+        coordinator.request(id) { count += 1; immediate.fulfill() }
+        // Two more within the window — both must fold into the single trailing.
+        coordinator.request(id) { count += 1 }
+        coordinator.request(id) { count += 1 }
+
+        wait(for: [immediate], timeout: 0.5)
+        XCTAssertEqual(count, 1)
+
+        let settled = expectation(description: "trailing settled")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+            // immediate + exactly one trailing
+            XCTAssertEqual(count, 2)
+            settled.fulfill()
+        }
+        wait(for: [settled], timeout: 1.5)
+    }
+
+    /// Once the window has fully elapsed, the next request is immediate again
+    /// (the throttle resets) and spawns no extra trailing refresh.
+    func testRequestAfterWindowRunsImmediatelyWithoutTrailing() {
+        let coordinator = GitRefreshCoordinator(minInterval: 0.3)
+        let id = UUID()
+        var count = 0
+        let first = expectation(description: "first")
+
+        coordinator.request(id) { count += 1; first.fulfill() }
+        wait(for: [first], timeout: 0.5)
+
+        // Wait past the window so the next request is on the immediate path.
+        let second = expectation(description: "second immediate")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) {
+            coordinator.request(id) { count += 1; second.fulfill() }
+        }
+        wait(for: [second], timeout: 1.0)
+        XCTAssertEqual(count, 2)
+
+        // Confirm no trailing was scheduled by the second (immediate) request.
+        let settled = expectation(description: "no extra trailing")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            XCTAssertEqual(count, 2)
+            settled.fulfill()
+        }
+        wait(for: [settled], timeout: 1.0)
+    }
+
+    /// `cancel` drops a not-yet-fired trailing refresh for the workspace.
+    func testCancelDropsPendingTrailing() {
+        let coordinator = GitRefreshCoordinator(minInterval: 0.3)
+        let id = UUID()
+        var count = 0
+        let immediate = expectation(description: "immediate")
+
+        coordinator.request(id) { count += 1; immediate.fulfill() }
+        wait(for: [immediate], timeout: 0.5)
+        XCTAssertEqual(count, 1)
+
+        // Second request schedules a trailing; cancel it before it fires.
+        coordinator.request(id) { count += 1 }
+        coordinator.cancel(id)
+
+        let settled = expectation(description: "trailing never fired")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+            XCTAssertEqual(count, 1)
+            settled.fulfill()
+        }
+        wait(for: [settled], timeout: 1.5)
+    }
+
+    /// Per-workspace isolation: throttling one workspace does not delay another.
+    func testPerWorkspaceIsolation() {
+        let coordinator = GitRefreshCoordinator(minInterval: 0.3)
+        let a = expectation(description: "a")
+        let b = expectation(description: "b")
+
+        coordinator.request(UUID()) { a.fulfill() }
+        coordinator.request(UUID()) { b.fulfill() }
+
+        // Two different workspaces → both immediate, neither blocks the other.
+        wait(for: [a, b], timeout: 0.3)
+    }
+}

--- a/GlintTests/GitRepositoryWatcherTests.swift
+++ b/GlintTests/GitRepositoryWatcherTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import Glint
+
+final class GitRepositoryWatcherTests: XCTestCase {
+    func testWorktreePathsIncludeGitDirAndCommonDir() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        let worktree = root.appendingPathComponent("worktree")
+        let gitDir = root.appendingPathComponent("main/.git/worktrees/feature")
+        try FileManager.default.createDirectory(at: worktree, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: gitDir, withIntermediateDirectories: true)
+        try "gitdir: ../main/.git/worktrees/feature\n".write(
+            to: worktree.appendingPathComponent(".git"), atomically: true, encoding: .utf8)
+        try "../..\n".write(
+            to: gitDir.appendingPathComponent("commondir"), atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let paths = Set(GitRepositoryWatcher.watchPaths(for: worktree.path))
+
+        XCTAssertTrue(paths.contains(worktree.standardizedFileURL.path))
+        XCTAssertTrue(paths.contains(gitDir.standardizedFileURL.path))
+        XCTAssertTrue(paths.contains(root.appendingPathComponent("main/.git").standardizedFileURL.path))
+    }
+}


### PR DESCRIPTION
## 背景

Glint 全生命周期挂着一个 1s `cwdTimer`:每秒采所有 pane 的 cwd、每 ~5s 把所有 pane 的 scrollback 序列化到磁盘、每 ~5s 对所有 repo 跑一次 `git status`。这是 idle 耗电的主要固定开销。

Replaces that hot polling with event-driven refresh, plus a coalescer so the new event channels don't double-spawn git.

## 改动 / Changes

**1. 热轮询 → 事件驱动** (`3fcc296`)
- 每个 bound repo 一个 FSEvents watcher(`GitRepositoryWatcher`),0.5s debounce、`NSApp.isActive` 下才触发
- Shell 的 command-finished 信号(`ghosttyCommandFinished`)→ 只刷新该 pane + 其所在 repo
- Shell integration(OSC 7 / 标题)在事件上驱动 cwd / 进程捕获
- 30s、仅 active 的 fallback timer,兜底无 integration 的 shell / 长跑 TUI(原来 1s 常开)
- scrollback flush 改为 per-pane dirty bit(原来每 5s 无差别序列化所有 live grid)

**2. 合并事件驱动的 git 刷新** (`a55aea6`)
- FSEvents 与 command-finished 会为同一次改动各发一次,而 `gitInFlight` 只合并时间重叠的运行 —— 一次本地 `git status`(~100ms)在 FSEvents 的 0.5s 尾随回调到达前就跑完了,所以一次 commit 会 spawn 两次、一串 rebase/checkout 是 2×N
- `GitRefreshCoordinator`:per-workspace、只作用于推式事件的节流,trailing 在 1.5s 边界补刷;快速重复折成一个 trailing、持续风暴封顶每 interval 一次且永不丢更新
- 拉式刷新(切 workspace/pane、popover、fallback timer)保持立即

## Tests

- `GitRepositoryWatcherTests`、`GhosttyTickSchedulerTests`
- `GitRefreshCoordinatorTests`:立即路径 / 窗口合并 / 窗口重置 / cancel / per-workspace 隔离,5/5 pass

## Notes

非选中 workspace 的 pane surface 通过 occlusion 已停 display link;本 PR 消除的是轮询层的固定开销。顺带排查"高能耗"报告:主因是 pane 里跑着的多个 agent + 第三方 hook 的 spawn 开销,不是 Glint 渲染本身。
