### PR TITLE
fix(pane): close host-claim races reopened by the #103 recovery / 修复 #103 恢复通道重新打开的 pane 所有权竞态

### DIFF
--- a/Glint/Pane/GhosttySurfaceView.swift
+++ b/Glint/Pane/GhosttySurfaceView.swift
@@ -39,6 +39,20 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
     /// representables alive; the older one must not re-parent the surface back.
     weak var paneHostView: NSView?
     var paneHostGeneration: UInt64 = 0
+    /// A claim that was declined while a recorded host still vetoed, kept so
+    /// the invalidation that dissolves the veto can re-drive it through full
+    /// arbitration (the event-driven side of the recovery in
+    /// `PaneSurfaceRepresentable`). Weak — a dismantled candidate must not be
+    /// kept alive; the visibility closure captures the store weakly because
+    /// the store owns the surfaces and a strong capture would be a cycle.
+    weak var pendingRecoveryHost: NSView?
+    var pendingRecoveryVisibility: (() -> Bool)?
+    /// Bumped on every arm/disarm of the pending recovery. Backstop chains
+    /// capture the epoch at scheduling time and die when it no longer
+    /// matches, so a chain queued for an old claim cannot act after a
+    /// success cleared the pending state or a newer decline re-armed it.
+    var pendingRecoveryEpoch: UInt = 0
+
     private var focusUpdateGate = SurfaceFocusUpdateGate()
     private var trackingArea: NSTrackingArea?
     /// Screen contents for the accessibility layer. AX clients poll AXValue

--- a/Glint/Pane/PaneSurfaceRepresentable.swift
+++ b/Glint/Pane/PaneSurfaceRepresentable.swift
@@ -40,6 +40,15 @@ enum SurfaceHostClaimPolicy {
     /// generation would otherwise decline the one legitimate attach forever,
     /// leaving the pane showing the outgoing workspace's terminal.
     ///
+    /// Only a host that is alive, attached, and no longer speaks for this
+    /// surface is adjudicated stale. A detached or missing host is NOT stale:
+    /// `shouldClaim` passes those anyway (it never inspects generations for a
+    /// detached host), and "detached" is indistinguishable from "brand-new
+    /// host mid-commit, not in the window yet" — the ambiguity
+    /// `shouldDeferUntilAfterCommit` exists to resolve. Acting on it from a
+    /// recovery pass would skip that deferral and steal the surface from a
+    /// host that is about to attach, which is #96's steal-back.
+    ///
     /// A recorded host that still expects this surface is NOT stale — the
     /// generation verdict stands there, so the split-collapse steal-back
     /// guard is unaffected.
@@ -47,10 +56,31 @@ enum SurfaceHostClaimPolicy {
                                     currentHostIsAttached: Bool,
                                     currentHostExpectsThisSurface: Bool,
                                     isSameHost: Bool) -> Bool {
-        guard !isSameHost else { return false }
-        guard currentHostExists else { return true }
-        return !currentHostIsAttached || !currentHostExpectsThisSurface
+        !isSameHost && currentHostExists && currentHostIsAttached && !currentHostExpectsThisSurface
     }
+}
+
+/// Gate for the synchronous attach path. The deferred, reassert, and recovery
+/// paths all re-check pane visibility before running; the make/update path
+/// must not be the exception.
+enum SurfaceAttachGate {
+    /// A representable whose pane is no longer in the selected workspace's
+    /// selected tab must not attach — its tree is on the way out. SwiftUI
+    /// evaluates the outgoing tree's representables once more before
+    /// dismantling them, and that final update would otherwise re-pin the
+    /// outgoing workspace's surface into a recycled container — either via
+    /// `shouldClaim`'s `isSameHost` shortcut (the stale recording still names
+    /// that container) or via a nil recording just cleared by the ownership
+    /// hand-off — leaving the live pane on the wrong workspace's terminal
+    /// with no later `updateNSView` pass left to correct it.
+    ///
+    /// Unconditional by design: a first mount is never blocked here, because
+    /// only the selected tab's tree is ever in the hierarchy (`ContentView`
+    /// renders `currentRoot` alone) and the store's selection is updated
+    /// before the tree re-renders — a mounted representable's pane is visible
+    /// at mount time by construction. Narrowing the gate to re-claims only
+    /// (host != nil) would reopen the hand-off-cleared variant of the steal.
+    static func allowsAttach(paneIsVisible: Bool) -> Bool { paneIsVisible }
 }
 
 /// Hosts a stable, store-owned `GhosttySurfaceView` inside a fresh container
@@ -64,8 +94,9 @@ struct PaneSurfaceRepresentable: NSViewRepresentable {
     let focused: Bool
     /// True while an in-window overlay (the command palette) is managing the
     /// window's first responder. When set, this view must NOT touch focus:
-    /// updateNSView re-runs ~1/s, and re-grabbing the terminal surface here
-    /// races the palette's search field and yanks focus back off it.
+    /// updateNSView re-runs on store mutations, and re-grabbing the terminal
+    /// surface here races the palette's search field and yanks focus back off
+    /// it.
     let deferFocus: Bool
     /// Evaluated inside the deferred re-pin, not when SwiftUI builds the view:
     /// workspace/tab selection may change before that callback runs.
@@ -76,32 +107,34 @@ struct PaneSurfaceRepresentable: NSViewRepresentable {
         container.wantsLayer = true
         Self.updateContainerBacking(container)
         surfaceView.refreshAppearanceBacking()
-        attach(surfaceView, to: container)
+        Self.performAttach(surfaceView, to: container, isPaneVisible: isPaneVisible)
         return container
     }
 
     func updateNSView(_ nsView: NoDragContainerView, context: Context) {
-        // SwiftUI re-runs this ~1/s (sidebar TimelineView), so it doubles as
-        // the live-refresh path for opacity changes: re-stamp the container and
-        // surface backing every pass so dragging the opacity slider flips the
-        // compositor without a relaunch.
+        // This pass re-runs whenever the parent view re-evaluates — store
+        // mutations only. The sidebar's per-second TimelineView redraws its
+        // own subtree and never invalidates the pane tree's representables,
+        // so a skipped attach here stays skipped until the next store
+        // mutation; the attach path below must settle ownership on its own.
+        // The pass doubles as the live-refresh path for opacity changes:
+        // re-stamp the container and surface backing so dragging the opacity
+        // slider flips the compositor without a relaunch.
         Self.updateContainerBacking(nsView)
         surfaceView.refreshAppearanceBacking()
         if surfaceView.superview !== nsView {
-            attach(surfaceView, to: nsView)
+            Self.performAttach(surfaceView, to: nsView, isPaneVisible: isPaneVisible)
         }
         // Don't yank focus out of a text editor (sidebar search, rename
-        // field, …). SwiftUI re-runs updateNSView roughly every second
-        // because of the sidebar's per-workspace elapsed-time
-        // TimelineView, so any unconditional sync here would steal focus
-        // and re-light the terminal cursor ~1s after the user clicks the
+        // field, …). An unconditional sync here would steal focus and
+        // re-light the terminal cursor right after the user clicks the
         // search box. resignFirstResponder already pushed ghostty into
         // the unfocused state; leave it alone until the responder dance
         // unwinds naturally.
         //
         // `deferFocus` covers the command palette: while it's open, skip
-        // the focus sync entirely so this ~1/s pass can't race the
-        // palette's search field for first responder.
+        // the focus sync entirely so this pass can't race the palette's
+        // search field for first responder.
         guard !deferFocus else { return }
         let textEditorActive = surfaceView.window?.firstResponder is NSText
         if !textEditorActive {
@@ -143,6 +176,25 @@ struct PaneSurfaceRepresentable: NSViewRepresentable {
         /// Paired with the surface-side host claim for the post-commit recheck.
         weak var expectedSurface: GhosttySurfaceView?
 
+        deinit {
+            // A host dismantled without an ownership hand-off nils the
+            // surface's weak paneHostView silently — no invalidation event
+            // ever fires, so a pending recovery that already outlived its
+            // backstop budget would strand the surface forever. Hand it one
+            // last event. Identity cannot be re-checked via
+            // `surface.paneHostView === self` (a weak reference is already
+            // nil by the time deinit runs); the generation token proves the
+            // recording still describes this container's tenure. All state
+            // checks happen on the main queue, where the recording may since
+            // have moved on.
+            guard let surface = expectedSurface else { return }
+            let generation = hostGeneration
+            DispatchQueue.main.async {
+                PaneSurfaceRepresentable.recoverPendingClaim(
+                    for: surface, afterHostDeinit: generation)
+            }
+        }
+
         override var mouseDownCanMoveWindow: Bool { false }
 
         override func setFrameOrigin(_ newOrigin: NSPoint) {
@@ -181,20 +233,41 @@ struct PaneSurfaceRepresentable: NSViewRepresentable {
 
     /// Which attach attempt this is. The passes differ only in which guard
     /// they are allowed to skip.
-    private enum AttachPass {
-        /// SwiftUI's own `makeNSView` / `updateNSView` call.
+    enum AttachPass {
+        /// SwiftUI's own `makeNSView` / `updateNSView` call, and every
+        /// recovery re-entry: full arbitration, deferral included.
         case initial
         /// Re-run once the commit made the incoming host's attachment state
-        /// readable, resolving the split-collapse ambiguity.
+        /// readable, resolving the split-collapse ambiguity. Skips only the
+        /// deferral itself — the claim verdict still applies.
         case postCommitDeferred
-        /// Re-run after the commit found the surface's recorded host claim
-        /// stale: the recording loses its veto and this container pins.
+        /// Re-run after the recovery proved the recorded host no longer
+        /// speaks for this surface (attached, expecting another). The only
+        /// pass allowed to skip the generation claim: a recording that
+        /// demonstrably describes someone else's container has no standing
+        /// to veto on generation. A detached or missing host never reaches
+        /// this pass — it re-enters `.initial` so the deferral still
+        /// protects a pre-commit host.
         case staleRecordingRecovery
     }
 
-    private func attach(_ surface: GhosttySurfaceView,
-                        to container: NoDragContainerView,
-                        pass: AttachPass = .initial) {
+    /// The attach arbitration, on the type rather than the instance so the
+    /// event-driven recovery (and the regression tests) can re-drive it with
+    /// a real surface and container instead of a test-side re-implementation.
+    static func performAttach(_ surface: GhosttySurfaceView,
+                              to container: NoDragContainerView,
+                              isPaneVisible: @escaping () -> Bool,
+                              pass: AttachPass = .initial) {
+        // The impostor gate: the outgoing tree's final update runs after the
+        // incoming tree has already claimed the recycled containers. Without
+        // this check that stale update re-pins the outgoing workspace's
+        // surface — via isSameHost or via a recording the hand-off just
+        // cleared. A gate-blocked attach disarms any pending recovery: the
+        // pane is not the one on screen anymore.
+        guard SurfaceAttachGate.allowsAttach(paneIsVisible: isPaneVisible()) else {
+            disarmPendingRecovery(surface)
+            return
+        }
         let currentHost = surface.paneHostView
         if pass == .initial,
            SurfaceHostClaimPolicy.shouldDeferUntilAfterCommit(
@@ -213,7 +286,8 @@ struct PaneSurfaceRepresentable: NSViewRepresentable {
             // older host genuinely needs to recover it.
             DispatchQueue.main.async {
                 guard container.window != nil, isPaneVisible() else { return }
-                attach(surface, to: container, pass: .postCommitDeferred)
+                performAttach(surface, to: container,
+                              isPaneVisible: isPaneVisible, pass: .postCommitDeferred)
             }
             return
         }
@@ -225,15 +299,36 @@ struct PaneSurfaceRepresentable: NSViewRepresentable {
                 isSameHost: currentHost === container
             )
             guard shouldClaim else {
-                scheduleStaleRecordingRecovery(surface, to: container)
+                // Arm the event-driven recovery: the recording's veto may
+                // dissolve long after this pass (the host gets reclaimed by
+                // another pane's surface), and with no incidental
+                // updateNSView pass left, only the invalidation event can
+                // re-drive this attach. The bounded backstop below only
+                // covers the paths no event fires for (e.g. the host
+                // deallocations and the weak reference nils silently).
+                armPendingRecovery(surface, host: container, visible: isPaneVisible)
+                scheduleRecoveryBackstop(surface, to: container,
+                                         isPaneVisible: isPaneVisible,
+                                         epoch: surface.pendingRecoveryEpoch)
                 return
             }
         }
 
+        disarmPendingRecovery(surface)
         surface.paneHostView = container
         surface.paneHostGeneration = container.hostGeneration
+        // Ownership hand-off: the moment this container stops speaking for the
+        // surface it held, that surface's recording of this container loses
+        // all standing. Clearing it here (and in `pin`'s eviction below) means
+        // a recycled container can never veto its previous surface's next
+        // legitimate attach — the decline-forever state from #103 is dead at
+        // birth instead of only detectable after the fact.
+        let previousSurface = container.expectedSurface
         container.expectedSurface = surface
-        Self.pin(surface, in: container)
+        if let previousSurface, previousSurface !== surface {
+            invalidateStaleRecording(of: previousSurface, hostedBy: container)
+        }
+        pin(surface, in: container)
         // When the split tree reshapes (workspace switch, pane close), SwiftUI
         // evaluates the OUTGOING tree's representables once more before
         // dismantling them, and that stale update can run *after* this attach —
@@ -251,29 +346,142 @@ struct PaneSurfaceRepresentable: NSViewRepresentable {
                 hostClaimMatches: surface.paneHostView === container &&
                     surface.paneHostGeneration == container.hostGeneration
             ) else { return }
-            Self.pin(surface, in: container)
+            pin(surface, in: container)
         }
     }
 
-    /// A declined claim used to be final, so a surface whose recorded host had
-    /// been recycled onto another pane stayed stuck on the outgoing
-    /// workspace's terminal until relaunch. Re-check after the commit: if the
-    /// recording no longer describes a live host that expects this surface, it
-    /// has no standing to veto and this container takes over.
-    private func scheduleStaleRecordingRecovery(_ surface: GhosttySurfaceView,
-                                                to container: NoDragContainerView) {
+    /// Opportunistic backstop for the event-driven recovery — NOT the
+    /// correctness mechanism. Each turn re-samples the recorded host's fate:
+    ///
+    /// - Still attached and still expecting this surface → the veto is live;
+    ///   sample again next turn, up to `recoveryRetryBudget`. Giving up does
+    ///   NOT disarm the pending recovery: `invalidateStaleRecording` fires
+    ///   whenever the host is finally reclaimed, however late, and re-drives
+    ///   the full arbitration (a fixed budget can only shrink the race
+    ///   window, never close the state machine — the invalidation event
+    ///   closes it).
+    /// - Gone or detached → full `.initial` re-entry, deferral included, so a
+    ///   pre-commit host keeps its #96 protection. This is the one path no
+    ///   invalidation event covers: a deallocated host nils the weak
+    ///   reference silently.
+    /// - Attached and expecting another surface → provably stale; the
+    ///   `.staleRecordingRecovery` pass may skip the generation claim.
+    ///
+    /// The `epoch` token invalidates chains that outlived their intent: every
+    /// arm, disarm, or re-arm bumps `pendingRecoveryEpoch`, so a backstop
+    /// queued for an older pending claim dies on its next turn instead of
+    /// acting for a candidate nobody asked for anymore (e.g. after a
+    /// successful claim cleared the pending state, or a newer decline
+    /// re-armed it for a different container).
+    private static func scheduleRecoveryBackstop(
+        _ surface: GhosttySurfaceView,
+        to container: NoDragContainerView,
+        isPaneVisible: @escaping () -> Bool,
+        epoch: UInt,
+        remainingRetries: Int = recoveryRetryBudget
+    ) {
         DispatchQueue.main.async {
-            guard container.window != nil, isPaneVisible() else { return }
+            guard surface.pendingRecoveryEpoch == epoch,
+                  container.window != nil,
+                  SurfaceAttachGate.allowsAttach(paneIsVisible: isPaneVisible()) else {
+                return
+            }
             let host = surface.paneHostView
-            guard SurfaceHostClaimPolicy.recordedHostIsStale(
+            let hostStillVetoes =
+                host !== container &&
+                host?.window != nil &&
+                (host as? NoDragContainerView)?.expectedSurface === surface
+            if hostStillVetoes {
+                guard remainingRetries > 0 else { return }
+                scheduleRecoveryBackstop(surface, to: container,
+                                         isPaneVisible: isPaneVisible,
+                                         epoch: epoch,
+                                         remainingRetries: remainingRetries - 1)
+                return
+            }
+            if host == nil || host?.window == nil {
+                performAttach(surface, to: container,
+                              isPaneVisible: isPaneVisible, pass: .initial)
+            } else if SurfaceHostClaimPolicy.recordedHostIsStale(
                 currentHostExists: host != nil,
                 currentHostIsAttached: host?.window != nil,
                 currentHostExpectsThisSurface:
                     (host as? NoDragContainerView)?.expectedSurface === surface,
                 isSameHost: host === container
-            ) else { return }
-            attach(surface, to: container, pass: .staleRecordingRecovery)
+            ) {
+                performAttach(surface, to: container,
+                              isPaneVisible: isPaneVisible, pass: .staleRecordingRecovery)
+            }
         }
+    }
+
+    /// Arms the event-driven recovery for a declined claim, bumping the epoch
+    /// so any backstop chain queued for an earlier pending claim dies.
+    private static func armPendingRecovery(_ surface: GhosttySurfaceView,
+                                           host: NoDragContainerView,
+                                           visible: @escaping () -> Bool) {
+        surface.pendingRecoveryHost = host
+        surface.pendingRecoveryVisibility = visible
+        surface.pendingRecoveryEpoch += 1
+    }
+
+    /// Clears the pending recovery (successful claim, or a gate-blocked
+    /// impostor), likewise bumping the epoch to kill in-flight backstop
+    /// chains that still speak for the cleared claim.
+    private static func disarmPendingRecovery(_ surface: GhosttySurfaceView) {
+        guard surface.pendingRecoveryHost != nil ||
+              surface.pendingRecoveryVisibility != nil else { return }
+        surface.pendingRecoveryHost = nil
+        surface.pendingRecoveryVisibility = nil
+        surface.pendingRecoveryEpoch += 1
+    }
+
+    /// How many extra runloop turns the backstop may spend re-sampling the
+    /// recorded host's fate. Small on purpose: correctness comes from the
+    /// invalidation event, not from polling.
+    private static let recoveryRetryBudget = 8
+
+    /// Deallocation follow-up for a host that died without an ownership
+    /// hand-off — the last eventless path. The weak paneHostView nils
+    /// silently on dealloc, so a pending recovery whose backstop budget
+    /// already ran out would never be re-driven. Verified on the main queue:
+    /// the recording must still describe the dead host's tenure (nil host +
+    /// matching generation token — identity is unverifiable by then), and
+    /// the pending candidate must still be attached and its pane visible;
+    /// then the claim re-enters the FULL `.initial` arbitration, deferral
+    /// included.
+    static func recoverPendingClaim(for surface: GhosttySurfaceView,
+                                    afterHostDeinit generation: UInt64) {
+        guard surface.paneHostView == nil,
+              surface.paneHostGeneration == generation,
+              let candidate = surface.pendingRecoveryHost as? NoDragContainerView,
+              candidate.window != nil,
+              let visible = surface.pendingRecoveryVisibility else { return }
+        performAttach(surface, to: candidate, isPaneVisible: visible, pass: .initial)
+    }
+
+    /// Drop a surface's host recording once the container it names stops
+    /// hosting it — the container was reclaimed by another pane's surface, or
+    /// evicted this one. Surviving recordings are vetoes: they still name an
+    /// attached container whose generation outranks the next candidate, which
+    /// is how a workspace switch could leave a pane on the outgoing
+    /// workspace's terminal forever. Clearing the recording also re-drives
+    /// the surface's pending recovery, if it has one — this invalidation is
+    /// the event that dissolves the veto.
+    static func invalidateStaleRecording(of surface: GhosttySurfaceView,
+                                         hostedBy container: NSView) {
+        guard surface.paneHostView === container else { return }
+        surface.paneHostView = nil
+        // Never pin into a candidate that has not mounted: the surface would
+        // ride a window-less container whose reassert bails on
+        // `containerIsAttached`, leaving the pane blank until the next store
+        // mutation. A candidate still mid-commit gets its claim when its own
+        // representable mounts (host is nil now, so `shouldClaim` passes);
+        // the pending state stays armed for the events that follow.
+        guard let candidate = surface.pendingRecoveryHost as? NoDragContainerView,
+              candidate.window != nil,
+              let visible = surface.pendingRecoveryVisibility else { return }
+        performAttach(surface, to: candidate, isPaneVisible: visible, pass: .initial)
     }
 
     private static func pin(_ surface: GhosttySurfaceView, in container: NSView) {
@@ -283,6 +491,9 @@ struct PaneSurfaceRepresentable: NSViewRepresentable {
         // we have to actively clean up rather than rely on full teardown.
         for child in container.subviews where child !== surface {
             child.removeFromSuperview()
+            if let evicted = child as? GhosttySurfaceView {
+                invalidateStaleRecording(of: evicted, hostedBy: container)
+            }
         }
         guard surface.superview !== container else { return }
         surface.removeFromSuperview()

--- a/Glint/Pane/PaneView.swift
+++ b/Glint/Pane/PaneView.swift
@@ -58,8 +58,11 @@ struct PaneView: View {
                 surfaceView: store.surfaceView(workspaceID: workspaceID, paneID: paneID, cwd: cwd),
                 focused: isFocused,
                 deferFocus: store.commandPaletteOpen || store.agentChooserIntent != nil,
-                isPaneVisible: {
-                    store.isPaneVisible(.init(workspace: workspaceID, pane: paneID))
+                isPaneVisible: { [weak store = store] in
+                    // Weak on purpose: the recovery stores this closure on the
+                    // surface for longer than a view lifetime, and the store
+                    // owns the surfaces — a strong capture would be a cycle.
+                    store?.isPaneVisible(.init(workspace: workspaceID, pane: paneID)) ?? false
                 }
             )
             if !isFocused {

--- a/GlintTests/PerformanceRegressionTests.swift
+++ b/GlintTests/PerformanceRegressionTests.swift
@@ -265,19 +265,47 @@ final class PerformanceRegressionTests: XCTestCase {
         ))
     }
 
-    func testDetachedOrMissingRecordedHostIsStale() {
-        XCTAssertTrue(SurfaceHostClaimPolicy.recordedHostIsStale(
+    func testDetachedOrMissingRecordedHostIsNotStaleForRecovery() {
+        // A detached or missing host has no standing to veto in `shouldClaim`
+        // (both pass the claim directly), so the recovery pass must not
+        // adjudicate it stale — worse, "detached" is indistinguishable from
+        // "brand-new host mid-commit, not in the window yet", and force-pinning
+        // across that gap is exactly the steal-back #96's generation guard
+        // exists to prevent.
+        XCTAssertFalse(SurfaceHostClaimPolicy.recordedHostIsStale(
             currentHostExists: true,
             currentHostIsAttached: false,
             currentHostExpectsThisSurface: true,
             isSameHost: false
         ))
-        XCTAssertTrue(SurfaceHostClaimPolicy.recordedHostIsStale(
+        XCTAssertFalse(SurfaceHostClaimPolicy.recordedHostIsStale(
             currentHostExists: false,
             currentHostIsAttached: false,
             currentHostExpectsThisSurface: false,
             isSameHost: false
         ))
+    }
+
+    func testInvisiblePaneCannotAttachThroughSynchronousPath() {
+        // The outgoing tree's final updateNSView runs after the incoming tree
+        // claimed the recycled containers; its pane is no longer visible, so
+        // the synchronous attach must refuse — every async pass already did.
+        XCTAssertTrue(SurfaceAttachGate.allowsAttach(paneIsVisible: true))
+        XCTAssertFalse(SurfaceAttachGate.allowsAttach(paneIsVisible: false))
+    }
+
+    func testRecordingInvalidationOnlyDropsTheNamedContainer() {
+        let container = PaneSurfaceRepresentable.NoDragContainerView()
+        let other = PaneSurfaceRepresentable.NoDragContainerView()
+        let released = GhosttySurfaceView(frame: .zero)
+        let bystander = GhosttySurfaceView(frame: .zero)
+        released.paneHostView = container
+        bystander.paneHostView = other
+
+        PaneSurfaceRepresentable.invalidateStaleRecording(of: released, hostedBy: container)
+
+        XCTAssertNil(released.paneHostView)
+        XCTAssertTrue(bystander.paneHostView === other)
     }
 
     func testSameHostIsNeverTreatedAsStaleRecording() {
@@ -289,84 +317,351 @@ final class PerformanceRegressionTests: XCTestCase {
         ))
     }
 
-    /// Reproduces the workspace-switch shape from #103: SwiftUI recycles the
-    /// split containers in flipped order, so surface A's recording ends up
-    /// pointing at the container that now hosts surface B. Without the
-    /// post-commit staleness recheck, A's legitimate attach is declined
-    /// forever and its pane keeps rendering the outgoing workspace.
-    func testSurfaceRecoversFromRecordingPointingAtRecycledContainer() {
+    /// Real-path stage for the host-claim sequences: a borderless window
+    /// with two recycled containers whose creation order drives their
+    /// generations, driven through the production `performAttach` — no
+    /// test-side arbiter to drift from the real one.
+    @MainActor
+    private final class PaneHostStage {
+        let window: NSWindow
+        let older: PaneSurfaceRepresentable.NoDragContainerView
+        let newer: PaneSurfaceRepresentable.NoDragContainerView
+
+        init() {
+            window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+                styleMask: [.borderless], backing: .buffered, defer: false
+            )
+            let root = NSView(frame: window.contentLayoutRect)
+            window.contentView = root
+            // Creation order drives `hostGeneration`: older < newer.
+            older = .init()
+            newer = .init()
+            root.addSubview(older)
+            root.addSubview(newer)
+        }
+
+        func attach(_ surface: GhosttySurfaceView,
+                    to container: PaneSurfaceRepresentable.NoDragContainerView,
+                    visible: Bool) {
+            PaneSurfaceRepresentable.performAttach(
+                surface, to: container, isPaneVisible: { visible })
+        }
+    }
+
+    /// Pumps the main queue for `turns` DispatchQueue.main.async rounds. The
+    /// awaited fulfillment guarantees every earlier main-queue block has run
+    /// (FIFO), so N turns = N async generations.
+    private func drainMainQueue(turns: Int) async {
+        for _ in 0..<turns {
+            let drained = XCTestExpectation(description: "main queue drained")
+            DispatchQueue.main.async { drained.fulfill() }
+            await fulfillment(of: [drained], timeout: 5)
+        }
+    }
+
+    /// Reproduces the workspace-switch steal-back shape: the incoming tree
+    /// claims a recycled container, then the OUTGOING tree's final
+    /// updateNSView runs and — its pane no longer visible — must not be able
+    /// to re-pin the old workspace's surface into that container. The
+    /// hand-off has already cleared the outgoing surface's recording, so its
+    /// late attach looks like a first mount (host nil): only the visibility
+    /// gate stops it. This is exactly why the gate must not be narrowed to
+    /// re-claims (host != nil).
+    func testOutgoingRepresentableCannotStealRecycledContainerAfterSwitch() {
+        let stage = PaneHostStage()
+        let surfaceOld = GhosttySurfaceView(frame: .zero)
+        let surfaceNew = GhosttySurfaceView(frame: .zero)
+
+        // Outgoing workspace: its pane's surface lives in the container.
+        stage.attach(surfaceOld, to: stage.older, visible: true)
+        XCTAssertTrue(surfaceOld.superview === stage.older)
+
+        // Switch: the incoming surface claims the same recycled container
+        // first (#93 documented that the outgoing tree is evaluated last)…
+        stage.attach(surfaceNew, to: stage.older, visible: true)
+        // …then the outgoing tree's final update arrives, pane invisible —
+        // once with the hand-off-cleared (nil) recording…
+        stage.attach(surfaceOld, to: stage.older, visible: false)
+        // …and once with a recording that still names the container, in case
+        // any path ever skips the hand-off clearing.
+        surfaceOld.paneHostView = stage.older
+        stage.attach(surfaceOld, to: stage.older, visible: false)
+
+        XCTAssertTrue(surfaceNew.superview === stage.older,
+                      "the outgoing surface must not steal the recycled container back")
+        XCTAssertTrue(surfaceNew.paneHostView === stage.older)
+        XCTAssertTrue(stage.older.expectedSurface === surfaceNew)
+        XCTAssertFalse(surfaceOld.superview === stage.older)
+    }
+
+    /// Reproduces the ordering confirmed against v0.1.28-beta.2 (defect: the
+    /// recovery sampled once, too early, and never retried): surface A's
+    /// attach is declined while its recorded host still expects it; the host
+    /// is reclaimed by another pane's surface only afterwards. The
+    /// invalidation event — not runloop polling — must re-drive A's pending
+    /// claim through full arbitration. No main-queue turn passes in this
+    /// test, so a fixed retry budget could not have helped.
+    func testEventDrivenRecoveryTakesOverOnInvalidationWithoutRunloopTurns() {
+        let stage = PaneHostStage()
+        let surfaceA = GhosttySurfaceView(frame: .zero)
+        let surfaceB = GhosttySurfaceView(frame: .zero)
+
+        // Outgoing workspace: A lives in the newer container.
+        stage.attach(surfaceA, to: stage.newer, visible: true)
+        XCTAssertTrue(surfaceA.superview === stage.newer)
+
+        // Incoming: A's pane is handed the older container and declined
+        // (newer is attached, newer-generation, still expecting A).
+        stage.attach(surfaceA, to: stage.older, visible: true)
+        XCTAssertTrue(surfaceA.superview === stage.newer,
+                      "declined attach must not move the surface")
+        XCTAssertTrue(surfaceA.pendingRecoveryHost === stage.older,
+                      "the declined claim must arm the event-driven recovery")
+
+        // The other pane's surface reclaims `newer` one commit later: the
+        // hand-off invalidates A's recording, which re-drives A's pending
+        // claim synchronously.
+        stage.attach(surfaceB, to: stage.newer, visible: true)
+
+        XCTAssertTrue(surfaceA.superview === stage.older,
+                      "the invalidation event must re-drive the declined claim")
+        XCTAssertTrue(surfaceB.superview === stage.newer)
+        XCTAssertTrue(surfaceA.paneHostView === stage.older)
+        XCTAssertNil(surfaceA.pendingRecoveryHost)
+    }
+
+    /// The backstop budget must not gate correctness: with the recorded host
+    /// still vetoing, the backstop exhausts itself and gives up — but the
+    /// pending claim stays armed, so an invalidation arriving arbitrarily
+    /// later still takes over. (A reclaim pushed past the budget was the
+    /// second confirmed counter-example: a fixed budget only shrinks the
+    /// race window.)
+    func testPendingRecoverySurvivesBackstopExhaustion() async {
+        let stage = PaneHostStage()
+        let surfaceA = GhosttySurfaceView(frame: .zero)
+        let surfaceB = GhosttySurfaceView(frame: .zero)
+
+        stage.attach(surfaceA, to: stage.newer, visible: true)
+        stage.attach(surfaceA, to: stage.older, visible: true) // declined
+
+        // Drain well past the (private, 8-turn) backstop budget; the host
+        // keeps vetoing the whole time, as a rightful owner would.
+        await drainMainQueue(turns: 12)
+
+        XCTAssertTrue(surfaceA.superview === stage.newer,
+                      "a rightful owner must outlive the backstop budget")
+        XCTAssertTrue(surfaceA.pendingRecoveryHost === stage.older,
+                      "budget exhaustion must not disarm the pending recovery")
+
+        // The host is finally reclaimed — much later than any budget.
+        stage.attach(surfaceB, to: stage.newer, visible: true)
+
+        XCTAssertTrue(surfaceA.superview === stage.older,
+                      "the late invalidation must still re-drive the claim")
+        XCTAssertTrue(surfaceB.superview === stage.newer)
+    }
+
+    /// The last eventless path: a host that simply DEALLOCATES (dismantled
+    /// without an ownership hand-off) nils the surface's weak paneHostView
+    /// silently — no invalidation fires. A pending recovery that already
+    /// outlived its backstop budget would strand the surface forever; the
+    /// container's deinit must hand the claim one last event via the
+    /// generation token (identity is unverifiable in deinit — the weak
+    /// reference is already nil by then).
+    func testPendingRecoverySurvivesHostDeallocationAfterBackstopExhaustion() async {
+        // Standalone stage: `newer` must be fully releasable, which the
+        // shared PaneHostStage's stored properties prevent.
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
             styleMask: [.borderless], backing: .buffered, defer: false
         )
         let root = NSView(frame: window.contentLayoutRect)
         window.contentView = root
-
-        // Two recycled containers, both live in the window across the switch.
-        let older = NSView()
-        let newer = NSView()
+        let older = PaneSurfaceRepresentable.NoDragContainerView()
+        var newer: PaneSurfaceRepresentable.NoDragContainerView? =
+            .init() // created second: the newer generation
         root.addSubview(older)
-        root.addSubview(newer)
-        let generation: [ObjectIdentifier: UInt64] = [
-            ObjectIdentifier(older): 10,
-            ObjectIdentifier(newer): 11,
-        ]
+        root.addSubview(newer!)
+        let surfaceA = GhosttySurfaceView(frame: .zero)
 
-        let surfaceA = NSView()
-        let surfaceB = NSView()
-
-        // What each container currently expects, and what each surface has
-        // recorded as its host — the pair `attach` keeps in sync.
-        var expectedSurface: [ObjectIdentifier: NSView] = [:]
-        var recordedHost: [ObjectIdentifier: NSView] = [:]
-
-        func pin(_ surface: NSView, in container: NSView) {
-            for child in container.subviews where child !== surface {
-                child.removeFromSuperview()
-            }
-            surface.removeFromSuperview()
-            container.addSubview(surface)
-            expectedSurface[ObjectIdentifier(container)] = surface
-            recordedHost[ObjectIdentifier(surface)] = container
+        func attach(_ surface: GhosttySurfaceView,
+                    to container: PaneSurfaceRepresentable.NoDragContainerView,
+                    visible: Bool) {
+            PaneSurfaceRepresentable.performAttach(
+                surface, to: container, isPaneVisible: { visible })
         }
 
-        func attach(_ surface: NSView, to container: NSView) {
-            let host = recordedHost[ObjectIdentifier(surface)]
-            let claimed = SurfaceHostClaimPolicy.shouldClaim(
-                candidateGeneration: generation[ObjectIdentifier(container)]!,
-                currentGeneration: host.map { generation[ObjectIdentifier($0)]! } ?? 0,
-                currentHostIsAttached: host?.window != nil,
-                isSameHost: host === container
-            )
-            if claimed {
-                pin(surface, in: container)
-                return
-            }
-            // Post-commit recovery.
-            guard SurfaceHostClaimPolicy.recordedHostIsStale(
-                currentHostExists: host != nil,
-                currentHostIsAttached: host?.window != nil,
-                currentHostExpectsThisSurface:
-                    host.flatMap { expectedSurface[ObjectIdentifier($0)] } === surface,
-                isSameHost: host === container
-            ) else { return }
-            pin(surface, in: container)
-        }
+        attach(surfaceA, to: newer!, visible: true)
+        attach(surfaceA, to: older, visible: true) // declined, pending armed
+        await drainMainQueue(turns: 12)            // backstop budget exhausted
 
-        // Outgoing workspace: A lives in the newer container.
-        attach(surfaceA, to: newer)
-        XCTAssertTrue(surfaceA.superview === newer)
+        XCTAssertTrue(surfaceA.pendingRecoveryHost === older,
+                      "precondition: the pending recovery is still armed")
 
-        // Incoming workspace reuses that same container for B, and hands A the
-        // older one. A's recording still points at `newer`, which is attached
-        // and outranks `older` on generation.
-        attach(surfaceB, to: newer)
-        attach(surfaceA, to: older)
+        // The host is dismantled outright — not reclaimed by another
+        // surface. Releasing the last strong references runs deinit, which
+        // queues the generation-token follow-up.
+        newer?.removeFromSuperview()
+        newer = nil
+        await drainMainQueue(turns: 2)
 
-        XCTAssertTrue(surfaceB.superview === newer)
         XCTAssertTrue(surfaceA.superview === older,
-                      "surface A must recover its pane instead of staying evicted")
-        XCTAssertTrue(recordedHost[ObjectIdentifier(surfaceA)] === older)
+                      "the deallocation token must re-drive the pending claim")
+        XCTAssertTrue(surfaceA.paneHostView === older)
+        XCTAssertNil(surfaceA.pendingRecoveryHost)
+    }
+
+    /// P1 from the #109 review: the invalidation re-drive must never pin the
+    /// surface into a candidate that has not mounted. A candidate still
+    /// mid-commit claims when its own representable mounts (the recording is
+    /// nil by then, so `shouldClaim` passes); pinning early would strand the
+    /// surface in a window-less container whose reassert bails on
+    /// `containerIsAttached`.
+    func testInvalidationRedriveSkipsUnmountedCandidate() {
+        let stage = PaneHostStage()
+        let surfaceA = GhosttySurfaceView(frame: .zero)
+        let surfaceB = GhosttySurfaceView(frame: .zero)
+
+        // The candidate `older` is mid-commit: not in the window yet.
+        stage.older.removeFromSuperview()
+
+        stage.attach(surfaceA, to: stage.newer, visible: true)
+        // A's claim for the unmounted candidate is declined (newer vetoes)
+        // and arms the pending recovery.
+        stage.attach(surfaceA, to: stage.older, visible: true)
+        XCTAssertTrue(surfaceA.pendingRecoveryHost === stage.older)
+
+        // The veto dissolves — but the candidate is still unmounted: no pin.
+        stage.attach(surfaceB, to: stage.newer, visible: true)
+
+        XCTAssertTrue(surfaceA.superview == nil,
+                      "the surface must not ride a window-less candidate")
+        XCTAssertTrue(surfaceA.paneHostView == nil)
+        XCTAssertTrue(surfaceA.pendingRecoveryHost === stage.older,
+                      "the pending claim stays armed for the candidate's own mount")
+
+        // The candidate's commit lands: its representable mounts and claims
+        // (host nil → shouldClaim passes).
+        stage.window.contentView?.addSubview(stage.older)
+        stage.attach(surfaceA, to: stage.older, visible: true)
+
+        XCTAssertTrue(surfaceA.superview === stage.older)
+        XCTAssertTrue(surfaceA.paneHostView === stage.older)
+    }
+
+    /// P1 from the #109 review: a backstop chain queued for an OLD pending
+    /// claim must die once that claim is satisfied and cleared — otherwise,
+    /// when the new host is later detached mid-commit, the stale chain would
+    /// re-claim the old candidate as if the surface still wanted it. The
+    /// epoch token invalidates the chain at its next turn.
+    func testStaleBackstopChainDiesAfterPendingIsCleared() async {
+        let stage = PaneHostStage()
+        let surfaceA = GhosttySurfaceView(frame: .zero)
+        let newest = PaneSurfaceRepresentable.NoDragContainerView()
+        stage.window.contentView?.addSubview(newest) // created last: newest gen
+
+        stage.attach(surfaceA, to: stage.newer, visible: true)
+        // Declined for `older` — a backstop chain is queued for that claim.
+        stage.attach(surfaceA, to: stage.older, visible: true)
+        XCTAssertTrue(surfaceA.pendingRecoveryHost === stage.older)
+
+        // The surface is claimed by an even newer container instead; the
+        // pending state clears and the epoch bumps.
+        stage.attach(surfaceA, to: newest, visible: true)
+        XCTAssertNil(surfaceA.pendingRecoveryHost)
+
+        // The new host is momentarily detached mid-commit — exactly when a
+        // stale chain, if it still ran, would re-claim `older`.
+        newest.removeFromSuperview()
+        await drainMainQueue(turns: 12)
+
+        XCTAssertTrue(surfaceA.superview === newest,
+                      "a stale backstop chain must not re-claim the old candidate")
+        XCTAssertTrue(surfaceA.paneHostView === newest)
+        XCTAssertNil(stage.older.expectedSurface)
+    }
+
+    /// Reproduces the pre-commit steal-back counter-example (defect: the
+    /// recovery re-entered arbitration with the deferral skipped): the newer
+    /// host is temporarily window-less mid-commit while an older candidate
+    /// wants the surface. The re-entry must go through the full `.initial`
+    /// pass so `shouldDeferUntilAfterCommit` still grants the newer host its
+    /// one-commit grace; once it re-attaches, the older candidate's claim is
+    /// declined and the backstop exhausts without ever moving the surface.
+    func testPreCommitDetachedHostIsNotStolenByRecovery() async {
+        let stage = PaneHostStage()
+        let surfaceA = GhosttySurfaceView(frame: .zero)
+
+        stage.attach(surfaceA, to: stage.newer, visible: true)
+
+        // Mid-commit: the newer host is momentarily out of the window but
+        // still alive and expecting A.
+        stage.newer.removeFromSuperview()
+        // The older candidate's attach defers (host exists, detached,
+        // older generation) instead of claiming…
+        stage.attach(surfaceA, to: stage.older, visible: true)
+        // …and the commit lands: the newer host survives and re-attaches.
+        stage.window.contentView?.addSubview(stage.newer)
+
+        await drainMainQueue(turns: 12)
+
+        XCTAssertTrue(surfaceA.superview === stage.newer,
+                      "the surface must never be stolen from a pre-commit host")
+        XCTAssertTrue(surfaceA.paneHostView === stage.newer)
+        XCTAssertNil(stage.older.expectedSurface)
+    }
+
+    /// The backstop's detached-host re-entry is the exact spot the previous
+    /// fix regressed: re-entering with a deferral-skipping pass let the
+    /// older container claim while the newer host was merely window-less
+    /// mid-commit (#96's steal-back). The re-entry must go through the full
+    /// `.initial` pass so `shouldDeferUntilAfterCommit` grants the newer
+    /// host its one-commit grace. The queue surgery below orders the turns
+    /// deterministically: the backstop samples while the host is detached,
+    /// the host re-attaches (the commit landed), and only then does the
+    /// deferred pass run.
+    func testBackstopReentryKeepsDeferralForDetachedHost() async {
+        let stage = PaneHostStage()
+        let surfaceA = GhosttySurfaceView(frame: .zero)
+
+        stage.attach(surfaceA, to: stage.newer, visible: true)
+        // Decline while the host still vetoes — the backstop's first sample
+        // is now queued…
+        stage.attach(surfaceA, to: stage.older, visible: true)
+        // …then detach the host, and queue the re-attach BEHIND that sample.
+        // The `.initial` re-entry appends its deferred pass after the
+        // re-attach, so the pass observes the host attached again.
+        stage.newer.removeFromSuperview()
+        DispatchQueue.main.async { [weak stage] in
+            stage?.window.contentView?.addSubview(stage?.newer ?? NSView())
+        }
+        await drainMainQueue(turns: 14)
+
+        XCTAssertTrue(surfaceA.superview === stage.newer,
+                      "a deferral-skipping re-entry steals from a pre-commit host")
+        XCTAssertTrue(surfaceA.paneHostView === stage.newer)
+        XCTAssertNil(stage.older.expectedSurface)
+    }
+
+    /// A successful claim — from any pass — must clear the pending recovery,
+    /// otherwise a stale candidate container could be re-driven by a later,
+    /// unrelated invalidation.
+    func testClaimClearsPendingRecovery() {
+        let stage = PaneHostStage()
+        let surfaceA = GhosttySurfaceView(frame: .zero)
+        let newest = PaneSurfaceRepresentable.NoDragContainerView()
+        stage.window.contentView?.addSubview(newest) // created last: newest generation
+
+        stage.attach(surfaceA, to: stage.newer, visible: true)
+        stage.attach(surfaceA, to: stage.older, visible: true) // declined, pending armed
+        XCTAssertTrue(surfaceA.pendingRecoveryHost === stage.older)
+
+        stage.attach(surfaceA, to: newest, visible: true) // newer generation: claims
+
+        XCTAssertTrue(surfaceA.superview === newest)
+        XCTAssertNil(surfaceA.pendingRecoveryHost)
+        XCTAssertNil(surfaceA.pendingRecoveryVisibility)
     }
 
     func testSplitLayoutExplicitlyAccountsForBothBranchesAndDivider() {


### PR DESCRIPTION
## 问题 / Problems

v0.1.28-beta.1/2 出现两个 0.1.27 已修复的回归（`15e633e` 是 0.1.27 → beta.2 之间唯一的 pane 挂载改动）：

1. 双 pane 分屏切换 workspace 后，一侧 pane 停留在旧 workspace 的终端直到重启（#93 / #103 症状复活）。
2. 3+ pane 场景拖分割线一侧不 resize。坏状态在更早的树重塑中产生（surface 被搁浅进一个不再接收布局的 host），拖动只是让坏状态显形——与 #96 当年「黑盒拖拽无法复现、靠确定性 harness 钉死」一致（#96 症状复活）。

## 根因 / Root causes

`15e633e` 的恢复通道有三个结构缺陷：

1. **一次性采样**：`scheduleStaleRecordingRecovery` 只复查一次。复查时旧 host 尚未被别的 surface 复用 → 放弃；随后 host 换 surface，再无第二次机会（`updateNSView` 在 inputs 不变时不再重跑，`ContentView` 已有注释证实），pane 永久停留旧内容。
2. **detached 判 stale + 重入跳过 defer**：被绕过的守卫是 `shouldDeferUntilAfterCommit`，而非世代仲裁——`shouldClaim` 对 detached host 本就不看世代。旧容器在 commit 前的窗口期把 surface 从尚未入 window 的新 host 手里抢回，surface 从此不跟随新布局。
3. **同步 attach 缺可见性门禁**（三条 async 路径都有）：workspace 切换时旧树最后一次 `updateNSView` 借 `shouldClaim` 的 `isSameHost` 短路，把旧 surface pin 回被复用的容器。

前两项已由独立评审用确定性反例钉死（旧实现上稳定红）；本 PR 对缺陷 2 的修复也做了 sabotage 红验证（把重入改回 `.postCommitDeferred` 时测试稳定失败）。

## 修复 / Fix

把「仲裁竞争中的采样」改为「所有权变更时显式转移」：

- **源头清除记录**：容器被别的 surface claim（`attach` 换主）或逐出旧 surface（`pin`）时，清除旧 surface 指向该容器的记录——recycled 容器不再能 veto 前任 surface 的下一次合法挂载，#103 的 decline-forever 状态在诞生地消灭。
- **同步路径无条件可见性门禁**（`SurfaceAttachGate`）：首挂不会被误伤（只有选中 tab 的树会进层级，挂载时 selection 已更新）；门禁必须无条件，才能同时拦住「记录被交接清空（host nil）」的 impostor——收窄成只拦 re-claim 会重新打开这条抢回路径。
- **`recordedHostIsStale` 收窄**到唯一可证状态：host attached 且已改认别的 surface。detached / missing 不判 stale（它们在 `shouldClaim` 里本就无否决权，且 detached 与「commit 前的新 host」不可区分）。
- **事件驱动 recovery**：decline 时在 surface 上挂 weak pending candidate；清除记录的 invalidation 事件把 pending 重新送进**完整 `.initial` 仲裁**（defer 保留，pre-commit host 有一拍宽限）。固定 8 轮 runloop 重试降级为兜底；预算耗尽**不**解除挂起——复用发生在预算之后同样能接管。合法 owner（attached 且仍认这个 surface）耗尽预算后保留 surface，#96 守卫语义不变。
- **析构 token 兜住最后一条无事件路径**：host 若直接析构（未被别的 surface 接管），weak `paneHostView` 静默置 nil，invalidation 永远不会触发。`NoDragContainerView.deinit` 捕获 `expectedSurface` + `hostGeneration`，回主线程后经 generation token 复核（deinit 时 weak 已 nil，身份只能靠 generation 证明），再把 pending 送回完整 `.initial` 仲裁。
- **评审加固（两条 P1）**：① invalidation 重驱动不 pin 到尚未挂载的 candidate——mid-commit 的 candidate 由它自己的 representable mount 时认领（此时记录已 nil、`shouldClaim` 放行），提前 pin 会让 surface 滞留 window-less 容器、reassert 因 `containerIsAttached` 直接放弃；② backstop 链携带 **epoch token**——arm/disarm 各自 bump `pendingRecoveryEpoch`，旧链下一轮即死，不能在 pending 被清空/换人后替旧 candidate 抢回（去掉 epoch guard 时该测试稳定红）。
- 仲裁核心抽成 static `performAttach`（internal），回归测试直接驱动生产路径，不再有测试侧 mirror（上一版的 mirror 曾复制了生产 bug，造成假绿）。

## 验证 / Testing

- 全量 `GlintTests`：334/334 通过（含新增用例）。
- 新增确定性时序用例（全部走真实 `performAttach`）：
  - 事件驱动接管：decline → 零 runloop 轮转 → invalidation 触发 pending 重新仲裁成功；
  - 预算耗尽后 invalidate 仍接管（复用推迟到 12 轮之后）；
  - 预算耗尽后 host 直接析构（weak 静默置 nil）→ deinit generation token 仍接管；
  - invalidation 重驱动跳过尚未挂载的 candidate，等其 mount 后再认领（P1-1）；
  - pending 清空后旧 backstop 链经 epoch token 失效，不替旧 candidate 抢回（P1-2，去掉 epoch guard 稳定红）；
  - pre-commit detached host 不被抢回（对 `.postCommitDeferred` 重入做 sabotage 后该测试稳定红）；
  - outgoing representable 抢回被门禁拦截（含记录已被交接清空的变体）；
  - 成功 claim 清除 pending；合法 owner 耗尽预算保留 surface。
- 实机路径建议复核：双 workspace 各 2 pane 来回切换；三分屏 close/split 后拖分割线。

关联 #103（其修复引入的回归）；保持 #93 / #96 的守卫语义不变。

---

EN summary: the #103 recovery re-opened both #93 and #96 — a one-shot stale recheck that sampled too early and never retried, a deferral-skipping re-entry that let an old container steal from a pre-commit host (the bypassed guard was `shouldDeferUntilAfterCommit`, not the generation arbitration), and an ungated synchronous attach that let the outgoing tree's final update re-pin a recycled container. Ownership now transitions explicitly: recordings are cleared at the source on hand-off/eviction, the sync path is visibility-gated, the stale verdict requires an attached host that demonstrably speaks for another surface, and recovery is event-driven (a weak pending candidate re-driven through full arbitration by the invalidation that dissolves the veto, plus a deinit generation token for the one path where a dying host nils the weak reference without any event) with the bounded retry demoted to a backstop. Review hardening: the invalidation re-drive never pins into an unmounted candidate (its own representable claims on mount), and backstop chains carry an epoch token so a chain queued for an old pending claim dies instead of re-claiming after the pending state is cleared or re-armed. Tests drive the production arbitration directly; 334/334 pass.
