### PR TITLE
fix(web-remote): 修复 iOS 中文输入和长按粘贴 / fix iOS IME and long-press paste

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,9 @@ jobs:
 
           scripts/verify-ghostty-resources.sh build/Build/Products/Debug/Glint.app
 
+      - name: Test Web Remote browser input
+        run: node --test scripts/test-web-remote-ime.mjs
+
       - name: Test Glint
         run: |
           set -euo pipefail

--- a/Glint.xcodeproj/project.pbxproj
+++ b/Glint.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		F584D3237E44E7444086E011 /* ShellRcBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9550DD194D906A2B5168DBFD /* ShellRcBlock.swift */; };
 		F5AE37B67B17DD61B652E5B6 /* ReviewDiffParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CFFB91CE5C44976A6961F1F /* ReviewDiffParsingTests.swift */; };
 		F6AFF715FCE5357CEB07683D /* SettingsSafety.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB20921E3CAC1006A8FBD3AE /* SettingsSafety.swift */; };
+		F706CFC2BB7DDA67F4B7D669 /* ime-input.mjs in Resources */ = {isa = PBXBuildFile; fileRef = 9E91B403BDA59652BE90F6ED /* ime-input.mjs */; };
 		F7ABF70CD455143BF89B89B3 /* SafeJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E2B9ADF809766CE4278047 /* SafeJSON.swift */; };
 		FAB0828152636BBBBC5989CD /* SyntaxHighlighterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FAD36B4BDB22AB47353C569 /* SyntaxHighlighterTests.swift */; };
 		FB4C8529271BF52873745556 /* crypto.mjs in Resources */ = {isa = PBXBuildFile; fileRef = F6DDF70810465204EB990667 /* crypto.mjs */; };
@@ -183,6 +184,7 @@
 		98BBD4C70C8DC534304294C9 /* InlineSuggestionInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineSuggestionInstaller.swift; sourceTree = "<group>"; };
 		9E574E2A2735328331FC3C78 /* CloseOnCmdW.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseOnCmdW.swift; sourceTree = "<group>"; };
 		9E67CF5D8552AE1F51386161 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		9E91B403BDA59652BE90F6ED /* ime-input.mjs */ = {isa = PBXFileReference; path = "ime-input.mjs"; sourceTree = "<group>"; };
 		9E982534C8CF6270BCF39106 /* ReviewWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewWindow.swift; sourceTree = "<group>"; };
 		A8C269A6E9AE87961C3356DC /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		ABF0871355239B5D7C80B719 /* web-remote.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = "web-remote.css"; sourceTree = "<group>"; };
@@ -236,6 +238,7 @@
 				5DB06D8C68CA7B9C7E1E83E7 /* addon-fit.mjs */,
 				2C85E16653B066382F22FEDD /* crypto-LICENSE.txt */,
 				F6DDF70810465204EB990667 /* crypto.mjs */,
+				9E91B403BDA59652BE90F6ED /* ime-input.mjs */,
 				2B1F1216422BE2A4234ABA44 /* nerd-fonts-LICENSE.txt */,
 				5627A3DA0ADBDC6194E2D7A7 /* symbols-nerd-font-LICENSE.txt */,
 				911638005A9881330F4F855F /* SymbolsNerdFontMono-Regular.ttf */,
@@ -565,6 +568,7 @@
 				EE6D05AB1D935F502865ABDA /* crypto-LICENSE.txt in Resources */,
 				FB4C8529271BF52873745556 /* crypto.mjs in Resources */,
 				262CB25BEB2B28B12C162F66 /* ghostty in Resources */,
+				F706CFC2BB7DDA67F4B7D669 /* ime-input.mjs in Resources */,
 				3B439B6978244B06B9695824 /* nerd-fonts-LICENSE.txt in Resources */,
 				7E6DBB055150A4D140351EB6 /* symbols-nerd-font-LICENSE.txt in Resources */,
 				0D3661ECB91851F77B1E48CE /* terminfo in Resources */,

--- a/Glint/Resources/WebRemote/ime-input.mjs
+++ b/Glint/Resources/WebRemote/ime-input.mjs
@@ -8,6 +8,96 @@ export function isIOSInputEnvironment(navigatorLike) {
     || (platform === "MacIntel" && touchPoints > 1);
 }
 
+export function shouldUseNativeTouchInput(navigatorLike, targetWindow) {
+  if (!isIOSInputEnvironment(navigatorLike)) return false;
+  return targetWindow?.matchMedia?.("(hover: none) and (pointer: coarse)").matches ?? true;
+}
+
+function pastedTextFromInput(baseline, newValue, eventData) {
+  if (baseline) {
+    const prefix = baseline.value.slice(0, baseline.start);
+    const suffix = baseline.value.slice(baseline.end);
+    if (newValue.startsWith(prefix) && newValue.endsWith(suffix)) {
+      return newValue.slice(prefix.length, newValue.length - suffix.length);
+    }
+  }
+  return typeof eventData === "string" ? eventData : newValue;
+}
+
+export function installIOSNativeTouchInput(
+  terminal,
+  pasteText,
+  navigatorLike = navigator,
+  targetWindow = window
+) {
+  if (!shouldUseNativeTouchInput(navigatorLike, targetWindow)
+      || !terminal.element
+      || !terminal.textarea) return null;
+
+  const screen = terminal.element.querySelector(".xterm-screen");
+  const rows = terminal.element.querySelector(".xterm-rows");
+  if (!screen || !rows) return null;
+
+  const textarea = terminal.textarea;
+  let pendingPaste = null;
+  terminal.element.classList.add("glint-native-touch-input");
+
+  const syncTextarea = () => {
+    const row = terminal.element.querySelector(".xterm-rows > div");
+    const measuredHeight = row?.getBoundingClientRect().height;
+    const cellHeight = measuredHeight > 0
+      ? measuredHeight
+      : (terminal.options?.fontSize || 13) * (terminal.options?.lineHeight || 1);
+    const screenWidth = screen.getBoundingClientRect().width;
+    const cellWidth = terminal.cols > 0 ? screenWidth / terminal.cols : 0;
+    const cursor = terminal.buffer.active;
+    textarea.style.left = `${cursor.cursorX * cellWidth}px`;
+    textarea.style.top = `${cursor.cursorY * cellHeight}px`;
+    textarea.style.width = `${Math.max(cellWidth, 80)}px`;
+    textarea.style.height = `${Math.max(cellHeight, 32)}px`;
+    textarea.style.lineHeight = `${cellHeight}px`;
+    textarea.style.zIndex = "10";
+  };
+
+  terminal.onRender?.(syncTextarea);
+  terminal.onCursorMove?.(syncTextarea);
+  if (targetWindow.requestAnimationFrame) targetWindow.requestAnimationFrame(syncTextarea);
+  else syncTextarea();
+
+  const handleNativeMouseDown = event => {
+    if (terminal.modes?.mouseTrackingMode
+        && terminal.modes.mouseTrackingMode !== "none") return;
+    event.stopPropagation();
+    terminal.focus();
+  };
+  rows.addEventListener("mousedown", handleNativeMouseDown, { capture: true });
+  textarea.addEventListener("mousedown", handleNativeMouseDown, { capture: true });
+
+  textarea.addEventListener("paste", event => {
+    // Let xterm consume ClipboardEvent data, but stop WebKit from also inserting
+    // the same text into the helper textarea and producing a second input event.
+    if (event.clipboardData) event.preventDefault();
+  }, { capture: true });
+
+  textarea.addEventListener("beforeinput", event => {
+    if (event.inputType !== "insertFromPaste") return;
+    const start = textarea.selectionStart ?? textarea.value.length;
+    const end = textarea.selectionEnd ?? start;
+    pendingPaste = { value: textarea.value, start: Math.min(start, end), end: Math.max(start, end) };
+  }, { capture: true });
+
+  textarea.addEventListener("input", event => {
+    if (event.inputType !== "insertFromPaste") return;
+    const text = pastedTextFromInput(pendingPaste, textarea.value, event.data);
+    pendingPaste = null;
+    textarea.value = "";
+    event.stopImmediatePropagation();
+    if (text) pasteText(text);
+  }, { capture: true });
+
+  return { syncTextarea };
+}
+
 export function textareaDelta(oldValue, newValue) {
   if (oldValue === newValue) return "";
   if (newValue.length < oldValue.length) return DELETE;

--- a/Glint/Resources/WebRemote/ime-input.mjs
+++ b/Glint/Resources/WebRemote/ime-input.mjs
@@ -1,0 +1,99 @@
+const DELETE = "\x7f";
+
+export function isIOSInputEnvironment(navigatorLike) {
+  const userAgent = navigatorLike?.userAgent || "";
+  const platform = navigatorLike?.platform || "";
+  const touchPoints = navigatorLike?.maxTouchPoints || 0;
+  return /iPad|iPhone|iPod/.test(userAgent)
+    || (platform === "MacIntel" && touchPoints > 1);
+}
+
+export function textareaDelta(oldValue, newValue) {
+  if (oldValue === newValue) return "";
+  if (newValue.length < oldValue.length) return DELETE;
+
+  let prefixLength = 0;
+  while (prefixLength < oldValue.length
+      && prefixLength < newValue.length
+      && oldValue.charCodeAt(prefixLength) === newValue.charCodeAt(prefixLength)) {
+    prefixLength += 1;
+  }
+  return DELETE.repeat(oldValue.length - prefixLength) + newValue.slice(prefixLength);
+}
+
+export class IOSIMEInputFallback {
+  constructor(textarea, emit, schedule = callback => setTimeout(callback, 0)) {
+    this.textarea = textarea;
+    this.emit = emit;
+    this.schedule = schedule;
+    this.pending229Baseline = null;
+    this.pendingCompositionCommit = null;
+    this.compositionGeneration = 0;
+  }
+
+  handleKeyDown(event) {
+    if (event.keyCode !== 229 || event.isComposing) return false;
+    if (this.pending229Baseline === null) this.pending229Baseline = this.textarea.value;
+    return true;
+  }
+
+  handleKeyUp() {
+    if (this.pending229Baseline === null) return;
+    const baseline = this.pending229Baseline;
+    this.pending229Baseline = null;
+    const payload = textareaDelta(baseline, this.textarea.value);
+    if (payload) this.emit(payload);
+  }
+
+  handleCompositionStart() {
+    this.pending229Baseline = null;
+    this.pendingCompositionCommit = null;
+    this.compositionGeneration += 1;
+  }
+
+  handleCompositionEnd(event) {
+    if (!event.data) return;
+    const commit = event.data;
+    const generation = ++this.compositionGeneration;
+    this.pendingCompositionCommit = commit;
+    // xterm registered its compositionend listener first, so its zero-delay
+    // send runs before this fallback. noteTerminalData cancels us when it did.
+    this.schedule(() => {
+      if (this.compositionGeneration !== generation
+          || this.pendingCompositionCommit !== commit) return;
+      this.pendingCompositionCommit = null;
+      this.emit(commit);
+    });
+  }
+
+  noteTerminalData() {
+    this.pending229Baseline = null;
+    this.pendingCompositionCommit = null;
+    this.compositionGeneration += 1;
+  }
+
+  shouldOwnInputEvent(event) {
+    return this.pending229Baseline !== null && !event.isComposing;
+  }
+}
+
+export function installIOSIMEInputFallback(terminal, emit, navigatorLike = navigator) {
+  if (!isIOSInputEnvironment(navigatorLike) || !terminal.textarea) return null;
+
+  const fallback = new IOSIMEInputFallback(terminal.textarea, emit);
+  terminal.attachCustomKeyEventHandler(event => {
+    // iOS exposes IME punctuation only after keydown. Keep xterm from taking
+    // its one-shot keydown snapshot; handle the final textarea value at keyup.
+    if (event.type === "keydown" && fallback.handleKeyDown(event)) return false;
+    if (event.type === "keyup") fallback.handleKeyUp(event);
+    return true;
+  });
+  terminal.textarea.addEventListener("input", event => {
+    // This fallback owns only the intercepted non-composition 229 cycle.
+    // Real composition events continue through xterm unchanged.
+    if (fallback.shouldOwnInputEvent(event)) event.stopImmediatePropagation();
+  }, { capture: true });
+  terminal.textarea.addEventListener("compositionstart", () => fallback.handleCompositionStart());
+  terminal.textarea.addEventListener("compositionend", event => fallback.handleCompositionEnd(event));
+  return fallback;
+}

--- a/Glint/Resources/WebRemote/web-remote.css
+++ b/Glint/Resources/WebRemote/web-remote.css
@@ -295,6 +295,34 @@ input:focus {
 #terminal .xterm { height: 100%; }
 #terminal .xterm-viewport { scrollbar-color: color-mix(in srgb, var(--text) 16%, transparent) transparent; }
 
+.xterm.glint-native-touch-input,
+.xterm.glint-native-touch-input .xterm-screen,
+.xterm.glint-native-touch-input .xterm-rows,
+.xterm.glint-native-touch-input .xterm-rows * {
+  -webkit-user-select: text !important;
+  user-select: text !important;
+  -webkit-touch-callout: default;
+}
+
+.xterm.glint-native-touch-input .xterm-rows { pointer-events: auto !important; }
+.xterm.glint-native-touch-input .xterm-rows span { display: inline !important; }
+
+.xterm.glint-native-touch-input .xterm-helper-textarea {
+  opacity: 1;
+  background: transparent;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  caret-color: transparent;
+  outline: none;
+  text-shadow: none;
+  -webkit-appearance: none;
+  appearance: none;
+  -webkit-user-select: text;
+  user-select: text;
+  -webkit-touch-callout: default;
+  pointer-events: auto;
+}
+
 .empty-state {
   position: absolute;
   inset: 0 0 48px;

--- a/Glint/Resources/WebRemote/web-remote.js
+++ b/Glint/Resources/WebRemote/web-remote.js
@@ -1,6 +1,6 @@
 import { Terminal } from "/xterm.mjs";
 import { FitAddon } from "/addon-fit.mjs";
-import { installIOSIMEInputFallback } from "/ime-input.mjs";
+import { installIOSIMEInputFallback, installIOSNativeTouchInput } from "/ime-input.mjs";
 import {
   hmacSha256,
   hkdfExtractExpand,
@@ -245,6 +245,7 @@ const iosIMEInputFallback = installIOSIMEInputFallback(
   terminal,
   data => sendInputBytes(textEncoder.encode(data))
 );
+installIOSNativeTouchInput(terminal, text => terminal.paste(text));
 document.fonts?.load('13px "Glint Nerd Symbols"').then(() => {
   terminal.refresh(0, terminal.rows - 1);
   fitTerminal();

--- a/Glint/Resources/WebRemote/web-remote.js
+++ b/Glint/Resources/WebRemote/web-remote.js
@@ -1,5 +1,6 @@
 import { Terminal } from "/xterm.mjs";
 import { FitAddon } from "/addon-fit.mjs";
+import { installIOSIMEInputFallback } from "/ime-input.mjs";
 import {
   hmacSha256,
   hkdfExtractExpand,
@@ -240,6 +241,10 @@ const terminal = new Terminal({
 const fitAddon = new FitAddon();
 terminal.loadAddon(fitAddon);
 terminal.open(elements.terminal);
+const iosIMEInputFallback = installIOSIMEInputFallback(
+  terminal,
+  data => sendInputBytes(textEncoder.encode(data))
+);
 document.fonts?.load('13px "Glint Nerd Symbols"').then(() => {
   terminal.refresh(0, terminal.rows - 1);
   fitTerminal();
@@ -841,7 +846,10 @@ function sendInputBytes(bytes) {
   send({ type: "input", pane: selectedPane, data: encodeBase64(bytes) });
 }
 
-terminal.onData(data => sendInputBytes(new TextEncoder().encode(data)));
+terminal.onData(data => {
+  iosIMEInputFallback?.noteTerminalData(data);
+  sendInputBytes(textEncoder.encode(data));
+});
 terminal.onBinary(data => {
   const bytes = Uint8Array.from(data, character => character.charCodeAt(0) & 0xff);
   sendInputBytes(bytes);

--- a/Glint/WebRemote/WebRemoteProtocol.swift
+++ b/Glint/WebRemote/WebRemoteProtocol.swift
@@ -627,6 +627,13 @@ enum WebRemoteAssets {
                 contentType: "text/javascript; charset=utf-8",
                 cacheControl: "public, max-age=31536000, immutable"
             )
+        case "/ime-input.mjs":
+            WebRemoteAsset(
+                resource: "ime-input",
+                fileExtension: "mjs",
+                contentType: "text/javascript; charset=utf-8",
+                cacheControl: "no-cache"
+            )
         case "/symbols-nerd-font-mono.ttf":
             WebRemoteAsset(
                 resource: "SymbolsNerdFontMono-Regular",

--- a/GlintTests/WebRemoteProtocolTests.swift
+++ b/GlintTests/WebRemoteProtocolTests.swift
@@ -309,6 +309,7 @@ final class WebRemoteProtocolTests: XCTestCase {
     func testAssetsOnlyExposeBundledAllowlist() {
         XCTAssertEqual(WebRemoteAssets.asset(for: "/")?.resource, "web-remote-index")
         XCTAssertEqual(WebRemoteAssets.asset(for: "/xterm.mjs")?.contentType, "text/javascript; charset=utf-8")
+        XCTAssertEqual(WebRemoteAssets.asset(for: "/ime-input.mjs")?.resource, "ime-input")
         XCTAssertEqual(WebRemoteAssets.asset(for: "/symbols-nerd-font-mono.ttf")?.contentType, "font/ttf")
         XCTAssertNil(WebRemoteAssets.asset(for: "/../state.json"))
         XCTAssertNil(WebRemoteAssets.asset(for: "/favicon.ico"))

--- a/GlintTests/WebRemoteServerIntegrationTests.swift
+++ b/GlintTests/WebRemoteServerIntegrationTests.swift
@@ -84,6 +84,13 @@ final class WebRemoteServerIntegrationTests: XCTestCase {
         XCTAssertFalse(data.isEmpty)
     }
 
+    func testHTTPServesIOSIMEInputFallback() async throws {
+        let (data, http) = try await request("/ime-input.mjs")
+        XCTAssertEqual(http.statusCode, 200)
+        XCTAssertNotNil(http.value(forHTTPHeaderField: "Content-Type")?.range(of: "text/javascript"))
+        XCTAssertFalse(data.isEmpty)
+    }
+
     func testHTTPReturns404ForUnknownAsset() async throws {
         let (data, http) = try await request("/favicon.ico")
         XCTAssertEqual(http.statusCode, 404)

--- a/scripts/test-web-remote-ime.mjs
+++ b/scripts/test-web-remote-ime.mjs
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  IOSIMEInputFallback,
+  installIOSIMEInputFallback,
+  isIOSInputEnvironment,
+  textareaDelta,
+} from "../Glint/Resources/WebRemote/ime-input.mjs";
+
+function makeTerminal() {
+  const listeners = new Map();
+  return {
+    textarea: {
+      value: "",
+      addEventListener(type, listener) {
+        listeners.set(type, listener);
+      },
+    },
+    attachCustomKeyEventHandler(handler) {
+      this.keyHandler = handler;
+    },
+    listeners,
+  };
+}
+
+test("only enables the fallback on iPhone and iPad environments", () => {
+  assert.equal(isIOSInputEnvironment({ userAgent: "Mozilla/5.0 (iPhone)", platform: "iPhone" }), true);
+  assert.equal(isIOSInputEnvironment({ userAgent: "Mozilla/5.0 (iPad)", platform: "iPad" }), true);
+  assert.equal(isIOSInputEnvironment({
+    userAgent: "Mozilla/5.0 (Macintosh)",
+    platform: "MacIntel",
+    maxTouchPoints: 5,
+  }), true);
+  assert.equal(isIOSInputEnvironment({
+    userAgent: "Mozilla/5.0 (Macintosh)",
+    platform: "MacIntel",
+    maxTouchPoints: 0,
+  }), false);
+  assert.equal(isIOSInputEnvironment({ userAgent: "Mozilla/5.0 (Linux; Android 16)" }), false);
+});
+
+test("does not install any handlers outside iOS and iPadOS", () => {
+  const terminal = makeTerminal();
+  const fallback = installIOSIMEInputFallback(
+    terminal,
+    () => {},
+    { userAgent: "Mozilla/5.0 (Macintosh)", platform: "MacIntel", maxTouchPoints: 0 }
+  );
+
+  assert.equal(fallback, null);
+  assert.equal(terminal.keyHandler, undefined);
+  assert.equal(terminal.listeners.size, 0);
+});
+
+test("installs an iOS-only key handler that owns deferred 229 input", () => {
+  const terminal = makeTerminal();
+  const emitted = [];
+  installIOSIMEInputFallback(
+    terminal,
+    value => emitted.push(value),
+    { userAgent: "Mozilla/5.0 (iPhone)", platform: "iPhone", maxTouchPoints: 5 }
+  );
+
+  assert.equal(terminal.keyHandler({ type: "keydown", keyCode: 229, isComposing: false }), false);
+  terminal.textarea.value = "，";
+  let inputStopped = false;
+  terminal.listeners.get("input")({
+    isComposing: false,
+    stopImmediatePropagation() { inputStopped = true; },
+  });
+  assert.equal(inputStopped, true);
+  assert.equal(terminal.keyHandler({ type: "keyup", keyCode: 0, isComposing: false }), true);
+  assert.deepEqual(emitted, ["，"]);
+});
+
+test("computes the minimal terminal payload for iOS textarea changes", () => {
+  assert.equal(textareaDelta("", "，"), "，");
+  assert.equal(textareaDelta("hello ", "hello。"), "\x7f。");
+  assert.equal(textareaDelta("unchanged", "unchanged"), "");
+  assert.equal(textareaDelta("abc", "ab"), "\x7f");
+});
+
+test("emits punctuation that only becomes visible at keyup", () => {
+  const textarea = { value: "" };
+  const emitted = [];
+  const fallback = new IOSIMEInputFallback(textarea, value => emitted.push(value));
+
+  assert.equal(fallback.handleKeyDown({ keyCode: 229, isComposing: false }), true);
+  textarea.value = "，";
+  fallback.handleKeyUp({ keyCode: 0 });
+
+  assert.deepEqual(emitted, ["，"]);
+});
+
+test("emits delete plus replacement for the double-space Chinese period conversion", () => {
+  const textarea = { value: "hello " };
+  const emitted = [];
+  const fallback = new IOSIMEInputFallback(textarea, value => emitted.push(value));
+
+  fallback.handleKeyDown({ keyCode: 229, isComposing: false });
+  textarea.value = "hello。";
+  fallback.handleKeyUp({ keyCode: 32 });
+
+  assert.deepEqual(emitted, ["\x7f。"]);
+});
+
+test("does not intercept ordinary keys or active compositions", () => {
+  const textarea = { value: "" };
+  const fallback = new IOSIMEInputFallback(textarea, () => {});
+
+  assert.equal(fallback.handleKeyDown({ keyCode: 65, isComposing: false }), false);
+  assert.equal(fallback.handleKeyDown({ keyCode: 229, isComposing: true }), false);
+});
+
+test("cancels the 229 fallback when a real composition starts", () => {
+  const textarea = { value: "" };
+  const emitted = [];
+  const fallback = new IOSIMEInputFallback(textarea, value => emitted.push(value));
+
+  fallback.handleKeyDown({ keyCode: 229, isComposing: false });
+  fallback.handleCompositionStart();
+  textarea.value = "你";
+  fallback.handleKeyUp({ keyCode: 0 });
+
+  assert.deepEqual(emitted, []);
+});
+
+test("does not duplicate data already emitted by xterm", () => {
+  const textarea = { value: "" };
+  const emitted = [];
+  const fallback = new IOSIMEInputFallback(textarea, value => emitted.push(value));
+
+  fallback.handleKeyDown({ keyCode: 229, isComposing: false });
+  textarea.value = "！";
+  fallback.noteTerminalData("！");
+  fallback.handleKeyUp({ keyCode: 0 });
+
+  assert.deepEqual(emitted, []);
+});
+
+test("falls back to compositionend data only when xterm emits nothing", () => {
+  const textarea = { value: "你" };
+  const emitted = [];
+  const scheduled = [];
+  const fallback = new IOSIMEInputFallback(
+    textarea,
+    value => emitted.push(value),
+    callback => scheduled.push(callback)
+  );
+
+  fallback.handleCompositionEnd({ data: "你" });
+  assert.deepEqual(emitted, []);
+  scheduled.shift()();
+  assert.deepEqual(emitted, ["你"]);
+});
+
+test("cancels the composition fallback when xterm already emitted", () => {
+  const textarea = { value: "你" };
+  const emitted = [];
+  const scheduled = [];
+  const fallback = new IOSIMEInputFallback(
+    textarea,
+    value => emitted.push(value),
+    callback => scheduled.push(callback)
+  );
+
+  fallback.handleCompositionEnd({ data: "你" });
+  fallback.noteTerminalData("你");
+  scheduled.shift()();
+
+  assert.deepEqual(emitted, []);
+});

--- a/scripts/test-web-remote-ime.mjs
+++ b/scripts/test-web-remote-ime.mjs
@@ -1,9 +1,12 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 import {
   IOSIMEInputFallback,
+  installIOSNativeTouchInput,
   installIOSIMEInputFallback,
   isIOSInputEnvironment,
+  shouldUseNativeTouchInput,
   textareaDelta,
 } from "../Glint/Resources/WebRemote/ime-input.mjs";
 
@@ -23,6 +26,47 @@ function makeTerminal() {
   };
 }
 
+function makeTouchTerminal() {
+  const elementListeners = new Map();
+  const rowsListeners = new Map();
+  const textareaListeners = new Map();
+  const classes = new Set();
+  const row = { getBoundingClientRect: () => ({ height: 20 }) };
+  const rows = {
+    addEventListener(type, listener) { rowsListeners.set(type, listener); },
+  };
+  const screen = { getBoundingClientRect: () => ({ width: 800 }) };
+  return {
+    cols: 80,
+    buffer: { active: { cursorX: 2, cursorY: 3 } },
+    element: {
+      classList: { add: value => classes.add(value) },
+      addEventListener(type, listener) { elementListeners.set(type, listener); },
+      querySelector(selector) {
+        if (selector === ".xterm-screen") return screen;
+        if (selector === ".xterm-rows") return rows;
+        if (selector === ".xterm-rows > div") return row;
+        return null;
+      },
+    },
+    textarea: {
+      value: "",
+      selectionStart: 0,
+      selectionEnd: 0,
+      style: {},
+      addEventListener(type, listener) { textareaListeners.set(type, listener); },
+    },
+    focusCalls: 0,
+    focus() { this.focusCalls += 1; },
+    onRender(listener) { this.renderListener = listener; },
+    onCursorMove(listener) { this.cursorListener = listener; },
+    classes,
+    elementListeners,
+    rowsListeners,
+    textareaListeners,
+  };
+}
+
 test("only enables the fallback on iPhone and iPad environments", () => {
   assert.equal(isIOSInputEnvironment({ userAgent: "Mozilla/5.0 (iPhone)", platform: "iPhone" }), true);
   assert.equal(isIOSInputEnvironment({ userAgent: "Mozilla/5.0 (iPad)", platform: "iPad" }), true);
@@ -39,6 +83,16 @@ test("only enables the fallback on iPhone and iPad environments", () => {
   assert.equal(isIOSInputEnvironment({ userAgent: "Mozilla/5.0 (Linux; Android 16)" }), false);
 });
 
+test("ships native touch selection and callout styles", () => {
+  const css = readFileSync(
+    new URL("../Glint/Resources/WebRemote/web-remote.css", import.meta.url),
+    "utf8"
+  );
+  assert.match(css, /\.xterm\.glint-native-touch-input/);
+  assert.match(css, /-webkit-touch-callout:\s*default/);
+  assert.match(css, /pointer-events:\s*auto/);
+});
+
 test("does not install any handlers outside iOS and iPadOS", () => {
   const terminal = makeTerminal();
   const fallback = installIOSIMEInputFallback(
@@ -50,6 +104,91 @@ test("does not install any handlers outside iOS and iPadOS", () => {
   assert.equal(fallback, null);
   assert.equal(terminal.keyHandler, undefined);
   assert.equal(terminal.listeners.size, 0);
+});
+
+test("enables native touch input only for coarse-pointer iOS environments", () => {
+  const iphone = { userAgent: "Mozilla/5.0 (iPhone)", platform: "iPhone", maxTouchPoints: 5 };
+  const desktop = { userAgent: "Mozilla/5.0 (Macintosh)", platform: "MacIntel", maxTouchPoints: 0 };
+  assert.equal(shouldUseNativeTouchInput(iphone, { matchMedia: () => ({ matches: true }) }), true);
+  assert.equal(shouldUseNativeTouchInput(iphone, { matchMedia: () => ({ matches: false }) }), false);
+  assert.equal(shouldUseNativeTouchInput(desktop, { matchMedia: () => ({ matches: true }) }), false);
+});
+
+test("makes the iOS textarea touchable at the terminal cursor", () => {
+  const terminal = makeTouchTerminal();
+  const frameCallbacks = [];
+  const controller = installIOSNativeTouchInput(
+    terminal,
+    () => {},
+    { userAgent: "Mozilla/5.0 (iPhone)", platform: "iPhone", maxTouchPoints: 5 },
+    {
+      matchMedia: () => ({ matches: true }),
+      requestAnimationFrame: callback => frameCallbacks.push(callback),
+    }
+  );
+
+  assert.notEqual(controller, null);
+  assert.equal(terminal.classes.has("glint-native-touch-input"), true);
+  frameCallbacks.shift()();
+  assert.equal(terminal.textarea.style.left, "20px");
+  assert.equal(terminal.textarea.style.top, "60px");
+  assert.equal(terminal.textarea.style.width, "80px");
+  assert.equal(terminal.textarea.style.height, "32px");
+  assert.equal(terminal.textarea.style.zIndex, "10");
+
+  let mouseStopped = false;
+  terminal.textareaListeners.get("mousedown")({
+    stopPropagation() { mouseStopped = true; },
+  });
+  assert.equal(mouseStopped, true);
+  assert.equal(terminal.focusCalls, 1);
+});
+
+test("routes native insertFromPaste text once and clears the helper textarea", () => {
+  const terminal = makeTouchTerminal();
+  const pasted = [];
+  installIOSNativeTouchInput(
+    terminal,
+    value => pasted.push(value),
+    { userAgent: "Mozilla/5.0 (iPhone)", platform: "iPhone", maxTouchPoints: 5 },
+    { matchMedia: () => ({ matches: true }), requestAnimationFrame: () => {} }
+  );
+
+  terminal.textarea.value = "old";
+  terminal.textarea.selectionStart = 3;
+  terminal.textarea.selectionEnd = 3;
+  terminal.textareaListeners.get("beforeinput")({ inputType: "insertFromPaste" });
+  terminal.textarea.value = "old粘贴";
+  let inputStopped = false;
+  terminal.textareaListeners.get("input")({
+    inputType: "insertFromPaste",
+    data: null,
+    stopImmediatePropagation() { inputStopped = true; },
+  });
+
+  assert.equal(inputStopped, true);
+  assert.deepEqual(pasted, ["粘贴"]);
+  assert.equal(terminal.textarea.value, "");
+});
+
+test("prevents native insertion when xterm can handle ClipboardEvent data", () => {
+  const terminal = makeTouchTerminal();
+  const pasted = [];
+  installIOSNativeTouchInput(
+    terminal,
+    value => pasted.push(value),
+    { userAgent: "Mozilla/5.0 (iPhone)", platform: "iPhone", maxTouchPoints: 5 },
+    { matchMedia: () => ({ matches: true }), requestAnimationFrame: () => {} }
+  );
+
+  let prevented = false;
+  terminal.textareaListeners.get("paste")({
+    clipboardData: { getData: () => "native" },
+    preventDefault() { prevented = true; },
+  });
+
+  assert.equal(prevented, true);
+  assert.deepEqual(pasted, []);
 });
 
 test("installs an iOS-only key handler that owns deferred 229 input", () => {


### PR DESCRIPTION
## Summary

- add an iOS/iPadOS-only input adapter for deferred IME keyCode 229 text
- preserve xterm normal composition handling and avoid duplicate sends
- fall back to compositionend data only when xterm emits nothing
- enable native touch selection and make the helper textarea touchable at the terminal cursor
- route native insertFromPaste without duplicating xterm clipboard handling
- keep terminal mouse mode and the existing two-finger scrolling path intact
- run browser input regression tests in CI

## Compatibility

Desktop Safari, Chrome, Firefox, and Android do not install these handlers. Native touch selection is additionally limited to coarse-pointer iOS/iPadOS environments. Other browsers on iOS/iPadOS share the same WebKit input path and receive the fixes.

## Validation

- node --test scripts/test-web-remote-ime.mjs: 16 passed
- WebRemoteProtocolTests: 37 passed
- Debug app build succeeded
- live HTTP assets on the Debug server match the committed IME module and CSS
- node syntax checks and git diff --check passed

The local socket integration group could not complete because a running Glint instance occupied ports 43871/43872. The HTTP asset test remains included for CI and an idle-port environment.