### PR TITLE
Attention & sidebar: ⌘⇧A jump-to-attention, sidebar sort + drag / 关注与侧边栏:⌘⇧A 跳转、排序与拖拽

### DIFF
--- a/Glint/Agent/PaneAgentState.swift
+++ b/Glint/Agent/PaneAgentState.swift
@@ -86,6 +86,29 @@ enum PaneAgentStatus: String, Codable {
     case compacting        // auto-compacting context window
     case justCompleted     // turn just finished — transient, fades to idle
     case failed            // turn ended in an API/transport error (StopFailure)
+
+    /// "Float to top" / "jump to next" priority — the single source of truth
+    /// shared by the sidebar sort (`SidebarView`) and ⌘⇧A
+    /// (`WorkspaceStore.jumpToAttention`) so the two always land on the same
+    /// "most worth seeing next" pane. A blocking `.needsPermission` outranks
+    /// unread results (a turn that `.failed` or `.justCompleted`), which both
+    /// float above everything else. Exhaustive, so adding a new case is a
+    /// compile error here — decide its rank in one place, not at every call
+    /// site. This is a coarser axis than `WorkspaceStore.statusRank` (the
+    /// status-dot ranking, which ranks `.failed` above `.justCompleted`);
+    /// here they're peers, so a local just-completed pane can win a tie
+    /// against a remote one.
+    var attentionRank: Int {
+        switch self {
+        case .needsPermission:                          return 0   // blocking → top
+        case .failed, .justCompleted:                   return 1   // unread results
+        case .idle, .thinking, .tool, .compacting:      return Self.sinkAttentionRank
+        }
+    }
+
+    /// The rank at which a status stops floating / no longer counts as "needs
+    /// you". `jumpToAttention` ignores panes at this rank or higher.
+    static let sinkAttentionRank = 2
 }
 
 struct PaneAgentState: Codable, Equatable {

--- a/Glint/App/GlintApp.swift
+++ b/Glint/App/GlintApp.swift
@@ -150,6 +150,12 @@ struct GlintApp: App {
                     workspaceStore.copyCurrentPath()
                 }
                 .keyboardShortcut("c", modifiers: [.command, .shift])
+                // Jump to the next pane needing attention (permission / done /
+                // failed). Multi-agent muscle memory; beeps if none.
+                Button("Jump to Attention") {
+                    workspaceStore.jumpToAttention()
+                }
+                .keyboardShortcut("a", modifiers: [.command, .shift])
             }
             // Hijack the App menu's Settings… so ⌘, opens our in-window
             // sheet instead of trying to summon a separate scene.

--- a/Glint/Chrome/CommandPalette.swift
+++ b/Glint/Chrome/CommandPalette.swift
@@ -362,6 +362,14 @@ struct CommandPalette: View {
             tint: actionTint,
             action: { store.settingsOpen = true }
         ))
+        items.append(.action(
+            title: "Jump to Attention",
+            subtitle: "Focus the next pane that needs you",
+            symbol: "exclamationmark.bubble",
+            shortcut: "⌘⇧A",
+            tint: actionTint,
+            action: { store.jumpToAttention() }
+        ))
 
         return items
     }

--- a/Glint/Chrome/SettingsView.swift
+++ b/Glint/Chrome/SettingsView.swift
@@ -2116,6 +2116,8 @@ private struct ShortcutsPane: View {
             SettingsDivider()
             shortcutRow("Copy Path", keys: ["⌘", "⇧", "C"])
             SettingsDivider()
+            shortcutRow("Jump to Attention", keys: ["⌘", "⇧", "A"])
+            SettingsDivider()
             shortcutRow("Settings", keys: ["⌘", ","])
             SettingsDivider()
             shortcutRow("Minimize", keys: ["⌘", "M"])

--- a/Glint/Chrome/SidebarView.swift
+++ b/Glint/Chrome/SidebarView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import AppKit
 import ImageIO
+import UniformTypeIdentifiers
 
 struct SidebarView: View {
     @EnvironmentObject var store: WorkspaceStore
@@ -108,6 +109,26 @@ struct SidebarView: View {
             // gap between cards).
             .background(NoDragSurface())
         }
+        // Drag a folder from Finder onto the sidebar → open it as a workspace,
+        // the same path as dropping it on the dock icon (WorkspaceStore.openURL
+        // → openFolder). Files are ignored: drop a file on the terminal pane to
+        // paste its path instead. The sidebar's internal reorder is a SwiftUI
+        // DragGesture, not system drag-and-drop, so this doesn't clash with it.
+        .onDrop(of: [.fileURL], isTargeted: nil) { providers in
+            for provider in providers {
+                provider.loadObject(ofClass: NSURL.self) { obj, _ in
+                    guard let url = obj as? URL, Self.isDirectory(url) else { return }
+                    DispatchQueue.main.async { store.openURL(url) }
+                }
+            }
+            // Accept iff at least one provider can yield a file URL, so a
+            // non-file drag (text, the sidebar's own cards) isn't swallowed.
+            return providers.contains { $0.canLoadObject(ofClass: NSURL.self) }
+        }
+    }
+
+    private static func isDirectory(_ url: URL) -> Bool {
+        (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
     }
 
     // MARK: drag-to-reorder (manual gesture, deterministic pointer hit-test)

--- a/Glint/Chrome/SidebarView.swift
+++ b/Glint/Chrome/SidebarView.swift
@@ -178,18 +178,22 @@ struct SidebarView: View {
             }
         }
         guard applySort, store.sortCompletedFirst else { return base }
-        // Stable partition: `.justCompleted` first, preserving the user's
-        // drag-assigned order within each group. Using enumerated() +
-        // offset as the tiebreaker keeps the sort deterministic regardless
-        // of `sorted(by:)` stability guarantees.
-        func attention(_ e: Workspace) -> Bool {
-            let s = store.agentSummary(for: e)?.status
-            return s == .justCompleted || s == .failed   // both float: finished or errored
+        // Stable 3-tier partition, preserving the user's drag-assigned order
+        // within each tier. enumerated() + offset tiebreaker keeps the sort
+        // deterministic regardless of `sorted(by:)` stability guarantees. A
+        // blocking `.needsPermission` outranks unread results (a turn that
+        // finished or errored) — both float above everything else. A workspace
+        // waiting on approval is the one you most need to see next.
+        func rank(_ ws: Workspace) -> Int {
+            switch store.agentSummary(for: ws)?.status {
+            case .needsPermission:                  return 0   // blocking → top
+            case .justCompleted, .failed:           return 1   // unread results
+            default:                                return 2
+            }
         }
         return base.enumerated().sorted { lhs, rhs in
-            let lhsDone = attention(lhs.element)
-            let rhsDone = attention(rhs.element)
-            if lhsDone != rhsDone { return lhsDone }
+            let lr = rank(lhs.element), rr = rank(rhs.element)
+            if lr != rr { return lr < rr }
             return lhs.offset < rhs.offset
         }.map(\.element)
     }

--- a/Glint/Chrome/SidebarView.swift
+++ b/Glint/Chrome/SidebarView.swift
@@ -201,16 +201,11 @@ struct SidebarView: View {
         guard applySort, store.sortCompletedFirst else { return base }
         // Stable 3-tier partition, preserving the user's drag-assigned order
         // within each tier. enumerated() + offset tiebreaker keeps the sort
-        // deterministic regardless of `sorted(by:)` stability guarantees. A
-        // blocking `.needsPermission` outranks unread results (a turn that
-        // finished or errored) — both float above everything else. A workspace
-        // waiting on approval is the one you most need to see next.
+        // deterministic regardless of `sorted(by:)` stability guarantees. The
+        // ranking itself is shared with ⌘⇧A via `PaneAgentStatus.attentionRank`,
+        // so the sidebar sort and the jump-to-attention target always agree.
         func rank(_ ws: Workspace) -> Int {
-            switch store.agentSummary(for: ws)?.status {
-            case .needsPermission:                  return 0   // blocking → top
-            case .justCompleted, .failed:           return 1   // unread results
-            default:                                return 2
-            }
+            store.agentSummary(for: ws)?.status.attentionRank ?? PaneAgentStatus.sinkAttentionRank
         }
         return base.enumerated().sorted { lhs, rhs in
             let lr = rank(lhs.element), rr = rank(rhs.element)

--- a/Glint/Resources/Localizable.xcstrings
+++ b/Glint/Resources/Localizable.xcstrings
@@ -1756,6 +1756,17 @@
         }
       }
     },
+    "Focus the next pane that needs you": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "聚焦到下一个需要你的面板"
+          }
+        }
+      }
+    },
     "Follow system": {
       "extractionState": "stale",
       "localizations": {
@@ -2316,6 +2327,17 @@
           "stringUnit": {
             "state": "translated",
             "value": "隔离的分支"
+          }
+        }
+      }
+    },
+    "Jump to Attention": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跳转到待处理项"
           }
         }
       }

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -2375,6 +2375,32 @@ final class WorkspaceStore: ObservableObject {
         refreshGitStatusNow(for: workspace)
     }
 
+    /// ⌘⇧A: jump to the next pane that needs you. A pane waiting for permission
+    /// (blocking) outranks one that just finished or failed (unread results).
+    /// The current workspace is scanned first so a local attention pane wins,
+    /// then every other active (non-archived) workspace. Reuses `revealPane`
+    /// (the notification-click path): it switches workspace, selects the pane's
+    /// tab, focuses it, and clears the unread / dock-badge state. Nothing needs
+    /// attention ⇒ beep.
+    func jumpToAttention() {
+        let priority: [PaneAgentStatus] = [.needsPermission, .justCompleted, .failed]
+        let current = selectedWorkspaceID
+        let active = workspaces.filter { !$0.archived }
+        let ordered = active.filter { $0.id == current }
+            + active.filter { $0.id != current }
+        for status in priority {
+            for ws in ordered {
+                for paneID in ws.panes.keys {
+                    let key = WorkspacePaneKey(workspace: ws.id, pane: paneID)
+                    guard paneAgentState[key]?.status == status else { continue }
+                    revealPane(workspace: ws.id, pane: paneID)
+                    return
+                }
+            }
+        }
+        NSSound.beep()
+    }
+
     // MARK: - external control (control.sock)
     //
     // Command dispatch for ControlBridge. Each method runs on the main thread

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -2375,30 +2375,38 @@ final class WorkspaceStore: ObservableObject {
         refreshGitStatusNow(for: workspace)
     }
 
-    /// ⌘⇧A: jump to the next pane that needs you. A pane waiting for permission
-    /// (blocking) outranks one that just finished or failed (unread results).
-    /// The current workspace is scanned first so a local attention pane wins,
-    /// then every other active (non-archived) workspace. Reuses `revealPane`
-    /// (the notification-click path): it switches workspace, selects the pane's
-    /// tab, focuses it, and clears the unread / dock-badge state. Nothing needs
+    /// ⌘⇧A: jump to the next pane that needs you. `PaneAgentStatus.attentionRank`
+    /// is the shared ordering, so ⌘⇧A lands on the same pane that floats to the
+    /// top of the sidebar. The current workspace is walked first (so a local
+    /// attention pane wins ties against a remote one), then panes in display
+    /// order (tab → leaves) — never `panes.keys`, whose order is unspecified and
+    /// would make the target non-deterministic. Reuses `revealPane` (the
+    /// notification-click path): it switches workspace, selects the pane's tab,
+    /// focuses it, and clears the unread / dock-badge state. Nothing needs
     /// attention ⇒ beep.
     func jumpToAttention() {
-        let priority: [PaneAgentStatus] = [.needsPermission, .justCompleted, .failed]
         let current = selectedWorkspaceID
-        let active = workspaces.filter { !$0.archived }
-        let ordered = active.filter { $0.id == current }
-            + active.filter { $0.id != current }
-        for status in priority {
-            for ws in ordered {
-                for paneID in ws.panes.keys {
+        let ordered = workspaces.filter { !$0.archived && $0.id == current }
+            + workspaces.filter { !$0.archived && $0.id != current }
+        // Walk panes in display order and keep the FIRST pane at the best
+        // (lowest) attentionRank. `< bestRank` (not `<=`) preserves the
+        // current-workspace-first / tab-order winner among equal ranks.
+        var bestRank = Int.max
+        var best: (ws: UUID, pane: PaneID)?
+        for ws in ordered {
+            for tab in ws.tabs {
+                for paneID in tab.root.leaves {
                     let key = WorkspacePaneKey(workspace: ws.id, pane: paneID)
-                    guard paneAgentState[key]?.status == status else { continue }
-                    revealPane(workspace: ws.id, pane: paneID)
-                    return
+                    guard let rank = paneAgentState[key]?.status.attentionRank,
+                          rank < PaneAgentStatus.sinkAttentionRank,   // ignore sinks (idle/thinking/…)
+                          rank < bestRank else { continue }
+                    bestRank = rank
+                    best = (ws.id, paneID)
                 }
             }
         }
-        NSSound.beep()
+        guard let target = best else { NSSound.beep(); return }
+        revealPane(workspace: target.ws, pane: target.pane)
     }
 
     // MARK: - external control (control.sock)
@@ -3716,6 +3724,13 @@ extension WorkspaceStore {
         }
     }
 
+    /// Attention ranking shared by the status merge and the icon pick.
+    /// Which status to SHOW (the tab chip's dot) when a tab has panes at
+    /// different statuses — NOT the "float to top" ordering. A different axis
+    /// from `PaneAgentStatus.attentionRank` (which ranks what the sidebar
+    /// floats and ⌘⇧A jumps to, and treats `.failed`/`.justCompleted` as
+    /// peers); here `.failed` outranks `.justCompleted` because an error dot
+    /// should win the chip. Don't "fix" one to match the other.
     private func statusRank(_ s: PaneAgentStatus) -> Int {
         switch s {
         case .needsPermission: return 5


### PR DESCRIPTION
Supersedes #78. The original cross-repository stacked branch included #77 commits and became conflicting after #77 was squash-merged. This branch replays only the four attention/sidebar commits from #78 onto the current main branch.

Local verification:
- Debug ad-hoc signed build passed
- Full GlintTests suite passed
- git diff --check passed
