### PR TITLE
fix: back off Git refresh during filesystem storms / 降低文件系统风暴期间的 Git 刷新频率

### DIFF
--- a/Glint/Git/GitRefreshCoordinator.swift
+++ b/Glint/Git/GitRefreshCoordinator.swift
@@ -57,7 +57,8 @@ final class GitRefreshCoordinator {
             pending[id]?.cancel()
             let now = Date()
             let elapsed = lastDispatch[id].map { now.timeIntervalSince($0) } ?? .infinity
-            let currentCount = coalescedWatcherRequestCount[id] ?? 0
+            let currentCount = source == .commandFinished
+                ? 0 : coalescedWatcherRequestCount[id] ?? 0
             let currentInterval = currentCount >= Self.stormThreshold
                 ? stormInterval : minInterval
             if elapsed >= currentInterval {

--- a/Glint/Git/GitRefreshCoordinator.swift
+++ b/Glint/Git/GitRefreshCoordinator.swift
@@ -11,16 +11,19 @@ import Foundation
 /// one `git commit` spawned two subprocesses. This coordinator closes that gap:
 /// once a refresh has been dispatched for a workspace, further refreshes
 /// requested within `minInterval` coalesce into ONE trailing refresh at the
-/// interval boundary. A sustained storm (build, rebase, checkout) thus
-/// refreshes at most once per `minInterval`, never zero — the trailing refresh
-/// always runs, so a genuine change can't be dropped while the storm throttles.
+/// interval boundary. A second coalesced request indicates a sustained storm
+/// (build, rebase, checkout), so the trailing refresh backs off to four times
+/// the base interval. The trailing refresh still always runs, so a genuine
+/// change can't be dropped while the storm throttles.
 ///
 /// Only the push-based event channels route through here. Pull-based refreshes
 /// (workspace/pane switch, popover open, the active-only fallback timer) call
 /// `refreshGitStatus` / `refreshGitStatusNow` directly and stay immediate.
 final class GitRefreshCoordinator {
     private let minInterval: TimeInterval
+    private let stormInterval: TimeInterval
     private let queue = DispatchQueue(label: "app.glint.git-refresh")
+    private static let stormThreshold = 2
     /// Last time a refresh for this workspace was actually dispatched (immediate
     /// path, or a trailing fire). The elapsed-since guard is what folds a
     /// trailing FSEvents callback back into the refresh the command-finished
@@ -29,9 +32,14 @@ final class GitRefreshCoordinator {
     /// One in-flight trailing work item per workspace, so a fresher request can
     /// cancel a not-yet-fired trailing refresh and replace it.
     private var pending: [UUID: DispatchWorkItem] = [:]
+    /// Requests coalesced since the last actual dispatch. A normal shell
+    /// command produces one watcher follow-up; several follow-ups in the same
+    /// window mean filesystem churn rather than one logical command.
+    private var coalescedRequestCount: [UUID: Int] = [:]
 
     init(minInterval: TimeInterval = 1.5) {
         self.minInterval = minInterval
+        self.stormInterval = minInterval * 4
     }
 
     /// Request a refresh of `id`. `run` runs on the main actor immediately when
@@ -44,15 +52,24 @@ final class GitRefreshCoordinator {
             pending[id]?.cancel()
             let now = Date()
             let elapsed = lastDispatch[id].map { now.timeIntervalSince($0) } ?? .infinity
-            if elapsed >= minInterval {
+            let currentCount = coalescedRequestCount[id] ?? 0
+            let currentInterval = currentCount >= Self.stormThreshold
+                ? stormInterval : minInterval
+            if elapsed >= currentInterval {
                 lastDispatch[id] = now
                 pending[id] = nil
+                coalescedRequestCount[id] = 0
                 DispatchQueue.main.async(execute: run)
             } else {
-                let delay = minInterval - elapsed
+                let nextCount = currentCount + 1
+                coalescedRequestCount[id] = nextCount
+                let targetInterval = nextCount >= Self.stormThreshold
+                    ? stormInterval : minInterval
+                let delay = targetInterval - elapsed
                 let item = DispatchWorkItem { [self] in
                     lastDispatch[id] = Date()
                     pending[id] = nil
+                    coalescedRequestCount[id] = 0
                     DispatchQueue.main.async(execute: run)
                 }
                 pending[id] = item
@@ -61,12 +78,15 @@ final class GitRefreshCoordinator {
         }
     }
 
-    /// Drop any not-yet-fired trailing refresh for `id` (e.g. its workspace was
-    /// removed). Does not affect a refresh already dispatched to the main queue.
+    /// Drop any not-yet-fired trailing refresh and throttle history for `id`
+    /// (e.g. its workspace was archived or removed). Does not affect a refresh
+    /// already dispatched to the main queue.
     func cancel(_ id: UUID) {
         queue.async { [self] in
             pending[id]?.cancel()
             pending[id] = nil
+            lastDispatch[id] = nil
+            coalescedRequestCount[id] = nil
         }
     }
 }

--- a/Glint/Git/GitRefreshCoordinator.swift
+++ b/Glint/Git/GitRefreshCoordinator.swift
@@ -11,15 +11,20 @@ import Foundation
 /// one `git commit` spawned two subprocesses. This coordinator closes that gap:
 /// once a refresh has been dispatched for a workspace, further refreshes
 /// requested within `minInterval` coalesce into ONE trailing refresh at the
-/// interval boundary. A second coalesced request indicates a sustained storm
-/// (build, rebase, checkout), so the trailing refresh backs off to four times
-/// the base interval. The trailing refresh still always runs, so a genuine
-/// change can't be dropped while the storm throttles.
+/// interval boundary. A second coalesced watcher request indicates a sustained
+/// filesystem storm (build, rebase, checkout), so the trailing refresh backs
+/// off to four times the base interval. The trailing refresh still always runs,
+/// so a genuine change can't be dropped while the storm throttles.
 ///
 /// Only the push-based event channels route through here. Pull-based refreshes
 /// (workspace/pane switch, popover open, the active-only fallback timer) call
 /// `refreshGitStatus` / `refreshGitStatusNow` directly and stay immediate.
 final class GitRefreshCoordinator {
+    enum Source {
+        case commandFinished
+        case fileWatcher
+    }
+
     private let minInterval: TimeInterval
     private let stormInterval: TimeInterval
     private let queue = DispatchQueue(label: "app.glint.git-refresh")
@@ -35,7 +40,7 @@ final class GitRefreshCoordinator {
     /// Requests coalesced since the last actual dispatch. A normal shell
     /// command produces one watcher follow-up; several follow-ups in the same
     /// window mean filesystem churn rather than one logical command.
-    private var coalescedRequestCount: [UUID: Int] = [:]
+    private var coalescedWatcherRequestCount: [UUID: Int] = [:]
 
     init(minInterval: TimeInterval = 1.5) {
         self.minInterval = minInterval
@@ -47,29 +52,29 @@ final class GitRefreshCoordinator {
     /// once at the interval boundary. Repeated requests within the window
     /// coalesce: a fresher request cancels any not-yet-fired trailing refresh
     /// and replaces it, so only the most recent request's `run` survives.
-    func request(_ id: UUID, run: @escaping () -> Void) {
+    func request(_ id: UUID, source: Source, run: @escaping () -> Void) {
         queue.async { [self] in
             pending[id]?.cancel()
             let now = Date()
             let elapsed = lastDispatch[id].map { now.timeIntervalSince($0) } ?? .infinity
-            let currentCount = coalescedRequestCount[id] ?? 0
+            let currentCount = coalescedWatcherRequestCount[id] ?? 0
             let currentInterval = currentCount >= Self.stormThreshold
                 ? stormInterval : minInterval
             if elapsed >= currentInterval {
                 lastDispatch[id] = now
                 pending[id] = nil
-                coalescedRequestCount[id] = 0
+                coalescedWatcherRequestCount[id] = 0
                 DispatchQueue.main.async(execute: run)
             } else {
-                let nextCount = currentCount + 1
-                coalescedRequestCount[id] = nextCount
+                let nextCount = currentCount + (source == .fileWatcher ? 1 : 0)
+                coalescedWatcherRequestCount[id] = nextCount
                 let targetInterval = nextCount >= Self.stormThreshold
                     ? stormInterval : minInterval
                 let delay = targetInterval - elapsed
                 let item = DispatchWorkItem { [self] in
                     lastDispatch[id] = Date()
                     pending[id] = nil
-                    coalescedRequestCount[id] = 0
+                    coalescedWatcherRequestCount[id] = 0
                     DispatchQueue.main.async(execute: run)
                 }
                 pending[id] = item
@@ -86,7 +91,7 @@ final class GitRefreshCoordinator {
             pending[id]?.cancel()
             pending[id] = nil
             lastDispatch[id] = nil
-            coalescedRequestCount[id] = nil
+            coalescedWatcherRequestCount[id] = nil
         }
     }
 }

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -1529,7 +1529,7 @@ final class WorkspaceStore: ObservableObject {
                 // callback that follows this same change ~0.5s later doesn't
                 // spawn a second `git status` (the in-flight gate only merges
                 // runs that overlap in time; a fast git finishes first).
-                self.gitRefreshCoordinator.request(wsID) { [weak self] in
+                self.gitRefreshCoordinator.request(wsID, source: .commandFinished) { [weak self] in
                     self?.refreshGitStatusNow(for: wsID)
                 }
             }
@@ -3498,7 +3498,7 @@ final class WorkspaceStore: ObservableObject {
             let paths = GitRepositoryWatcher.watchPaths(for: path)
             let watcher = GitRepositoryWatcher(paths: paths) { [weak self] in
                 guard NSApp.isActive else { return }
-                self?.gitRefreshCoordinator.request(id) { [weak self] in
+                self?.gitRefreshCoordinator.request(id, source: .fileWatcher) { [weak self] in
                     self?.refreshGitStatusNow(for: id)
                 }
             }

--- a/GlintTests/GitRefreshCoordinatorTests.swift
+++ b/GlintTests/GitRefreshCoordinatorTests.swift
@@ -36,8 +36,7 @@ final class GitRefreshCoordinatorTests: XCTestCase {
         let immediate = expectation(description: "immediate")
 
         coordinator.request(id) { count += 1; immediate.fulfill() }
-        // Two more within the window — both must fold into the single trailing.
-        coordinator.request(id) { count += 1 }
+        // The watcher follow-up within the window folds into one trailing run.
         coordinator.request(id) { count += 1 }
 
         wait(for: [immediate], timeout: 0.5)
@@ -47,6 +46,31 @@ final class GitRefreshCoordinatorTests: XCTestCase {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
             // immediate + exactly one trailing
             XCTAssertEqual(count, 2)
+            settled.fulfill()
+        }
+        wait(for: [settled], timeout: 1.5)
+    }
+
+    /// A build/rebase can keep FSEvents busy for seconds. Once the burst is
+    /// clearly larger than the normal command-finished + watcher pair, refresh
+    /// less often instead of spawning one git process pair every base window.
+    func testSustainedStormBacksOffBeyondBaseInterval() {
+        let coordinator = GitRefreshCoordinator(minInterval: 0.15)
+        let id = UUID()
+        var count = 0
+
+        coordinator.request(id) { count += 1 }
+        for offset in stride(from: 0.04, through: 0.52, by: 0.04) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + offset) {
+                coordinator.request(id) { count += 1 }
+            }
+        }
+
+        let settled = expectation(description: "storm throttled")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.75) {
+            // Fixed 150 ms throttling produces about five refreshes here. The
+            // storm path should produce the initial refresh plus one trailing.
+            XCTAssertLessThanOrEqual(count, 3)
             settled.fulfill()
         }
         wait(for: [settled], timeout: 1.5)

--- a/GlintTests/GitRefreshCoordinatorTests.swift
+++ b/GlintTests/GitRefreshCoordinatorTests.swift
@@ -110,6 +110,27 @@ final class GitRefreshCoordinatorTests: XCTestCase {
         wait(for: [trailing], timeout: 0.45)
     }
 
+    /// A command completing after watcher events must bypass an active storm
+    /// backoff once the base interval has elapsed.
+    func testCommandCompletionBypassesActiveWatcherStormBackoff() {
+        let coordinator = GitRefreshCoordinator(minInterval: 0.2)
+        let id = UUID()
+        let immediate = expectation(description: "immediate watcher refresh")
+        let command = expectation(description: "command refresh")
+
+        coordinator.request(id, source: .fileWatcher) { immediate.fulfill() }
+        wait(for: [immediate], timeout: 0.5)
+
+        coordinator.request(id, source: .fileWatcher) {}
+        coordinator.request(id, source: .fileWatcher) {}
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            coordinator.request(id, source: .commandFinished) { command.fulfill() }
+        }
+
+        // Active storm backoff would postpone this until roughly 0.8 seconds.
+        wait(for: [command], timeout: 0.5)
+    }
+
     /// Once the window has fully elapsed, the next request is immediate again
     /// (the throttle resets) and spawns no extra trailing refresh.
     func testRequestAfterWindowRunsImmediatelyWithoutTrailing() {

--- a/GlintTests/GitRefreshCoordinatorTests.swift
+++ b/GlintTests/GitRefreshCoordinatorTests.swift
@@ -21,7 +21,7 @@ final class GitRefreshCoordinatorTests: XCTestCase {
         let id = UUID()
         let ran = expectation(description: "immediate run")
 
-        coordinator.request(id) { ran.fulfill() }
+        coordinator.request(id, source: .commandFinished) { ran.fulfill() }
 
         // timeout < minInterval: a trailing path would still be pending here.
         wait(for: [ran], timeout: 0.15)
@@ -35,9 +35,9 @@ final class GitRefreshCoordinatorTests: XCTestCase {
         var count = 0
         let immediate = expectation(description: "immediate")
 
-        coordinator.request(id) { count += 1; immediate.fulfill() }
+        coordinator.request(id, source: .commandFinished) { count += 1; immediate.fulfill() }
         // The watcher follow-up within the window folds into one trailing run.
-        coordinator.request(id) { count += 1 }
+        coordinator.request(id, source: .fileWatcher) { count += 1 }
 
         wait(for: [immediate], timeout: 0.5)
         XCTAssertEqual(count, 1)
@@ -59,10 +59,10 @@ final class GitRefreshCoordinatorTests: XCTestCase {
         let id = UUID()
         var count = 0
 
-        coordinator.request(id) { count += 1 }
+        coordinator.request(id, source: .fileWatcher) { count += 1 }
         for offset in stride(from: 0.04, through: 0.52, by: 0.04) {
             DispatchQueue.main.asyncAfter(deadline: .now() + offset) {
-                coordinator.request(id) { count += 1 }
+                coordinator.request(id, source: .fileWatcher) { count += 1 }
             }
         }
 
@@ -76,6 +76,40 @@ final class GitRefreshCoordinatorTests: XCTestCase {
         wait(for: [settled], timeout: 1.5)
     }
 
+    /// Separate command completions are not evidence of filesystem churn, so
+    /// several quick commands must still refresh at the base interval.
+    func testRapidCommandCompletionsDoNotTriggerStormBackoff() {
+        let coordinator = GitRefreshCoordinator(minInterval: 0.2)
+        let id = UUID()
+        let immediate = expectation(description: "immediate")
+        let trailing = expectation(description: "base-interval trailing")
+
+        coordinator.request(id, source: .commandFinished) { immediate.fulfill() }
+        coordinator.request(id, source: .commandFinished) {}
+        coordinator.request(id, source: .commandFinished) { trailing.fulfill() }
+
+        wait(for: [immediate], timeout: 0.5)
+        // Storm backoff would postpone this until roughly 0.8 seconds.
+        wait(for: [trailing], timeout: 0.45)
+    }
+
+    /// A normal watcher follow-up between commands must not combine with the
+    /// commands to look like a filesystem storm.
+    func testCommandAndWatcherRequestsDoNotTriggerStormBackoff() {
+        let coordinator = GitRefreshCoordinator(minInterval: 0.2)
+        let id = UUID()
+        let immediate = expectation(description: "immediate")
+        let trailing = expectation(description: "base-interval trailing")
+
+        coordinator.request(id, source: .commandFinished) { immediate.fulfill() }
+        coordinator.request(id, source: .fileWatcher) {}
+        coordinator.request(id, source: .commandFinished) { trailing.fulfill() }
+
+        wait(for: [immediate], timeout: 0.5)
+        // Counting all three requests would postpone this to roughly 0.8 seconds.
+        wait(for: [trailing], timeout: 0.45)
+    }
+
     /// Once the window has fully elapsed, the next request is immediate again
     /// (the throttle resets) and spawns no extra trailing refresh.
     func testRequestAfterWindowRunsImmediatelyWithoutTrailing() {
@@ -84,13 +118,13 @@ final class GitRefreshCoordinatorTests: XCTestCase {
         var count = 0
         let first = expectation(description: "first")
 
-        coordinator.request(id) { count += 1; first.fulfill() }
+        coordinator.request(id, source: .commandFinished) { count += 1; first.fulfill() }
         wait(for: [first], timeout: 0.5)
 
         // Wait past the window so the next request is on the immediate path.
         let second = expectation(description: "second immediate")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) {
-            coordinator.request(id) { count += 1; second.fulfill() }
+            coordinator.request(id, source: .commandFinished) { count += 1; second.fulfill() }
         }
         wait(for: [second], timeout: 1.0)
         XCTAssertEqual(count, 2)
@@ -111,12 +145,12 @@ final class GitRefreshCoordinatorTests: XCTestCase {
         var count = 0
         let immediate = expectation(description: "immediate")
 
-        coordinator.request(id) { count += 1; immediate.fulfill() }
+        coordinator.request(id, source: .commandFinished) { count += 1; immediate.fulfill() }
         wait(for: [immediate], timeout: 0.5)
         XCTAssertEqual(count, 1)
 
         // Second request schedules a trailing; cancel it before it fires.
-        coordinator.request(id) { count += 1 }
+        coordinator.request(id, source: .commandFinished) { count += 1 }
         coordinator.cancel(id)
 
         let settled = expectation(description: "trailing never fired")
@@ -133,8 +167,8 @@ final class GitRefreshCoordinatorTests: XCTestCase {
         let a = expectation(description: "a")
         let b = expectation(description: "b")
 
-        coordinator.request(UUID()) { a.fulfill() }
-        coordinator.request(UUID()) { b.fulfill() }
+        coordinator.request(UUID(), source: .commandFinished) { a.fulfill() }
+        coordinator.request(UUID(), source: .commandFinished) { b.fulfill() }
 
         // Two different workspaces → both immediate, neither blocks the other.
         wait(for: [a, b], timeout: 0.3)


### PR DESCRIPTION
## 概要 / Summary

- 保留首次 Git 状态刷新立即执行，以及普通 command-finished + watcher 场景的一次尾随刷新。
- 当同一 workspace 在节流窗口内出现持续 FSEvents 风暴时，将尾随刷新从基础间隔退避到 4 倍，默认从 1.5 秒调整为 6 秒。
- 在刷新执行或取消时清理风暴计数与节流历史，避免旧状态影响后续刷新。
- 添加持续事件风暴回归测试，同时保留普通尾随刷新行为测试。

- Preserve the immediate Git status refresh and the normal single trailing refresh for a command-finished plus watcher pair.
- Back off the trailing refresh from the base interval to 4x, 6 seconds by default, when repeated FSEvents indicate sustained filesystem churn for one workspace.
- Clear storm counters and throttle history after dispatch or cancellation so stale state cannot affect later refreshes.
- Add regression coverage for sustained event storms while retaining coverage for normal trailing refresh behavior.

## 说明 / Note

最新 upstream/main 已通过 PR #84 排除 archived workspace 的 Git watcher 与 fallback polling，并包含对应回归测试，因此本 PR 不重复修改该逻辑。

The latest upstream/main already excludes archived workspaces from Git watchers and fallback polling via PR #84, with regression coverage, so this PR does not duplicate that change.

## 验证 / Verification

- xcodebuild Debug test on macOS
- 209 tests passed, 0 failures
- git diff --check passed