### PR TITLE
fix: prevent stale terminal surface repins on workspace switch

### DIFF
--- a/Glint/Pane/PaneSurfaceRepresentable.swift
+++ b/Glint/Pane/PaneSurfaceRepresentable.swift
@@ -1,6 +1,14 @@
 import SwiftUI
 import AppKit
 
+enum SurfaceReassertionPolicy {
+    static func shouldReassert(containerIsAttached: Bool,
+                               expectedSurfaceMatches: Bool,
+                               paneIsVisible: Bool) -> Bool {
+        containerIsAttached && expectedSurfaceMatches && paneIsVisible
+    }
+}
+
 /// Hosts a stable, store-owned `GhosttySurfaceView` inside a fresh container
 /// NSView. SwiftUI may rebuild the container any time the split tree reshapes;
 /// the surface itself outlives that and just re-parents.
@@ -15,6 +23,9 @@ struct PaneSurfaceRepresentable: NSViewRepresentable {
     /// updateNSView re-runs ~1/s, and re-grabbing the terminal surface here
     /// races the palette's search field and yanks focus back off it.
     let deferFocus: Bool
+    /// Evaluated inside the deferred re-pin, not when SwiftUI builds the view:
+    /// workspace/tab selection may change before that callback runs.
+    let isPaneVisible: () -> Bool
 
     func makeNSView(context: Context) -> NoDragContainerView {
         let container = NoDragContainerView()
@@ -131,10 +142,15 @@ struct PaneSurfaceRepresentable: NSViewRepresentable {
         // re-parenting the surface into a container that's torn down moments
         // later, leaving the live pane blank. Containers that survive the
         // commit re-assert their claim right after it; dismantled ones are out
-        // of the window by then and bail.
+        // of the window by then and bail. A recycled container can still be in
+        // the window after a workspace/tab switch, so also verify that this
+        // surface's pane is the one currently visible.
         DispatchQueue.main.async {
-            guard container.window != nil,
-                  container.expectedSurface === surface else { return }
+            guard SurfaceReassertionPolicy.shouldReassert(
+                containerIsAttached: container.window != nil,
+                expectedSurfaceMatches: container.expectedSurface === surface,
+                paneIsVisible: isPaneVisible()
+            ) else { return }
             Self.pin(surface, in: container)
         }
     }

--- a/Glint/Pane/PaneView.swift
+++ b/Glint/Pane/PaneView.swift
@@ -57,7 +57,12 @@ struct PaneView: View {
             PaneSurfaceRepresentable(
                 surfaceView: store.surfaceView(workspaceID: workspaceID, paneID: paneID, cwd: cwd),
                 focused: isFocused,
-                deferFocus: store.commandPaletteOpen || store.agentChooserIntent != nil
+                deferFocus: store.commandPaletteOpen || store.agentChooserIntent != nil,
+                isPaneVisible: {
+                    guard store.selectedWorkspaceID == workspaceID,
+                          let tab = store.selectedWorkspace?.selectedTab else { return false }
+                    return tab.root.leaves.contains(paneID)
+                }
             )
             if !isFocused {
                 // Use a black wash so translucent panes stay translucent; tune

--- a/GlintTests/PerformanceRegressionTests.swift
+++ b/GlintTests/PerformanceRegressionTests.swift
@@ -145,6 +145,19 @@ final class PerformanceRegressionTests: XCTestCase {
         ))
     }
 
+    func testDelayedSurfaceReassertRejectsPaneAfterWorkspaceSwitch() {
+        XCTAssertTrue(SurfaceReassertionPolicy.shouldReassert(
+            containerIsAttached: true,
+            expectedSurfaceMatches: true,
+            paneIsVisible: true
+        ))
+        XCTAssertFalse(SurfaceReassertionPolicy.shouldReassert(
+            containerIsAttached: true,
+            expectedSurfaceMatches: true,
+            paneIsVisible: false
+        ))
+    }
+
     func testBackgroundWorkspaceFirstResponderDoesNotPauseIdleClock() {
         XCTAssertTrue(TerminalFocusPolicy.protectsFromIdleOfflining(
             appIsActive: true,


### PR DESCRIPTION
## 变更内容 / Summary

- 延迟 re-pin 在执行时重新确认 pane 仍属于当前 workspace 的当前 tab。
- 阻止已退出的 SwiftUI representable 把旧 terminal surface 重新挂进复用的可见容器。
- 增加 workspace 切换后的 stale re-pin 回归测试。

## 验证方式 / Testing

- 回归测试已确认旧策略失败、修复后通过。
- 完整 macOS 测试：250 tests，0 failures。
- Dev 实测：3 个 workspace 连续 100 轮、300 次切换；581 次 stale re-pin 回调被拦截，应用保持可用且无崩溃。

## 截图或录屏 / Screenshots or recordings

不适用（无 UI 样式变化）。

## 关联议题 / Related issues

无。
