### PR TITLE
fix: prevent terminal white flash when closing a split

### DIFF
--- a/Glint/Pane/PaneSurfaceRepresentable.swift
+++ b/Glint/Pane/PaneSurfaceRepresentable.swift
@@ -17,6 +17,17 @@ enum SurfaceHostClaimPolicy {
                             isSameHost: Bool) -> Bool {
         isSameHost || !currentHostIsAttached || candidateGeneration >= currentGeneration
     }
+
+    static func shouldDeferUntilAfterCommit(candidateGeneration: UInt64,
+                                            currentGeneration: UInt64,
+                                            currentHostExists: Bool,
+                                            currentHostIsAttached: Bool,
+                                            isSameHost: Bool) -> Bool {
+        !isSameHost &&
+            currentHostExists &&
+            !currentHostIsAttached &&
+            candidateGeneration < currentGeneration
+    }
 }
 
 /// Hosts a stable, store-owned `GhosttySurfaceView` inside a fresh container
@@ -145,14 +156,38 @@ struct PaneSurfaceRepresentable: NSViewRepresentable {
         GhosttyManager.shared.applyTerminalBacking(to: container.layer)
     }
 
-    private func attach(_ surface: GhosttySurfaceView, to container: NoDragContainerView) {
+    private func attach(_ surface: GhosttySurfaceView,
+                        to container: NoDragContainerView,
+                        isPostCommitRetry: Bool = false) {
         let currentHost = surface.paneHostView
-        guard SurfaceHostClaimPolicy.shouldClaim(
+        if !isPostCommitRetry,
+           SurfaceHostClaimPolicy.shouldDeferUntilAfterCommit(
+               candidateGeneration: container.hostGeneration,
+               currentGeneration: surface.paneHostGeneration,
+               currentHostExists: currentHost != nil,
+               currentHostIsAttached: currentHost?.window != nil,
+               isSameHost: currentHost === container
+           ) {
+            // During a split collapse the incoming host can claim the surface
+            // just before SwiftUI gives the outgoing tree one last update.
+            // The incoming container is not in the window yet, so the old host
+            // would otherwise mistake it for abandoned and steal the surface
+            // back. Resolve that ambiguity after the current commit: the new
+            // host will be attached if it survived, or still detached if the
+            // older host genuinely needs to recover it.
+            DispatchQueue.main.async {
+                guard container.window != nil, isPaneVisible() else { return }
+                attach(surface, to: container, isPostCommitRetry: true)
+            }
+            return
+        }
+        let shouldClaim = SurfaceHostClaimPolicy.shouldClaim(
             candidateGeneration: container.hostGeneration,
             currentGeneration: surface.paneHostGeneration,
             currentHostIsAttached: currentHost?.window != nil,
             isSameHost: currentHost === container
-        ) else { return }
+        )
+        guard shouldClaim else { return }
 
         surface.paneHostView = container
         surface.paneHostGeneration = container.hostGeneration

--- a/GlintTests/PerformanceRegressionTests.swift
+++ b/GlintTests/PerformanceRegressionTests.swift
@@ -187,6 +187,32 @@ final class PerformanceRegressionTests: XCTestCase {
         ))
     }
 
+    func testOlderOutgoingHostDefersWhileNewerClaimIsPreCommit() {
+        XCTAssertTrue(SurfaceHostClaimPolicy.shouldDeferUntilAfterCommit(
+            candidateGeneration: 10,
+            currentGeneration: 11,
+            currentHostExists: true,
+            currentHostIsAttached: false,
+            isSameHost: false
+        ))
+
+        // Once the incoming host survives the commit and attaches, the stale
+        // outgoing host must not steal the surface back.
+        XCTAssertFalse(SurfaceHostClaimPolicy.shouldDeferUntilAfterCommit(
+            candidateGeneration: 10,
+            currentGeneration: 11,
+            currentHostExists: true,
+            currentHostIsAttached: true,
+            isSameHost: false
+        ))
+        XCTAssertFalse(SurfaceHostClaimPolicy.shouldClaim(
+            candidateGeneration: 10,
+            currentGeneration: 11,
+            currentHostIsAttached: true,
+            isSameHost: false
+        ))
+    }
+
     func testNewestHostWinsDeterministicOutgoingIncomingOutgoingRace() {
         let outgoingHost = NSView()
         let incomingHost = NSView()


### PR DESCRIPTION
## Summary
- defer stale outgoing surface-host claims until the current SwiftUI commit completes
- keep the newer surviving host attached instead of briefly detaching the Ghostty surface
- cover the pre-commit host arbitration race with a regression test

## Root cause
When a split collapsed, the incoming host could claim the surviving surface before it entered the window. A final update from the outgoing tree then treated that detached incoming host as abandoned and stole the surface back, leaving the survivor blank until a later SwiftUI update restored it.

## Performance
The normal path adds only generation and attachment-state comparisons. The race path schedules one main-queue callback; there is no polling, timer, or continuous redraw.

## Verification
- PerformanceRegressionTests: 25 passed, 0 failed
- full Debug build succeeded
- live Ghostty/IOSurface reproduction no longer observed a detach; resized IOSurface appeared in about 4 ms