### PR TITLE
fix(codex): stabilize quota windows / 稳定 Codex 额度窗口

### DIFF
--- a/Glint/Agent/UsageStore.swift
+++ b/Glint/Agent/UsageStore.swift
@@ -6,16 +6,27 @@ import IOKit
 /// One agent's rate-limit snapshot. Percentages are 0–100 (fraction of the
 /// window already consumed); `nil` fields mean "not reported by this source".
 struct AgentQuota: Hashable, Codable {
-    /// Rolling session window (Codex `primary`, ~5h). 0–100.
+    /// Codex `primary` window (historically ~5h, now source-defined). 0–100.
     var sessionPercent: Double
-    /// Longer rolling window (Codex `secondary`, ~7d). nil when unknown.
+    /// Codex `secondary` window. nil when the source reports only one window.
     var weeklyPercent: Double?
-    /// When the session window rolls over. nil when unknown.
+    /// When the primary window rolls over. nil when unknown.
     var sessionResetsAt: Date?
-    /// When the weekly window rolls over. nil when unknown.
+    /// When the secondary window rolls over. nil when unknown.
     var weeklyResetsAt: Date?
     /// Plan label, e.g. "plus" / "pro". Shown verbatim if present.
     var planType: String?
+    /// Source-reported window sizes. nil keeps legacy 5h / 7d labels.
+    var primaryWindowMinutes: Int? = nil
+    var secondaryWindowMinutes: Int? = nil
+
+    var primaryWindowLabel: String {
+        Self.windowLabel(minutes: primaryWindowMinutes, fallback: "5h")
+    }
+
+    var secondaryWindowLabel: String {
+        Self.windowLabel(minutes: secondaryWindowMinutes, fallback: "7d")
+    }
 
     /// >= this fraction used → render the session readout in the warn (amber)
     /// color. Chosen so the common "busy but fine" range stays calm and only
@@ -40,8 +51,17 @@ struct AgentQuota: Hashable, Codable {
             weeklyPercent: finite(weeklyPercent),
             sessionResetsAt: finite(sessionResetsAt),
             weeklyResetsAt: finite(weeklyResetsAt),
-            planType: planType
+            planType: planType,
+            primaryWindowMinutes: primaryWindowMinutes,
+            secondaryWindowMinutes: secondaryWindowMinutes
         )
+    }
+
+    private static func windowLabel(minutes: Int?, fallback: String) -> String {
+        guard let minutes, minutes > 0 else { return fallback }
+        if minutes.isMultiple(of: 1_440) { return "\(minutes / 1_440)d" }
+        if minutes.isMultiple(of: 60) { return "\(minutes / 60)h" }
+        return "\(minutes)m"
     }
 }
 
@@ -339,9 +359,11 @@ final class UsageStore: ObservableObject {
 enum CodexUsageReader {
     private struct Window: Decodable {
         let used_percent: Double?
+        let window_minutes: Int?
         let resets_at: Double?      // unix seconds
     }
     private struct RateLimits: Decodable {
+        let limit_id: String?
         let primary: Window?
         let secondary: Window?
         let plan_type: String?
@@ -415,6 +437,11 @@ enum CodexUsageReader {
                   let rlData = SafeJSON.data(rlAny),
                   let rl = try? JSONDecoder().decode(RateLimits.self, from: rlData)
             else { continue }
+            // Newer Codex sessions also persist model-specific buckets (for
+            // example GPT-5.3-Codex-Spark) in the same shape. The sidebar's
+            // Codex row is the general account limit, so ignore known non-
+            // general IDs; nil keeps compatibility with older rollout files.
+            guard rl.limit_id == nil || rl.limit_id == "codex" else { continue }
 
             let primary = rl.primary
             let secondary = rl.secondary
@@ -424,7 +451,9 @@ enum CodexUsageReader {
                 weeklyPercent: secondary?.used_percent,
                 sessionResetsAt: primary?.resets_at.map { Date(timeIntervalSince1970: $0) },
                 weeklyResetsAt: secondary?.resets_at.map { Date(timeIntervalSince1970: $0) },
-                planType: rl.plan_type
+                planType: rl.plan_type,
+                primaryWindowMinutes: primary?.window_minutes,
+                secondaryWindowMinutes: secondary?.window_minutes
             )
         }
         return nil
@@ -463,6 +492,7 @@ enum CodexLiveReader {
     private struct Payload: Decodable {
         struct Window: Decodable {
             let used_percent: Double?   // 0–100 (integer over the wire)
+            let limit_window_seconds: Int?
             let reset_at: Double?       // unix seconds
         }
         struct RateLimit: Decodable {
@@ -508,7 +538,7 @@ enum CodexLiveReader {
         return (token, account)
     }
 
-    private static func decode(_ data: Data) -> AgentQuota? {
+    static func decode(_ data: Data) -> AgentQuota? {
         guard let p = try? JSONDecoder().decode(Payload.self, from: data),
               let primary = p.rate_limit?.primary_window,
               let sessionPercent = primary.used_percent else { return nil }
@@ -518,7 +548,9 @@ enum CodexLiveReader {
             weeklyPercent: secondary?.used_percent,
             sessionResetsAt: primary.reset_at.map { Date(timeIntervalSince1970: $0) },
             weeklyResetsAt: secondary?.reset_at.map { Date(timeIntervalSince1970: $0) },
-            planType: p.plan_type
+            planType: p.plan_type,
+            primaryWindowMinutes: primary.limit_window_seconds.map { $0 / 60 },
+            secondaryWindowMinutes: secondary?.limit_window_seconds.map { $0 / 60 }
         )
     }
 }

--- a/Glint/Chrome/SidebarView.swift
+++ b/Glint/Chrome/SidebarView.swift
@@ -361,10 +361,10 @@ struct SidebarView: View {
 }
 
 /// Bottom-of-sidebar usage readout (above New Workspace). One row per agent
-/// that currently has data: a name column, then two equal-width tracks — the
-/// rolling session (5h) window and the weekly (7d) window — each captioned
-/// with its percent and a compact reset countdown. Renders nothing when no
-/// agent has data, so the divider+New Workspace sit flush as before.
+/// that currently has data: a name column, then one or two source-defined
+/// window tracks, each captioned with its percent and a compact reset countdown.
+/// Renders nothing when no agent has data, so the divider+New Workspace sit
+/// flush as before.
 private struct QuotaSection: View {
     @EnvironmentObject var store: WorkspaceStore
     let claude: AgentQuota?
@@ -431,30 +431,31 @@ private struct QuotaRow: View {
             TimelineView(.periodic(from: .now, by: 60)) { ctx in
                 HStack(spacing: 8) {
                     QuotaColumn(
-                        kind: "5h",
+                        kind: quota.primaryWindowLabel,
                         percent: quota.sessionPercent,
                         resetsAt: quota.sessionResetsAt,
                         now: ctx.date,
                         fill: color,
                         warn: quota.sessionIsWarn ? warn : nil
                     )
-                    QuotaColumn(
-                        kind: "7d",
-                        percent: quota.weeklyPercent,
-                        resetsAt: quota.weeklyResetsAt,
-                        now: ctx.date,
-                        fill: color.opacity(0.45),
-                        warn: nil
-                    )
+                    if quota.weeklyPercent != nil {
+                        QuotaColumn(
+                            kind: quota.secondaryWindowLabel,
+                            percent: quota.weeklyPercent,
+                            resetsAt: quota.weeklyResetsAt,
+                            now: ctx.date,
+                            fill: color.opacity(0.45),
+                            warn: nil
+                        )
+                    }
                 }
             }
         }
     }
 }
 
-/// One window track: caption (`5h 62% · 2h14m`) over a thin progress bar. A
-/// nil percent renders a muted "—" with an empty track so a single-window
-/// source still lines up under the other agent's two columns.
+/// One window track: caption (`5h 62% · 2h14m`) over a thin progress bar.
+/// A nil percent degrades to a muted "—" with an empty track.
 private struct QuotaColumn: View {
     let kind: String
     let percent: Double?

--- a/GlintTests/CodexUsageReaderTests.swift
+++ b/GlintTests/CodexUsageReaderTests.swift
@@ -18,14 +18,56 @@ final class CodexUsageReaderTests: XCTestCase {
         let sessions = home.appendingPathComponent("sessions/2026/06/22", isDirectory: true)
         try FileManager.default.createDirectory(at: sessions, withIntermediateDirectories: true)
         let rollout = sessions.appendingPathComponent("rollout-test.jsonl")
-        let line = #"{"type":"event_msg","payload":{"rate_limits":{"primary":{"used_percent":25,"resets_at":1900000000},"secondary":{"used_percent":50,"resets_at":1900100000},"plan_type":"pro"}}}"#
+        let line = #"{"type":"event_msg","payload":{"rate_limits":{"primary":{"used_percent":25,"window_minutes":300,"resets_at":1900000000},"secondary":{"used_percent":50,"window_minutes":10080,"resets_at":1900100000},"plan_type":"pro"}}}"#
         try line.write(to: rollout, atomically: true, encoding: .utf8)
 
         let quota = try XCTUnwrap(CodexUsageReader.read(from: home))
 
         XCTAssertEqual(quota.sessionPercent, 25)
         XCTAssertEqual(quota.weeklyPercent, 50)
+        XCTAssertEqual(quota.primaryWindowMinutes, 300)
+        XCTAssertEqual(quota.secondaryWindowMinutes, 10_080)
+        XCTAssertEqual(quota.primaryWindowLabel, "5h")
+        XCTAssertEqual(quota.secondaryWindowLabel, "7d")
         XCTAssertEqual(quota.planType, "pro")
+    }
+
+    func testIgnoresNewerModelSpecificQuotaWhenReadingGeneralQuota() throws {
+        let sessions = home.appendingPathComponent("sessions/2026/07/13", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessions, withIntermediateDirectories: true)
+
+        let general = sessions.appendingPathComponent("rollout-general.jsonl")
+        let generalLine = #"{"type":"event_msg","payload":{"rate_limits":{"limit_id":"codex","limit_name":null,"primary":{"used_percent":8,"window_minutes":10080,"resets_at":1900000000},"secondary":null,"plan_type":"prolite"}}}"#
+        try generalLine.write(to: general, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 100)],
+            ofItemAtPath: general.path
+        )
+
+        let spark = sessions.appendingPathComponent("rollout-spark.jsonl")
+        let sparkLine = #"{"type":"event_msg","payload":{"rate_limits":{"limit_id":"codex_bengalfox","limit_name":"GPT-5.3-Codex-Spark","primary":{"used_percent":0,"window_minutes":10080,"resets_at":1900100000},"secondary":null,"plan_type":"prolite"}}}"#
+        try sparkLine.write(to: spark, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 200)],
+            ofItemAtPath: spark.path
+        )
+
+        let quota = try XCTUnwrap(CodexUsageReader.read(from: home))
+
+        XCTAssertEqual(quota.sessionPercent, 8)
+    }
+
+    func testDecodesLiveSingleWeeklyWindow() throws {
+        let payload = #"{"plan_type":"prolite","rate_limit":{"primary_window":{"used_percent":8,"limit_window_seconds":604800,"reset_after_seconds":575254,"reset_at":1900000000},"secondary_window":null}}"#
+        let data = try XCTUnwrap(payload.data(using: .utf8))
+
+        let quota = try XCTUnwrap(CodexLiveReader.decode(data))
+
+        XCTAssertEqual(quota.sessionPercent, 8)
+        XCTAssertNil(quota.weeklyPercent)
+        XCTAssertEqual(quota.primaryWindowMinutes, 10_080)
+        XCTAssertNil(quota.secondaryWindowMinutes)
+        XCTAssertEqual(quota.primaryWindowLabel, "7d")
     }
 
     func testAuthStatusIsPerHomeAndNonfatal() throws {
@@ -51,7 +93,9 @@ final class CodexUsageReaderTests: XCTestCase {
             weeklyPercent: 40,
             sessionResetsAt: nil,
             weeklyResetsAt: nil,
-            planType: "plus"
+            planType: "plus",
+            primaryWindowMinutes: 300,
+            secondaryWindowMinutes: 10_080
         )
         let statuses = [
             CodexHomeStatus(


### PR DESCRIPTION
## Summary

- Ignore model-specific Codex rate-limit buckets when reading the general quota from persisted session events.
- Preserve source-reported quota window durations and render dynamic one- or two-window usage tracks.
- Add regressions for mixed general/Spark disk events and the new single 7-day live payload shape.

## Testing

- `xcodebuild -quiet -project Glint.xcodeproj -scheme GlintTests -configuration Debug -derivedDataPath /tmp/glint-codex-quota-dd CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO ARCHS=arm64 ONLY_ACTIVE_ARCH=YES test`
- `xcodebuild -quiet -project Glint.xcodeproj -scheme Glint -configuration Debug -derivedDataPath /tmp/glint-codex-quota-dd CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO ARCHS=arm64 ONLY_ACTIVE_ARCH=YES build`
