### PR TITLE
Fix Review correctness and performance regressions / 修复 Review 正确性与性能问题

### DIFF
--- a/Glint.xcodeproj/project.pbxproj
+++ b/Glint.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D7A100000000000000000002 /* PerformanceRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A100000000000000000001 /* PerformanceRegressionTests.swift */; };
 		04E75EAD5165E8D96C1C5517 /* MascotAssetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349714D49AE52D84995314FD /* MascotAssetTests.swift */; };
 		07817DC6A98F8ED2E236CFA1 /* CodexHome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E3B385162995D0F1F5B72D /* CodexHome.swift */; };
 		0FB9792E290FC2A8B527B2D0 /* GitRepositoryWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C888E59D1091BFC22A9EA4 /* GitRepositoryWatcherTests.swift */; };
@@ -91,6 +92,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		D7A100000000000000000001 /* PerformanceRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceRegressionTests.swift; sourceTree = "<group>"; };
 		050E267AE14712D4D6633B4F /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		05F2CA2243872C8111048EF2 /* AgentBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBridge.swift; sourceTree = "<group>"; };
 		08FC2FBC9E8729A5ECBF857C /* PaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneView.swift; sourceTree = "<group>"; };
@@ -223,6 +225,7 @@
 				EBCC04C19D745AA867D961FD /* PaneAgentKindTests.swift */,
 				797C4E86D052EF8A68DD9B39 /* PaneSessionIdMigrationTests.swift */,
 				51DE2D7740BD03498A936B62 /* PersistenceRecoveryTests.swift */,
+				D7A100000000000000000001 /* PerformanceRegressionTests.swift */,
 				4A0B24E791FF6CEB30A9DDD5 /* RemoteTitleParserTests.swift */,
 				2CFFB91CE5C44976A6961F1F /* ReviewDiffParsingTests.swift */,
 				D7F8C1899F93B387843907FF /* ReviewScopeTests.swift */,
@@ -474,6 +477,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D7A100000000000000000002 /* PerformanceRegressionTests.swift in Sources */,
 				A019A2AD685F1407D7E2A7E1 /* AgentHookRoutingTests.swift in Sources */,
 				81532B36FEC3039B8EAD9CB1 /* AgentKindResolutionTests.swift in Sources */,
 				C41119D04864077E5B554F59 /* CodexHomeStoreTests.swift in Sources */,

--- a/Glint/Chrome/NewWorkspaceSheet.swift
+++ b/Glint/Chrome/NewWorkspaceSheet.swift
@@ -40,6 +40,7 @@ private struct WorktreePane: View {
     @State private var creating = false
     @State private var errorText: String?
     @State private var showAdvanced = false
+    @State private var branchValidationTask: Task<Void, Never>?
     @FocusState private var branchFocused: Bool
 
     private var canCreate: Bool {
@@ -81,6 +82,7 @@ private struct WorktreePane: View {
             // over the sheet's default first-responder assignment.
             DispatchQueue.main.async { branchFocused = true }
         }
+        .onDisappear { branchValidationTask?.cancel() }
     }
 
     // Why the Create button is disabled — surfaced as its tooltip so a greyed
@@ -237,6 +239,7 @@ private struct WorktreePane: View {
     }
 
     private func detect() {
+        branchValidationTask?.cancel()
         let target = (repo as NSString).expandingTildeInPath
         // Reset detecting here too: a prior probe may still be in flight with
         // detecting=true, and its stale MainActor block below is skipped by the
@@ -272,22 +275,30 @@ private struct WorktreePane: View {
     private func branchChanged() {
         if !pathEdited { recomputePath() }
         let name = branch.trimmingCharacters(in: .whitespaces)
+        branchValidationTask?.cancel()
         // Reset to "pending" so Create is disabled until the async check resolves
         // — otherwise pressing ⏎ right after typing fires against the previous
         // name's stale availability.
         branchAvailable = nil
         branchInvalid = false
         guard !name.isEmpty, let root = repoRoot else { return }
-        Task {
+        branchValidationTask = Task { @MainActor in
+            do {
+                try await Task.sleep(nanoseconds: 250_000_000)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
             let valid = await store.git.isValidBranchName(name, repo: root)
+            guard !Task.isCancelled else { return }
             var exists = false
             if valid { exists = await store.git.localBranchExists(repo: root, name: name) }
-            await MainActor.run {
-                // Ignore a result that arrived after the field changed again.
-                guard branch.trimmingCharacters(in: .whitespaces) == name else { return }
-                branchInvalid = !valid
-                branchAvailable = valid && !exists
-            }
+            guard !Task.isCancelled else { return }
+            // Ignore a result that arrived after the field changed again.
+            guard repoRoot == root,
+                  branch.trimmingCharacters(in: .whitespaces) == name else { return }
+            branchInvalid = !valid
+            branchAvailable = valid && !exists
         }
     }
 

--- a/Glint/Chrome/SettingsView.swift
+++ b/Glint/Chrome/SettingsView.swift
@@ -580,21 +580,20 @@ private struct AppearancePane: View {
         SettingsCard("Opacity & blur",
                      footer: "Let the desktop show through — the terminal area and the sidebar/toolbar can be tuned separately. Background blur frosts the desktop behind the window so terminal text stays readable. Note: macOS native fullscreen disables window transparency.") {
             SettingsRow("Terminal opacity") {
-                OpacityControl(value: $store.terminalOpacity)
+                CommittedSlider(value: $store.terminalOpacity, in: 0.3...1.0) {
+                    "\(Int(($0 * 100).rounded()))%"
+                }
             }
             SettingsDivider()
             SettingsRow("Interface opacity", subtitle: "Sidebar and toolbar") {
-                OpacityControl(value: $store.chromeOpacity)
+                CommittedSlider(value: $store.chromeOpacity, in: 0.3...1.0) {
+                    "\(Int(($0 * 100).rounded()))%"
+                }
             }
             SettingsDivider()
             SettingsRow("Background blur") {
-                HStack(spacing: 10) {
-                    Slider(value: $store.backgroundBlur, in: 0...60)
-                        .frame(width: 150)
-                    Text("\(Int(store.backgroundBlur.rounded()))")
-                        .font(.system(size: 11, weight: .medium, design: .monospaced))
-                        .foregroundStyle(Theme.text3)
-                        .frame(width: 38, alignment: .trailing)
+                CommittedSlider(value: $store.backgroundBlur, in: 0...60) {
+                    "\(Int($0.rounded()))"
                 }
             }
         }
@@ -693,18 +692,47 @@ private struct ThemePreviewCard: View {
     }
 }
 
-/// 透明度滑块 + 百分比标签。范围下限 0.3,避免拖到全透导致界面不可用。
-private struct OpacityControl: View {
+/// Keeps continuous drag values local and commits once when the drag ends.
+/// Keyboard changes still commit immediately. This prevents every mouse-move
+/// from rewriting UserDefaults and rebuilding Ghostty's full configuration.
+private struct CommittedSlider: View {
     @Binding var value: Double
+    let range: ClosedRange<Double>
+    let format: (Double) -> String
+    @State private var draft: Double
+    @State private var isEditing = false
+
+    init(value: Binding<Double>, in range: ClosedRange<Double>,
+         format: @escaping (Double) -> String) {
+        _value = value
+        self.range = range
+        self.format = format
+        _draft = State(initialValue: value.wrappedValue)
+    }
+
     var body: some View {
         HStack(spacing: 10) {
-            Slider(value: $value, in: 0.3...1.0)
+            Slider(value: $draft, in: range, onEditingChanged: editingChanged)
                 .frame(width: 150)
-            Text("\(Int((value * 100).rounded()))%")
+            Text(verbatim: format(draft))
                 .font(.system(size: 11, weight: .medium, design: .monospaced))
                 .foregroundStyle(Theme.text3)
                 .frame(width: 38, alignment: .trailing)
         }
+        .onChange(of: draft) { _, newValue in
+            if !isEditing { value = newValue }
+        }
+        .onChange(of: value) { _, newValue in
+            if !isEditing { draft = newValue }
+        }
+        .onDisappear {
+            if value != draft { value = draft }
+        }
+    }
+
+    private func editingChanged(_ editing: Bool) {
+        isEditing = editing
+        if !editing, value != draft { value = draft }
     }
 }
 

--- a/Glint/Ghostty/GhosttyManager.swift
+++ b/Glint/Ghostty/GhosttyManager.swift
@@ -51,6 +51,7 @@ final class GhosttyManager {
     private var config: ghostty_config_t?
     private var appearanceObservation: NSKeyValueObservation?
     private let tickScheduler = GhosttyTickScheduler()
+    private var focusObservers: [NSObjectProtocol] = []
 
     private init() {
         bootstrap()
@@ -95,6 +96,7 @@ final class GhosttyManager {
         self.app = app
 
         observeColorScheme()
+        observeAppFocus()
     }
 
     /// Push the system Light/Dark setting into ghostty and re-push on
@@ -115,6 +117,31 @@ final class GhosttyManager {
             ? GHOSTTY_COLOR_SCHEME_DARK
             : GHOSTTY_COLOR_SCHEME_LIGHT
         ghostty_app_set_color_scheme(app, scheme)
+    }
+
+    /// App focus is separate from a surface's first-responder state. AppKit
+    /// keeps the first responder when the app resigns active, so mirror the
+    /// lifecycle explicitly to stop cursor blink / render work in the background.
+    private func observeAppFocus() {
+        setAppFocus(NSApp.isActive)
+        let center = NotificationCenter.default
+        focusObservers.append(center.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil, queue: .main
+        ) { [weak self] _ in
+            self?.setAppFocus(true)
+        })
+        focusObservers.append(center.addObserver(
+            forName: NSApplication.didResignActiveNotification,
+            object: nil, queue: .main
+        ) { [weak self] _ in
+            self?.setAppFocus(false)
+        })
+    }
+
+    private func setAppFocus(_ focused: Bool) {
+        guard let app else { return }
+        ghostty_app_set_focus(app, focused)
     }
 
     // MARK: transparency
@@ -334,18 +361,18 @@ final class GhosttyManager {
         applyGlintTheme(newCfg)
         ghostty_config_finalize(newCfg)
         ghostty_app_update_config(app, newCfg)
+        let oldCfg = config
+        self.config = newCfg
+        // `ghostty_app_update_config` copies the configuration into the app and
+        // surfaces; its API contract says caller-owned memory may be freed as
+        // soon as the call returns.
+        if let oldCfg { ghostty_config_free(oldCfg) }
         // Blur is a window-level effect ghostty won't (re)apply on its own —
         // re-assert it after the config swap so toggling opacity/blur live
         // takes hold without a relaunch.
         DispatchQueue.main.async { [weak self] in
             self?.applyWindowEffects()
         }
-        // ghostty takes the config from here. We keep a reference for parity
-        // with bootstrap; we don't free the previous one because ghostty may
-        // still be holding it during in-flight reload propagation. The few
-        // extra config objects accumulated over a session are bounded by how
-        // often a user changes settings (~tens of bytes per knob).
-        self.config = newCfg
     }
 
     private static let writeClipboard: ghostty_runtime_write_clipboard_cb = { _, _, contentPtr, count, _ in

--- a/Glint/Git/GitDiff.swift
+++ b/Glint/Git/GitDiff.swift
@@ -59,7 +59,7 @@ extension GitService {
                                            deletions: 0, isBinary: false)
                 }
             }
-            return Self.withMtime(map.values.sorted { $0.path < $1.path }, repo: repo)
+            return withMtime(map.values.sorted { $0.path < $1.path }, repo: repo)
 
         case .branch(let base):
             async let names = git(["diff", "\(base)...HEAD", "--name-status"], cwd: repo,
@@ -69,15 +69,16 @@ extension GitService {
             let map = Self.mergeNameNumstat(
                 nameStatus: (try? await names)?.stdout ?? "",
                 numstat: (try? await nums)?.stdout ?? "")
-            return Self.withMtime(map.values.sorted { $0.path < $1.path }, repo: repo)
+            return withMtime(map.values.sorted { $0.path < $1.path }, repo: repo)
         }
     }
 
-    /// Stat each file's working-tree path for its modification date — one cheap
-    /// syscall per file, nil-safe (a deleted/missing file yields nil). Review-only
-    /// enrichment kept here so `modDate` is populated before the model builds its
-    /// list views.
-    private static func withMtime(_ files: [GitFileChange], repo: String) -> [GitFileChange] {
+    /// Stat each LOCAL file's working-tree path for its modification date — one
+    /// cheap syscall per file, nil-safe (a deleted/missing file yields nil).
+    /// A non-local runner's `repo` belongs to another filesystem, so leave its
+    /// dates empty rather than reading an unrelated same-pathed local file.
+    private func withMtime(_ files: [GitFileChange], repo: String) -> [GitFileChange] {
+        guard runner is LocalGitRunner else { return files }
         let fm = FileManager.default
         let base = repo as NSString
         return files.map { f in

--- a/Glint/Git/GitService.swift
+++ b/Glint/Git/GitService.swift
@@ -135,6 +135,59 @@ func boundedMap(paths: [String], maxConcurrent: Int,
     }
 }
 
+private final class ProcessCancellationState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var process: Process?
+    private var cancelled = false
+    private var killer: DispatchWorkItem?
+
+    /// Install and launch atomically with respect to cancellation. Holding the
+    /// lock across `run()` closes the race where cancellation fires after the
+    /// preflight check but before the subprocess actually exists.
+    func launch(_ process: Process) throws -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !cancelled else { return false }
+        self.process = process
+        do {
+            try process.run()
+            return true
+        } catch {
+            self.process = nil
+            throw error
+        }
+    }
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        guard let process, process.isRunning else {
+            lock.unlock()
+            return
+        }
+        let pid = process.processIdentifier
+        let killer = DispatchWorkItem {
+            if process.isRunning { kill(pid, SIGKILL) }
+        }
+        self.killer?.cancel()
+        self.killer = killer
+        lock.unlock()
+
+        kill(pid, SIGTERM)
+        DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(2), execute: killer)
+    }
+
+    /// Clear the process and return whether cancellation won the race.
+    func finish() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        process = nil
+        killer?.cancel()
+        killer = nil
+        return cancelled
+    }
+}
+
 /// Spawn `executable arguments` with `cwd`/`env`, drain both pipes concurrently
 /// (so neither fixed pipe buffer can deadlock on large output), and enforce an
 /// optional hard `timeout`. On the deadline: SIGTERM, then SIGKILL after a 2s
@@ -157,6 +210,21 @@ func boundedMap(paths: [String], maxConcurrent: Int,
 /// render a half-streamed diff as if it were complete.
 private func captureProcess(executable: String, arguments: [String], cwd: String?,
                             env: [String: String], timeout: TimeInterval?) async throws -> GitResult {
+    let cancellation = ProcessCancellationState()
+    return try await withTaskCancellationHandler(operation: {
+        let result = try await captureProcessBody(
+            executable: executable, arguments: arguments, cwd: cwd,
+            env: env, timeout: timeout, cancellation: cancellation)
+        try Task.checkCancellation()
+        return result
+    }, onCancel: {
+        cancellation.cancel()
+    })
+}
+
+private func captureProcessBody(executable: String, arguments: [String], cwd: String?,
+                                env: [String: String], timeout: TimeInterval?,
+                                cancellation: ProcessCancellationState) async throws -> GitResult {
     try await withCheckedThrowingContinuation { (cont: CheckedContinuation<GitResult, Error>) in
         DispatchQueue.global(qos: .userInitiated).async {
             let proc = Process()
@@ -172,9 +240,15 @@ private func captureProcess(executable: String, arguments: [String], cwd: String
             proc.standardOutput = outPipe
             proc.standardError = errPipe
             do {
-                try proc.run()
+                guard try cancellation.launch(proc) else {
+                    cont.resume(throwing: CancellationError())
+                    return
+                }
             } catch {
-                cont.resume(throwing: GitError.launchFailed(error.localizedDescription))
+                let wasCancelled = cancellation.finish()
+                cont.resume(throwing: wasCancelled
+                            ? CancellationError()
+                            : GitError.launchFailed(error.localizedDescription))
                 return
             }
 
@@ -212,11 +286,15 @@ private func captureProcess(executable: String, arguments: [String], cwd: String
             watchdog?.cancel()
             killer?.cancel()
 
-            cont.resume(returning: GitResult(
-                exitCode: proc.terminationStatus,
-                stdout: String(decoding: outData, as: UTF8.self),
-                stderr: String(decoding: errData, as: UTF8.self),
-                wasSignaled: proc.terminationReason == .uncaughtSignal))
+            if cancellation.finish() {
+                cont.resume(throwing: CancellationError())
+            } else {
+                cont.resume(returning: GitResult(
+                    exitCode: proc.terminationStatus,
+                    stdout: String(decoding: outData, as: UTF8.self),
+                    stderr: String(decoding: errData, as: UTF8.self),
+                    wasSignaled: proc.terminationReason == .uncaughtSignal))
+            }
         }
     }
 }

--- a/Glint/Review/ReviewWindow.swift
+++ b/Glint/Review/ReviewWindow.swift
@@ -138,6 +138,17 @@ final class ReviewModel: ObservableObject {
         diff = .empty
         loadingDiff = false
     }
+
+    static func revealTarget(fullPath: String, repo: String,
+                             fileManager: FileManager = .default) -> URL {
+        let repoURL = URL(fileURLWithPath: repo).standardizedFileURL
+        var candidate = URL(fileURLWithPath: fullPath).standardizedFileURL
+        while candidate.path != repoURL.path,
+              !fileManager.fileExists(atPath: candidate.path) {
+            candidate.deleteLastPathComponent()
+        }
+        return fileManager.fileExists(atPath: candidate.path) ? candidate : repoURL
+    }
 }
 
 // MARK: - Root view
@@ -635,10 +646,7 @@ private struct FileListView: View {
 
     private func revealFile(_ file: GitFileChange) {
         let full = fullPath(for: file)
-        let url = URL(fileURLWithPath: full)
-        // A deleted file isn't on disk — reveal its containing folder instead.
-        let target = FileManager.default.fileExists(atPath: full) ? url
-            : url.deletingLastPathComponent()
+        let target = ReviewModel.revealTarget(fullPath: full, repo: model.repo)
         NSWorkspace.shared.activateFileViewerSelecting([target])
     }
 
@@ -1557,6 +1565,7 @@ final class ReviewWindowController: NSObject, NSWindowDelegate {
 
     private var window: NSWindow?
     private var model: ReviewModel?   // strong ref for the window's lifetime
+    private var skipNextKeyReload = false
     /// Lives for the duration the window is open. Re-applies NSWindow.appearance
     /// whenever the store bumps `themeRevision`, so a mid-session theme switch
     /// doesn't leave borderless-menu popups (rendered by AppKit, not SwiftUI)
@@ -1594,6 +1603,10 @@ final class ReviewWindowController: NSObject, NSWindowDelegate {
         // titlebar with no per-frame recomputation.
         w.contentView = NoSafeAreaHostingView(rootView: root)
         window = w
+        // ReviewView's .task performs this model's initial load. Becoming key
+        // below is synchronous and must not launch the same full scan again;
+        // later key transitions still refresh changes made while unfocused.
+        skipNextKeyReload = !w.isKeyWindow
         w.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
     }
@@ -1631,8 +1644,12 @@ final class ReviewWindowController: NSObject, NSWindowDelegate {
     }
 
     func windowDidBecomeKey(_ notification: Notification) {
-        guard notification.object as? NSWindow === window,
-              let model else { return }
+        guard notification.object as? NSWindow === window else { return }
+        if skipNextKeyReload {
+            skipNextKeyReload = false
+            return
+        }
+        guard let model else { return }
         Task { await model.reload() }
     }
 }

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -3432,7 +3432,7 @@ final class WorkspaceStore: ObservableObject {
 
     private func syncGitWatchers() {
         var desired: [UUID: String] = [:]
-        for ws in workspaces {
+        for ws in workspaces where !ws.archived {
             switch ws.source.kind {
             case .localRepo, .localWorktree:
                 if let path = ws.source.gitPath { desired[ws.id] = path }
@@ -3460,6 +3460,10 @@ final class WorkspaceStore: ObservableObject {
 
     func refreshGitStatus(for id: UUID) async {
         guard let ws = workspaces.first(where: { $0.id == id }) else {
+            if gitStatuses[id] != nil { gitStatuses[id] = nil }
+            return
+        }
+        guard !ws.archived else {
             if gitStatuses[id] != nil { gitStatuses[id] = nil }
             return
         }
@@ -3519,13 +3523,21 @@ final class WorkspaceStore: ObservableObject {
     /// looking at. Other plain shells are NOT timer-polled — they refresh on
     /// demand via `refreshGitStatusNow` when switched/focused, which avoids
     /// spawning N git subprocesses every tick for background terminals.
-    private func shouldTimerPoll(_ ws: Workspace) -> Bool {
-        guard effectiveGitPath(for: ws) != nil else { return false }
+    static func shouldTimerPoll(_ ws: Workspace, selectedWorkspaceID: UUID?,
+                                effectiveGitPath: String?, appIsActive: Bool) -> Bool {
+        guard appIsActive, !ws.archived else { return false }
+        guard effectiveGitPath != nil else { return false }
         if ws.id == selectedWorkspaceID { return true }
         switch ws.source.kind {
         case .localRepo, .localWorktree: return true
         default: return false
         }
+    }
+
+    private func shouldTimerPoll(_ ws: Workspace) -> Bool {
+        Self.shouldTimerPoll(ws, selectedWorkspaceID: selectedWorkspaceID,
+                             effectiveGitPath: effectiveGitPath(for: ws),
+                             appIsActive: NSApp.isActive)
     }
 
     /// Fire-and-forget single refresh, used when the *displayed* terminal

--- a/GlintTests/PerformanceRegressionTests.swift
+++ b/GlintTests/PerformanceRegressionTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import Glint
+
+@MainActor
+final class PerformanceRegressionTests: XCTestCase {
+    private func workspace(archived: Bool) -> Workspace {
+        let paneID = PaneID(value: 0)
+        let tabID = TabID(value: 0)
+        return Workspace(
+            id: UUID(), name: "repo", userNamed: false,
+            accentHex: "5E5CE6", symbol: "terminal",
+            tabs: [WorkspaceTab(id: tabID, name: nil, root: .leaf(paneID), focusedPane: paneID)],
+            selectedTabID: tabID, nextTabSeq: 1,
+            panes: [paneID: Pane(id: paneID, title: "Terminal")], nextPaneSeq: 1,
+            archived: archived,
+            source: WorkspaceSource(kind: .localRepo, repoRoot: "/tmp/repo")
+        )
+    }
+
+    func testGitTimerPolicySkipsArchivedWorkspace() {
+        let workspace = workspace(archived: true)
+
+        XCTAssertFalse(WorkspaceStore.shouldTimerPoll(
+            workspace, selectedWorkspaceID: workspace.id,
+            effectiveGitPath: "/tmp/repo", appIsActive: true
+        ))
+    }
+
+    func testGitTimerPolicySkipsWhenAppIsInactive() {
+        let workspace = workspace(archived: false)
+
+        XCTAssertFalse(WorkspaceStore.shouldTimerPoll(
+            workspace, selectedWorkspaceID: workspace.id,
+            effectiveGitPath: "/tmp/repo", appIsActive: false
+        ))
+    }
+
+    func testGitTimerPolicyPollsSelectedActiveWorkspace() {
+        let workspace = workspace(archived: false)
+
+        XCTAssertTrue(WorkspaceStore.shouldTimerPoll(
+            workspace, selectedWorkspaceID: workspace.id,
+            effectiveGitPath: "/tmp/repo", appIsActive: true
+        ))
+    }
+
+    func testCancellingLocalRunnerTerminatesSubprocessPromptly() async {
+        let runner = LocalGitRunner(gitPath: "/bin/sleep")
+        let clock = ContinuousClock()
+        let started = clock.now
+        let task = Task {
+            try await runner.run(["2"], cwd: nil, timeout: .poll)
+        }
+
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("A cancelled subprocess should not run to completion")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            XCTFail("Expected CancellationError, got \(error)")
+        }
+        XCTAssertLessThan(started.duration(to: clock.now), .seconds(1))
+    }
+}

--- a/GlintTests/ReviewDiffParsingTests.swift
+++ b/GlintTests/ReviewDiffParsingTests.swift
@@ -11,6 +11,22 @@ import XCTest
 /// Windows-authored diff body parses as zero add/del lines — nothing tints.
 final class ReviewDiffParsingTests: XCTestCase {
 
+    private struct NonLocalDiffRunner: GitRunner {
+        func run(_ args: [String], cwd: String?, timeout: GitTimeout) async throws -> GitResult {
+            if args.contains("--name-status") {
+                return GitResult(exitCode: 0, stdout: "M\tfile.txt\n", stderr: "")
+            }
+            if args.contains("--numstat") {
+                return GitResult(exitCode: 0, stdout: "1\t1\tfile.txt\n", stderr: "")
+            }
+            return GitResult(exitCode: 0, stdout: "", stderr: "")
+        }
+
+        func countUntrackedAdditions(repo: String, paths: [String]) async -> [String: Int] {
+            [:]
+        }
+    }
+
     private func file(_ path: String) -> GitFileChange {
         GitFileChange(path: path, kind: .modified, additions: 1, deletions: 1, isBinary: false)
     }
@@ -200,5 +216,32 @@ rename to n
         let nodes = TreeNode.build([file("a.txt"), file("a.txt")])
         XCTAssertEqual(nodes.count, 1)
         XCTAssertEqual(nodes[0].name, "a.txt")
+    }
+
+    func testChangedFilesDoesNotReadMtimeForNonLocalRunner() async throws {
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("glint-remote-mtime-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try Data("local collision".utf8).write(to: repo.appendingPathComponent("file.txt"))
+
+        let files = await GitService(runner: NonLocalDiffRunner())
+            .changedFiles(repo: repo.path, scope: .workingTree)
+
+        XCTAssertEqual(files.count, 1)
+        XCTAssertNil(files[0].modDate)
+    }
+
+    @MainActor
+    func testRevealTargetWalksUpDeletedTreeToExistingRepo() throws {
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("glint-reveal-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let deleted = repo.appendingPathComponent("removed/tree/file.txt")
+
+        let target = ReviewModel.revealTarget(fullPath: deleted.path, repo: repo.path)
+
+        XCTAssertEqual(target.standardizedFileURL, repo.standardizedFileURL)
     }
 }


### PR DESCRIPTION
## Summary / 概要

- Prevent remote Review from reading local mtimes, suppress the duplicate first-open reload, and reveal the nearest existing ancestor for deleted trees.  
  防止远程 Review 读取本地文件时间，避免首次打开时重复重载，并在文件树已删除时定位最近的现存父目录。

- Commit opacity and blur slider values once per drag, free replaced Ghostty configs, and mirror macOS app focus into Ghostty.  
  透明度和模糊滑块在每次拖动结束后仅提交一次，释放被替换的 Ghostty 配置，并将 macOS 应用焦点状态同步给 Ghostty。

- Preserve the event-driven refresh architecture from #83 while excluding archived or inactive workspaces; make Git subprocess cancellation effective and debounce worktree branch validation.  
  保留 #83 的事件驱动刷新架构，同时排除已归档或应用非活跃时的 workspace；让 Git 子进程真正响应取消，并为 worktree 分支校验增加防抖。

## Verification / 验证

- Regression tests were observed failing on latest main before the fixes, then passing afterward.  
  回归测试已在最新 main 上确认修复前失败、修复后通过。

- Full macOS suite: 186 tests, 0 failures.  
  完整 macOS 测试套件：186 个测试，0 失败。

- git diff --check passed.  
  git diff --check 检查通过。