### PR TITLE
perf: reduce terminal refresh churn / 降低终端刷新开销

### DIFF
--- a/Glint/App/GlintApp.swift
+++ b/Glint/App/GlintApp.swift
@@ -54,6 +54,7 @@ struct GlintApp: App {
         Window("Glint", id: "glint-main") {
             ContentView()
                 .environmentObject(workspaceStore)
+                .environmentObject(workspaceStore.activity)
                 .environmentObject(updater)
                 .environmentObject(usage)
                 .environmentObject(codexHomes)

--- a/Glint/Chrome/ContentView.swift
+++ b/Glint/Chrome/ContentView.swift
@@ -738,6 +738,7 @@ private struct TabBarPlan: Equatable {
 /// (Safari-style). Active chips get a faint fill and an accent underline.
 private struct TabChip: View {
     @EnvironmentObject var store: WorkspaceStore
+    @EnvironmentObject private var activity: PaneActivityStore
     let ws: Workspace
     let tab: WorkspaceTab
     let isActive: Bool
@@ -1321,6 +1322,7 @@ private struct TabOverflowPopover: View {
 /// that swaps the breathing status dot for a close (×) on hover.
 private struct TabOverflowRow: View {
     @EnvironmentObject var store: WorkspaceStore
+    @EnvironmentObject private var activity: PaneActivityStore
     let ws: Workspace
     let tab: WorkspaceTab
     let onSelect: () -> Void
@@ -1632,6 +1634,7 @@ struct SparkShape: Shape {
 /// a chevron that animates between closed/open.
 private struct WorkspaceSwitcher: View {
     @EnvironmentObject var store: WorkspaceStore
+    @EnvironmentObject private var activity: PaneActivityStore
     @State private var isOpen = false
     @State private var hover = false
 
@@ -1682,6 +1685,7 @@ private struct WorkspaceSwitcher: View {
         .popover(isPresented: $isOpen, arrowEdge: .bottom) {
             WorkspaceSwitcherPopover { isOpen = false }
                 .environmentObject(store)
+                .environmentObject(activity)
         }
     }
 
@@ -1808,6 +1812,7 @@ private struct WorkspaceSwitcherPopover: View {
 
 private struct WorkspaceSwitcherRow: View {
     @EnvironmentObject var store: WorkspaceStore
+    @EnvironmentObject private var activity: PaneActivityStore
     let ws: Workspace
     let isCurrent: Bool
     let onSelect: () -> Void

--- a/Glint/Chrome/ContentView.swift
+++ b/Glint/Chrome/ContentView.swift
@@ -1170,6 +1170,7 @@ struct TabIcon: View {
 /// the workspace switcher's dropdown, with select-on-click and hover-close.
 private struct TabOverflowChip: View {
     @EnvironmentObject var store: WorkspaceStore
+    @EnvironmentObject private var activity: PaneActivityStore
     let ws: Workspace
     let tabs: [WorkspaceTab]
     @State private var isOpen = false
@@ -1202,6 +1203,7 @@ private struct TabOverflowChip: View {
         .popover(isPresented: $isOpen, arrowEdge: .bottom) {
             TabOverflowPopover(ws: ws, tabs: tabs) { isOpen = false }
                 .environmentObject(store)
+                .environmentObject(activity)
         }
     }
 

--- a/Glint/Chrome/SidebarView.swift
+++ b/Glint/Chrome/SidebarView.swift
@@ -5,6 +5,7 @@ import UniformTypeIdentifiers
 
 struct SidebarView: View {
     @EnvironmentObject var store: WorkspaceStore
+    @EnvironmentObject private var activity: PaneActivityStore
     @EnvironmentObject var usage: UsageStore
     @State private var searchText: String = ""
     @FocusState private var searchFocused: Bool
@@ -608,6 +609,7 @@ private struct CardFrameKey: PreferenceKey {
 
 private struct WorkspaceCard: View {
     @EnvironmentObject var store: WorkspaceStore
+    @EnvironmentObject private var activity: PaneActivityStore
     /// System "Reduce Motion" — when on, the looping decorations (border
     /// glow, pulsing dots/borders, mascot animation) render as static states.
     @Environment(\.accessibilityReduceMotion) private var reduceMotion

--- a/Glint/Ghostty/GhosttyManager.swift
+++ b/Glint/Ghostty/GhosttyManager.swift
@@ -172,11 +172,33 @@ final class GhosttyManager {
     /// IOSurfaceLayer and the pane container so the two can't diverge — clear +
     /// non-opaque when translucent, theme-bg + opaque otherwise.
     func applyTerminalBacking(to layer: CALayer?) {
-        guard let layer else { return }
-        let transparent = terminalIsTransparent
-        layer.isOpaque = !transparent
-        layer.backgroundColor = transparent ? NSColor.clear.cgColor
-                                            : currentBackgroundColor.cgColor
+        Self.applyTerminalBacking(
+            to: layer,
+            transparent: terminalIsTransparent,
+            opaqueBackgroundColor: currentBackgroundColor.cgColor
+        )
+    }
+
+    /// Diff-based backing update used by the high-frequency representable
+    /// refresh path. Returns whether the layer actually changed.
+    @discardableResult
+    static func applyTerminalBacking(to layer: CALayer?,
+                                     transparent: Bool,
+                                     opaqueBackgroundColor: CGColor) -> Bool {
+        guard let layer else { return false }
+        let desiredOpaque = !transparent
+        let desiredBackground = transparent ? NSColor.clear.cgColor : opaqueBackgroundColor
+        var changed = false
+
+        if layer.isOpaque != desiredOpaque {
+            layer.isOpaque = desiredOpaque
+            changed = true
+        }
+        if layer.backgroundColor.map({ !CFEqual($0, desiredBackground) }) ?? true {
+            layer.backgroundColor = desiredBackground
+            changed = true
+        }
+        return changed
     }
 
     /// Ask ghostty to install the NSVisualEffectView-backed window blur. This

--- a/Glint/Git/GitRefreshCoordinator.swift
+++ b/Glint/Git/GitRefreshCoordinator.swift
@@ -11,16 +11,19 @@ import Foundation
 /// one `git commit` spawned two subprocesses. This coordinator closes that gap:
 /// once a refresh has been dispatched for a workspace, further refreshes
 /// requested within `minInterval` coalesce into ONE trailing refresh at the
-/// interval boundary. A sustained storm (build, rebase, checkout) thus
-/// refreshes at most once per `minInterval`, never zero — the trailing refresh
-/// always runs, so a genuine change can't be dropped while the storm throttles.
+/// interval boundary. A second coalesced request indicates a sustained storm
+/// (build, rebase, checkout), so the trailing refresh backs off to four times
+/// the base interval. The trailing refresh still always runs, so a genuine
+/// change can't be dropped while the storm throttles.
 ///
 /// Only the push-based event channels route through here. Pull-based refreshes
 /// (workspace/pane switch, popover open, the active-only fallback timer) call
 /// `refreshGitStatus` / `refreshGitStatusNow` directly and stay immediate.
 final class GitRefreshCoordinator {
     private let minInterval: TimeInterval
+    private let stormInterval: TimeInterval
     private let queue = DispatchQueue(label: "app.glint.git-refresh")
+    private static let stormThreshold = 2
     /// Last time a refresh for this workspace was actually dispatched (immediate
     /// path, or a trailing fire). The elapsed-since guard is what folds a
     /// trailing FSEvents callback back into the refresh the command-finished
@@ -29,9 +32,14 @@ final class GitRefreshCoordinator {
     /// One in-flight trailing work item per workspace, so a fresher request can
     /// cancel a not-yet-fired trailing refresh and replace it.
     private var pending: [UUID: DispatchWorkItem] = [:]
+    /// Requests coalesced since the last actual dispatch. A normal shell
+    /// command produces one watcher follow-up; several follow-ups in the same
+    /// window mean filesystem churn rather than one logical command.
+    private var coalescedRequestCount: [UUID: Int] = [:]
 
     init(minInterval: TimeInterval = 1.5) {
         self.minInterval = minInterval
+        self.stormInterval = minInterval * 4
     }
 
     /// Request a refresh of `id`. `run` runs on the main actor immediately when
@@ -44,15 +52,24 @@ final class GitRefreshCoordinator {
             pending[id]?.cancel()
             let now = Date()
             let elapsed = lastDispatch[id].map { now.timeIntervalSince($0) } ?? .infinity
-            if elapsed >= minInterval {
+            let currentCount = coalescedRequestCount[id] ?? 0
+            let currentInterval = currentCount >= Self.stormThreshold
+                ? stormInterval : minInterval
+            if elapsed >= currentInterval {
                 lastDispatch[id] = now
                 pending[id] = nil
+                coalescedRequestCount[id] = 0
                 DispatchQueue.main.async(execute: run)
             } else {
-                let delay = minInterval - elapsed
+                let nextCount = currentCount + 1
+                coalescedRequestCount[id] = nextCount
+                let targetInterval = nextCount >= Self.stormThreshold
+                    ? stormInterval : minInterval
+                let delay = targetInterval - elapsed
                 let item = DispatchWorkItem { [self] in
                     lastDispatch[id] = Date()
                     pending[id] = nil
+                    coalescedRequestCount[id] = 0
                     DispatchQueue.main.async(execute: run)
                 }
                 pending[id] = item
@@ -61,12 +78,15 @@ final class GitRefreshCoordinator {
         }
     }
 
-    /// Drop any not-yet-fired trailing refresh for `id` (e.g. its workspace was
-    /// removed). Does not affect a refresh already dispatched to the main queue.
+    /// Drop any not-yet-fired trailing refresh and throttle history for `id`
+    /// (e.g. its workspace was archived or removed). Does not affect a refresh
+    /// already dispatched to the main queue.
     func cancel(_ id: UUID) {
         queue.async { [self] in
             pending[id]?.cancel()
             pending[id] = nil
+            lastDispatch[id] = nil
+            coalescedRequestCount[id] = nil
         }
     }
 }

--- a/Glint/Git/GitRefreshCoordinator.swift
+++ b/Glint/Git/GitRefreshCoordinator.swift
@@ -11,15 +11,20 @@ import Foundation
 /// one `git commit` spawned two subprocesses. This coordinator closes that gap:
 /// once a refresh has been dispatched for a workspace, further refreshes
 /// requested within `minInterval` coalesce into ONE trailing refresh at the
-/// interval boundary. A second coalesced request indicates a sustained storm
-/// (build, rebase, checkout), so the trailing refresh backs off to four times
-/// the base interval. The trailing refresh still always runs, so a genuine
-/// change can't be dropped while the storm throttles.
+/// interval boundary. A second coalesced watcher request indicates a sustained
+/// filesystem storm (build, rebase, checkout), so the trailing refresh backs
+/// off to four times the base interval. The trailing refresh still always runs,
+/// so a genuine change can't be dropped while the storm throttles.
 ///
 /// Only the push-based event channels route through here. Pull-based refreshes
 /// (workspace/pane switch, popover open, the active-only fallback timer) call
 /// `refreshGitStatus` / `refreshGitStatusNow` directly and stay immediate.
 final class GitRefreshCoordinator {
+    enum Source {
+        case commandFinished
+        case fileWatcher
+    }
+
     private let minInterval: TimeInterval
     private let stormInterval: TimeInterval
     private let queue = DispatchQueue(label: "app.glint.git-refresh")
@@ -35,7 +40,7 @@ final class GitRefreshCoordinator {
     /// Requests coalesced since the last actual dispatch. A normal shell
     /// command produces one watcher follow-up; several follow-ups in the same
     /// window mean filesystem churn rather than one logical command.
-    private var coalescedRequestCount: [UUID: Int] = [:]
+    private var coalescedWatcherRequestCount: [UUID: Int] = [:]
 
     init(minInterval: TimeInterval = 1.5) {
         self.minInterval = minInterval
@@ -47,29 +52,29 @@ final class GitRefreshCoordinator {
     /// once at the interval boundary. Repeated requests within the window
     /// coalesce: a fresher request cancels any not-yet-fired trailing refresh
     /// and replaces it, so only the most recent request's `run` survives.
-    func request(_ id: UUID, run: @escaping () -> Void) {
+    func request(_ id: UUID, source: Source, run: @escaping () -> Void) {
         queue.async { [self] in
             pending[id]?.cancel()
             let now = Date()
             let elapsed = lastDispatch[id].map { now.timeIntervalSince($0) } ?? .infinity
-            let currentCount = coalescedRequestCount[id] ?? 0
+            let currentCount = coalescedWatcherRequestCount[id] ?? 0
             let currentInterval = currentCount >= Self.stormThreshold
                 ? stormInterval : minInterval
             if elapsed >= currentInterval {
                 lastDispatch[id] = now
                 pending[id] = nil
-                coalescedRequestCount[id] = 0
+                coalescedWatcherRequestCount[id] = 0
                 DispatchQueue.main.async(execute: run)
             } else {
-                let nextCount = currentCount + 1
-                coalescedRequestCount[id] = nextCount
+                let nextCount = currentCount + (source == .fileWatcher ? 1 : 0)
+                coalescedWatcherRequestCount[id] = nextCount
                 let targetInterval = nextCount >= Self.stormThreshold
                     ? stormInterval : minInterval
                 let delay = targetInterval - elapsed
                 let item = DispatchWorkItem { [self] in
                     lastDispatch[id] = Date()
                     pending[id] = nil
-                    coalescedRequestCount[id] = 0
+                    coalescedWatcherRequestCount[id] = 0
                     DispatchQueue.main.async(execute: run)
                 }
                 pending[id] = item
@@ -86,7 +91,7 @@ final class GitRefreshCoordinator {
             pending[id]?.cancel()
             pending[id] = nil
             lastDispatch[id] = nil
-            coalescedRequestCount[id] = nil
+            coalescedWatcherRequestCount[id] = nil
         }
     }
 }

--- a/Glint/Pane/GhosttySurfaceView.swift
+++ b/Glint/Pane/GhosttySurfaceView.swift
@@ -3,6 +3,23 @@ import Darwin
 import QuartzCore
 import GhosttyKit
 
+/// Tracks the last focus state sent across the Ghostty C boundary. SwiftUI can
+/// re-run `updateNSView` for unrelated sidebar changes, so identical focus
+/// values must be a no-op instead of waking the renderer each time.
+struct SurfaceFocusUpdateGate {
+    private var lastApplied: Bool?
+
+    mutating func shouldApply(_ focused: Bool) -> Bool {
+        guard lastApplied != focused else { return false }
+        lastApplied = focused
+        return true
+    }
+
+    mutating func reset() {
+        lastApplied = nil
+    }
+}
+
 /// AppKit view hosting one `ghostty_surface_t`.
 ///
 /// We give ghostty an `NSView*` via `ghostty_surface_config_s.platform.macos.nsview`.
@@ -17,6 +34,7 @@ import GhosttyKit
 final class GhosttySurfaceView: NSView, NSTextInputClient {
 
     private var surface: ghostty_surface_t?
+    private var focusUpdateGate = SurfaceFocusUpdateGate()
     private var trackingArea: NSTrackingArea?
     private var markedTextValue: NSAttributedString = NSAttributedString(string: "")
     /// While non-nil, `insertText`/`doCommand(by:)` divert into this buffer
@@ -366,6 +384,7 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
             return
         }
         self.surface = s
+        focusUpdateGate.reset()
         // ghostty just swapped in its IOSurfaceLayer — re-stamp the
         // opaque/clear backing onto the NEW layer (init's settings were on the
         // discarded placeholder layer).
@@ -1128,20 +1147,20 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
 
     override func becomeFirstResponder() -> Bool {
         let ok = super.becomeFirstResponder()
-        if let s = surface { ghostty_surface_set_focus(s, true) }
+        setGhosttyFocus(true)
         return ok
     }
 
     override func resignFirstResponder() -> Bool {
         let ok = super.resignFirstResponder()
-        if let s = surface { ghostty_surface_set_focus(s, false) }
+        setGhosttyFocus(false)
         return ok
     }
 
     /// Explicit focus sync — splits / SwiftUI rebuilds don't always route
     /// firstResponder cleanly, so the SwiftUI layer pokes us directly.
     func setGhosttyFocus(_ flag: Bool) {
-        guard let s = surface else { return }
+        guard let s = surface, focusUpdateGate.shouldApply(flag) else { return }
         ghostty_surface_set_focus(s, flag)
     }
 

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -1529,7 +1529,7 @@ final class WorkspaceStore: ObservableObject {
                 // callback that follows this same change ~0.5s later doesn't
                 // spawn a second `git status` (the in-flight gate only merges
                 // runs that overlap in time; a fast git finishes first).
-                self.gitRefreshCoordinator.request(wsID) { [weak self] in
+                self.gitRefreshCoordinator.request(wsID, source: .commandFinished) { [weak self] in
                     self?.refreshGitStatusNow(for: wsID)
                 }
             }
@@ -3498,7 +3498,7 @@ final class WorkspaceStore: ObservableObject {
             let paths = GitRepositoryWatcher.watchPaths(for: path)
             let watcher = GitRepositoryWatcher(paths: paths) { [weak self] in
                 guard NSApp.isActive else { return }
-                self?.gitRefreshCoordinator.request(id) { [weak self] in
+                self?.gitRefreshCoordinator.request(id, source: .fileWatcher) { [weak self] in
                     self?.refreshGitStatusNow(for: id)
                 }
             }

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -515,14 +515,24 @@ final class WorkspaceStore: ObservableObject {
     @Published var workspaces: [Workspace]
     @Published var selectedWorkspaceID: UUID?
     @Published var sidebarCollapsed: Bool
+    /// High-frequency, non-persistent pane state is published separately so
+    /// agent hooks and foreground-process changes don't invalidate every view
+    /// that observes the workspace model (including the terminal subtree).
+    let activity: PaneActivityStore
     /// Latest foreground-process name per (workspace, pane). Event-driven with
     /// a slow fallback capture; drives the workspace card icon. Non-persistent.
-    @Published var paneProcesses: [WorkspacePaneKey: String] = [:]
+    var paneProcesses: [WorkspacePaneKey: String] {
+        get { activity.paneProcesses }
+        set { activity.paneProcesses = newValue }
+    }
     /// CLI-agent state per pane (push-driven via AgentBridge hooks).
     /// Beats `paneProcesses` for icon/state because hooks carry live
     /// status (thinking/permission/…) a process-name capture can't know.
     /// Non-persistent.
-    @Published var paneAgentState: [WorkspacePaneKey: PaneAgentState] = [:]
+    var paneAgentState: [WorkspacePaneKey: PaneAgentState] {
+        get { activity.paneAgentState }
+        set { activity.paneAgentState = newValue }
+    }
 
     /// Drives the command-palette overlay. Toggled by the toolbar's ⌘
     /// button and the ⌘⇧P global shortcut. Mutually exclusive with the agent
@@ -1378,7 +1388,12 @@ final class WorkspaceStore: ObservableObject {
     /// created by GlintApp as a @StateObject).
     static private(set) weak var current: WorkspaceStore?
 
-    init() {
+    convenience init() {
+        self.init(activity: PaneActivityStore())
+    }
+
+    init(activity: PaneActivityStore) {
+        self.activity = activity
         let loaded = Persistence.load() ?? PersistedState.fresh
         self.workspaces = loaded.workspaces
         let shouldRestore = (UserDefaults.standard.object(forKey: "glint.restoreLastWorkspace") as? Bool) ?? true
@@ -3744,6 +3759,12 @@ enum AppIconPreset: String, CaseIterable, Identifiable {
         case .graphite: return "石墨"
         }
     }
+}
+
+@MainActor
+final class PaneActivityStore: ObservableObject {
+    @Published var paneProcesses: [WorkspaceStore.WorkspacePaneKey: String] = [:]
+    @Published var paneAgentState: [WorkspaceStore.WorkspacePaneKey: PaneAgentState] = [:]
 }
 
 extension WorkspaceStore {

--- a/GlintTests/GitRefreshCoordinatorTests.swift
+++ b/GlintTests/GitRefreshCoordinatorTests.swift
@@ -36,8 +36,7 @@ final class GitRefreshCoordinatorTests: XCTestCase {
         let immediate = expectation(description: "immediate")
 
         coordinator.request(id) { count += 1; immediate.fulfill() }
-        // Two more within the window — both must fold into the single trailing.
-        coordinator.request(id) { count += 1 }
+        // The watcher follow-up within the window folds into one trailing run.
         coordinator.request(id) { count += 1 }
 
         wait(for: [immediate], timeout: 0.5)
@@ -47,6 +46,31 @@ final class GitRefreshCoordinatorTests: XCTestCase {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
             // immediate + exactly one trailing
             XCTAssertEqual(count, 2)
+            settled.fulfill()
+        }
+        wait(for: [settled], timeout: 1.5)
+    }
+
+    /// A build/rebase can keep FSEvents busy for seconds. Once the burst is
+    /// clearly larger than the normal command-finished + watcher pair, refresh
+    /// less often instead of spawning one git process pair every base window.
+    func testSustainedStormBacksOffBeyondBaseInterval() {
+        let coordinator = GitRefreshCoordinator(minInterval: 0.15)
+        let id = UUID()
+        var count = 0
+
+        coordinator.request(id) { count += 1 }
+        for offset in stride(from: 0.04, through: 0.52, by: 0.04) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + offset) {
+                coordinator.request(id) { count += 1 }
+            }
+        }
+
+        let settled = expectation(description: "storm throttled")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.75) {
+            // Fixed 150 ms throttling produces about five refreshes here. The
+            // storm path should produce the initial refresh plus one trailing.
+            XCTAssertLessThanOrEqual(count, 3)
             settled.fulfill()
         }
         wait(for: [settled], timeout: 1.5)

--- a/GlintTests/GitRefreshCoordinatorTests.swift
+++ b/GlintTests/GitRefreshCoordinatorTests.swift
@@ -21,7 +21,7 @@ final class GitRefreshCoordinatorTests: XCTestCase {
         let id = UUID()
         let ran = expectation(description: "immediate run")
 
-        coordinator.request(id) { ran.fulfill() }
+        coordinator.request(id, source: .commandFinished) { ran.fulfill() }
 
         // timeout < minInterval: a trailing path would still be pending here.
         wait(for: [ran], timeout: 0.15)
@@ -35,9 +35,9 @@ final class GitRefreshCoordinatorTests: XCTestCase {
         var count = 0
         let immediate = expectation(description: "immediate")
 
-        coordinator.request(id) { count += 1; immediate.fulfill() }
+        coordinator.request(id, source: .commandFinished) { count += 1; immediate.fulfill() }
         // The watcher follow-up within the window folds into one trailing run.
-        coordinator.request(id) { count += 1 }
+        coordinator.request(id, source: .fileWatcher) { count += 1 }
 
         wait(for: [immediate], timeout: 0.5)
         XCTAssertEqual(count, 1)
@@ -59,10 +59,10 @@ final class GitRefreshCoordinatorTests: XCTestCase {
         let id = UUID()
         var count = 0
 
-        coordinator.request(id) { count += 1 }
+        coordinator.request(id, source: .fileWatcher) { count += 1 }
         for offset in stride(from: 0.04, through: 0.52, by: 0.04) {
             DispatchQueue.main.asyncAfter(deadline: .now() + offset) {
-                coordinator.request(id) { count += 1 }
+                coordinator.request(id, source: .fileWatcher) { count += 1 }
             }
         }
 
@@ -76,6 +76,40 @@ final class GitRefreshCoordinatorTests: XCTestCase {
         wait(for: [settled], timeout: 1.5)
     }
 
+    /// Separate command completions are not evidence of filesystem churn, so
+    /// several quick commands must still refresh at the base interval.
+    func testRapidCommandCompletionsDoNotTriggerStormBackoff() {
+        let coordinator = GitRefreshCoordinator(minInterval: 0.2)
+        let id = UUID()
+        let immediate = expectation(description: "immediate")
+        let trailing = expectation(description: "base-interval trailing")
+
+        coordinator.request(id, source: .commandFinished) { immediate.fulfill() }
+        coordinator.request(id, source: .commandFinished) {}
+        coordinator.request(id, source: .commandFinished) { trailing.fulfill() }
+
+        wait(for: [immediate], timeout: 0.5)
+        // Storm backoff would postpone this until roughly 0.8 seconds.
+        wait(for: [trailing], timeout: 0.45)
+    }
+
+    /// A normal watcher follow-up between commands must not combine with the
+    /// commands to look like a filesystem storm.
+    func testCommandAndWatcherRequestsDoNotTriggerStormBackoff() {
+        let coordinator = GitRefreshCoordinator(minInterval: 0.2)
+        let id = UUID()
+        let immediate = expectation(description: "immediate")
+        let trailing = expectation(description: "base-interval trailing")
+
+        coordinator.request(id, source: .commandFinished) { immediate.fulfill() }
+        coordinator.request(id, source: .fileWatcher) {}
+        coordinator.request(id, source: .commandFinished) { trailing.fulfill() }
+
+        wait(for: [immediate], timeout: 0.5)
+        // Counting all three requests would postpone this to roughly 0.8 seconds.
+        wait(for: [trailing], timeout: 0.45)
+    }
+
     /// Once the window has fully elapsed, the next request is immediate again
     /// (the throttle resets) and spawns no extra trailing refresh.
     func testRequestAfterWindowRunsImmediatelyWithoutTrailing() {
@@ -84,13 +118,13 @@ final class GitRefreshCoordinatorTests: XCTestCase {
         var count = 0
         let first = expectation(description: "first")
 
-        coordinator.request(id) { count += 1; first.fulfill() }
+        coordinator.request(id, source: .commandFinished) { count += 1; first.fulfill() }
         wait(for: [first], timeout: 0.5)
 
         // Wait past the window so the next request is on the immediate path.
         let second = expectation(description: "second immediate")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) {
-            coordinator.request(id) { count += 1; second.fulfill() }
+            coordinator.request(id, source: .commandFinished) { count += 1; second.fulfill() }
         }
         wait(for: [second], timeout: 1.0)
         XCTAssertEqual(count, 2)
@@ -111,12 +145,12 @@ final class GitRefreshCoordinatorTests: XCTestCase {
         var count = 0
         let immediate = expectation(description: "immediate")
 
-        coordinator.request(id) { count += 1; immediate.fulfill() }
+        coordinator.request(id, source: .commandFinished) { count += 1; immediate.fulfill() }
         wait(for: [immediate], timeout: 0.5)
         XCTAssertEqual(count, 1)
 
         // Second request schedules a trailing; cancel it before it fires.
-        coordinator.request(id) { count += 1 }
+        coordinator.request(id, source: .commandFinished) { count += 1 }
         coordinator.cancel(id)
 
         let settled = expectation(description: "trailing never fired")
@@ -133,8 +167,8 @@ final class GitRefreshCoordinatorTests: XCTestCase {
         let a = expectation(description: "a")
         let b = expectation(description: "b")
 
-        coordinator.request(UUID()) { a.fulfill() }
-        coordinator.request(UUID()) { b.fulfill() }
+        coordinator.request(UUID(), source: .commandFinished) { a.fulfill() }
+        coordinator.request(UUID(), source: .commandFinished) { b.fulfill() }
 
         // Two different workspaces → both immediate, neither blocks the other.
         wait(for: [a, b], timeout: 0.3)

--- a/GlintTests/PerformanceRegressionTests.swift
+++ b/GlintTests/PerformanceRegressionTests.swift
@@ -1,4 +1,6 @@
 import XCTest
+import Combine
+import QuartzCore
 @testable import Glint
 
 @MainActor
@@ -64,5 +66,50 @@ final class PerformanceRegressionTests: XCTestCase {
             XCTFail("Expected CancellationError, got \(error)")
         }
         XCTAssertLessThan(started.duration(to: clock.now), .seconds(1))
+    }
+
+    func testSurfaceFocusGateSuppressesDuplicateUpdates() {
+        var gate = SurfaceFocusUpdateGate()
+
+        XCTAssertTrue(gate.shouldApply(true))
+        XCTAssertFalse(gate.shouldApply(true))
+        XCTAssertTrue(gate.shouldApply(false))
+        XCTAssertFalse(gate.shouldApply(false))
+
+        gate.reset()
+        XCTAssertTrue(gate.shouldApply(false))
+    }
+
+    func testTerminalBackingSkipsIdenticalLayerWrites() {
+        let layer = CALayer()
+        let background = CGColor(red: 0.1, green: 0.2, blue: 0.3, alpha: 1)
+
+        XCTAssertTrue(GhosttyManager.applyTerminalBacking(
+            to: layer, transparent: false, opaqueBackgroundColor: background
+        ))
+        XCTAssertFalse(GhosttyManager.applyTerminalBacking(
+            to: layer, transparent: false, opaqueBackgroundColor: background
+        ))
+        XCTAssertTrue(GhosttyManager.applyTerminalBacking(
+            to: layer, transparent: true, opaqueBackgroundColor: background
+        ))
+        XCTAssertFalse(layer.isOpaque)
+    }
+
+    func testPaneActivityDoesNotPublishWorkspaceStore() {
+        let activity = PaneActivityStore()
+        let store = WorkspaceStore(activity: activity)
+        let key = WorkspaceStore.WorkspacePaneKey(workspace: UUID(), pane: PaneID(value: 0))
+        var workspacePublishes = 0
+        var activityPublishes = 0
+        let workspaceCancellable = store.objectWillChange.sink { workspacePublishes += 1 }
+        let activityCancellable = activity.objectWillChange.sink { activityPublishes += 1 }
+
+        store.paneProcesses[key] = "zsh"
+
+        XCTAssertEqual(store.paneProcesses[key], "zsh")
+        XCTAssertEqual(activityPublishes, 1)
+        XCTAssertEqual(workspacePublishes, 0)
+        withExtendedLifetime((workspaceCancellable, activityCancellable)) {}
     }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> 依赖 #88。本 PR 当前为 Draft，必须等待 #88 合并后 rebase 到最新 upstream/main、重新验证并移除 Draft 状态，才能合并。
>
> Depends on #88. This PR is intentionally a draft. It must be rebased onto the latest upstream/main, revalidated, and marked ready only after #88 is merged.

## 变更内容 / Summary

中文：

- 缓存最近一次下发给 Ghostty 的焦点状态，相同状态不再重复跨 Swift/C 边界调用。
- 将终端宿主 CALayer 的 opaque/backgroundColor 更新改为差异写入；配置未变化时不再重复触发图层属性写入。
- 将高频、非持久化的 paneProcesses 和 paneAgentState 从 WorkspaceStore 的发布链拆到独立 PaneActivityStore。
- 仅让侧边栏、Tab 状态和工作区切换器观察 PaneActivityStore，Agent hook/前台进程变化不再广播整个 WorkspaceStore，也不会因此使终端视图树失效。
- 增加 Focus 去重、Layer 差异更新和 Activity 发布边界的回归测试。

English:

- Cache the last focus state sent to Ghostty so identical values no longer cross the Swift/C boundary repeatedly.
- Make terminal-host CALayer opaque/backgroundColor updates diff-based, avoiding redundant property writes when the configuration is unchanged.
- Move high-frequency, non-persistent paneProcesses and paneAgentState updates out of the WorkspaceStore publication chain into a dedicated PaneActivityStore.
- Observe PaneActivityStore only from the sidebar, tab-status, and workspace-switcher views. Agent hooks and foreground-process changes no longer broadcast through WorkspaceStore or invalidate the terminal view tree through that store.
- Add regression coverage for focus deduplication, layer diffing, and the activity publication boundary.

## 性能量化 / Performance quantification

以下数字是可由代码路径和回归测试验证的操作数/静态 fan-out 缩减，不是 Instruments 或整机功耗百分比；避免把微观调用缩减误写成未经测量的电池续航提升。

The figures below quantify code-path operations and static observer fan-out. They are not Instruments measurements or whole-system battery percentages, so they should not be interpreted as an unmeasured battery-life claim.

- 稳态重复 Focus：连续 N 次相同焦点同步由 N 次 Ghostty C 调用降为 1 次。N = 100,000 时，重复调用减少 99.999%。
  Identical steady-state focus syncs drop from N Ghostty C calls to 1. At N = 100,000, redundant calls are reduced by 99.999%.
- 稳态 Layer 配置：每轮 2 次属性写入由 2N 次降为首次最多 2 次。N = 100,000 时，重复属性写入减少 99.999%。
  Identical layer configuration drops from 2N property writes to at most 2 initial writes. At N = 100,000, redundant property writes are reduced by 99.999%.
- Pane 活动更新：每次事件对 WorkspaceStore.objectWillChange 的发布由 1 次降为 0 次，针对这类事件消除 100% 的全局 Store 广播。
  Pane activity updates reduce WorkspaceStore.objectWillChange emissions from 1 per event to 0, eliminating 100% of global store broadcasts for this event class.
- 源码级观察范围由 41 个 WorkspaceStore 环境观察声明收窄到 6 个 PaneActivityStore 观察声明，静态 fan-out 范围缩小 85.4%。实际运行时收益取决于当时挂载的视图和 Agent 活跃度。
  The source-level observer scope narrows from 41 WorkspaceStore environment-observer declarations to 6 PaneActivityStore observer declarations, an 85.4% reduction in static fan-out. Runtime gains depend on the mounted views and agent activity.

## 验证方式 / Testing

- 定向性能回归测试：7 tests, 0 failures。
  Targeted performance regression suite: 7 tests, 0 failures.
- 完整测试：214 tests, 0 failures。
  Full test suite: 214 tests, 0 failures.
- git diff --check 通过。
  git diff --check passes.
- 已启动 Debug 构建用于手动 smoke test。
  Launched the Debug build for a manual smoke test.

## 截图或录屏 / Screenshots or recordings

无视觉变化。

No visual changes.

## 依赖与合并顺序 / Dependency and merge order

- Depends on #88.
- 当前分支直接建立在 #88 的 head ea170ed 之上，因此 Draft diff 暂时也包含 #88 的提交。
  This branch is based directly on #88 head ea170ed, so the draft diff temporarily includes the #88 commits as ancestry.
- #88 合并后：fetch upstream/main → rebase → force-push → 重跑完整测试 → 确认只剩本 PR 的 7 文件 → 标记 Ready。
  After #88 merges: fetch upstream/main → rebase → force-push → rerun the full suite → confirm only this PR's 7 files remain → mark ready.

## 关联议题 / Related issues

Depends on #88.
