### PR TITLE
perf(accessibility): expose viewport contents instead of full scrollback / 无障碍层改为仅暴露可视区内容

### DIFF
--- a/Glint.xcodeproj/project.pbxproj
+++ b/Glint.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		175E069EE844FB32C6EE51BB /* Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDE0D7C434B8E9C76C4A297 /* Persistence.swift */; };
 		180444BD20493AE4822BD372 /* GhosttyTickSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D751E30DFF2EFA6F705A374 /* GhosttyTickSchedulerTests.swift */; };
 		21C03B3AE912F4D30FA6F92C /* PaneAgentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DDB9C7B5A277B7924270A3 /* PaneAgentState.swift */; };
+		2218BACA355875F975446783 /* GhosttySurfaceAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454D414FF362C09886EA963F /* GhosttySurfaceAccessibility.swift */; };
 		262CB25BEB2B28B12C162F66 /* ghostty in Resources */ = {isa = PBXBuildFile; fileRef = 1CD90B7C77381E05E8A2BA8C /* ghostty */; };
 		2D9012046800A06555DEA381 /* GitRefreshCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65BE76E8E627A5347D565968 /* GitRefreshCoordinatorTests.swift */; };
 		2DD19A3FDAE094EF32B0B9F0 /* zsh-autosuggestions.zsh in Resources */ = {isa = PBXBuildFile; fileRef = D03AFC613028C5BB0D99238D /* zsh-autosuggestions.zsh */; };
@@ -59,6 +60,7 @@
 		942ED7C1C1A2E823BA52F67A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3023490E670A10EC38870B12 /* Assets.xcassets */; };
 		97FE40619FD0C44784E91017 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = C8CE97CEC40ECB2954522DD7 /* InfoPlist.xcstrings */; };
 		9A5EC6D5F8F65EE762FCD917 /* addon-fit.mjs in Resources */ = {isa = PBXBuildFile; fileRef = 5DB06D8C68CA7B9C7E1E83E7 /* addon-fit.mjs */; };
+		9C8BC416E070194670E97100 /* AccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DD41E0F48A7A20C41F3AE6 /* AccessibilityTests.swift */; };
 		9F605AB2DC185A94ED28E6D4 /* AgentChoice.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3EB9A1E80F3CC4BCA468774 /* AgentChoice.swift */; };
 		A019A2AD685F1407D7E2A7E1 /* AgentHookRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0082D535969C315B8D75D7 /* AgentHookRoutingTests.swift */; };
 		A91EFEF0FEA392A0745724DE /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = 89B8883C4456681F07B6D662 /* AppIcon.icon */; };
@@ -116,6 +118,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		01DD41E0F48A7A20C41F3AE6 /* AccessibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityTests.swift; sourceTree = "<group>"; };
 		050E267AE14712D4D6633B4F /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		05F2CA2243872C8111048EF2 /* AgentBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBridge.swift; sourceTree = "<group>"; };
 		07C2CEDE2C717743C29E6026 /* web-remote.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "web-remote.js"; sourceTree = "<group>"; };
@@ -150,6 +153,7 @@
 		407B3A9D15F4B9E613DA1CF8 /* ReleaseNotes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseNotes.swift; sourceTree = "<group>"; };
 		41DDB9C7B5A277B7924270A3 /* PaneAgentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneAgentState.swift; sourceTree = "<group>"; };
 		4408F9761E584DE2AB6630E2 /* UpdaterController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdaterController.swift; sourceTree = "<group>"; };
+		454D414FF362C09886EA963F /* GhosttySurfaceAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttySurfaceAccessibility.swift; sourceTree = "<group>"; };
 		45C96BF92C4618FF97D68919 /* WebRemoteServerIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRemoteServerIntegrationTests.swift; sourceTree = "<group>"; };
 		49C5AC93BE947131B5611EF8 /* xterm.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = xterm.css; sourceTree = "<group>"; };
 		49C888E59D1091BFC22A9EA4 /* GitRepositoryWatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepositoryWatcherTests.swift; sourceTree = "<group>"; };
@@ -271,6 +275,7 @@
 		5D84BADE56807E092D26B87B /* Pane */ = {
 			isa = PBXGroup;
 			children = (
+				454D414FF362C09886EA963F /* GhosttySurfaceAccessibility.swift */,
 				E298AD81B1615CBBFD69F48A /* GhosttySurfaceView.swift */,
 				98BBD4C70C8DC534304294C9 /* InlineSuggestionInstaller.swift */,
 				16137B405E48DBE262A15B6D /* PaneSurfaceRepresentable.swift */,
@@ -292,6 +297,7 @@
 		5F9010EBEE9DCDE13D866A74 /* GlintTests */ = {
 			isa = PBXGroup;
 			children = (
+				01DD41E0F48A7A20C41F3AE6 /* AccessibilityTests.swift */,
 				D36068DE0F0DDDECA779C743 /* AgentElapsedTimerTests.swift */,
 				FF0082D535969C315B8D75D7 /* AgentHookRoutingTests.swift */,
 				4EEF00CBEF45A9D60423A207 /* AgentKindResolutionTests.swift */,
@@ -590,6 +596,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9C8BC416E070194670E97100 /* AccessibilityTests.swift in Sources */,
 				D0C97B91E9D08E8943549FCD /* AgentElapsedTimerTests.swift in Sources */,
 				A019A2AD685F1407D7E2A7E1 /* AgentHookRoutingTests.swift in Sources */,
 				81532B36FEC3039B8EAD9CB1 /* AgentKindResolutionTests.swift in Sources */,
@@ -637,6 +644,7 @@
 				EF937781512647E835836F83 /* ControlBridge.swift in Sources */,
 				C11ED5034D6EF2BA539846AD /* FontCatalog.swift in Sources */,
 				3CB9F41E3B1CB4A8790D9159 /* GhosttyManager.swift in Sources */,
+				2218BACA355875F975446783 /* GhosttySurfaceAccessibility.swift in Sources */,
 				1115F230E14FBE3C1FC754A2 /* GhosttySurfaceView.swift in Sources */,
 				164C6F51683CE7942393E816 /* GitDiff.swift in Sources */,
 				6290F26DFE2D0D5E1FEB9FA9 /* GitRefreshCoordinator.swift in Sources */,

--- a/Glint/Pane/GhosttySurfaceAccessibility.swift
+++ b/Glint/Pane/GhosttySurfaceAccessibility.swift
@@ -1,0 +1,208 @@
+import AppKit
+import GhosttyKit
+
+// MARK: - Accessibility
+//
+// Voice-input assistants (Qianwen dictation and friends) and screen readers
+// probe the FOCUSED element's AX role to decide whether the frontmost app has
+// a text field they can type into. Terminal.app / iTerm2 / Ghostty.app all
+// expose their terminal surface as AXTextArea; without these overrides this
+// view reports the NSView default (AXGroup), so Qianwen's hotkey input falls
+// back to its "no input field" quick-action popup (记便签 / 问千问 / 复制)
+// instead of typing here. Mirrors upstream ghostty's SurfaceView_AppKit
+// accessibility extension, plus a settable AXSelectedText (the standard
+// dictation insertion attribute) routed into the same pipe as `insertText`.
+
+extension GhosttySurfaceView {
+    /// Indicates that this view should be exposed to accessibility tools like VoiceOver.
+    override func isAccessibilityElement() -> Bool {
+        return true
+    }
+
+    /// We use .textArea because the terminal surface is essentially an editable
+    /// text area where users can input commands and view output.
+    override func accessibilityRole() -> NSAccessibility.Role? {
+        return .textArea
+    }
+
+    override func accessibilityHelp() -> String? {
+        return String(localized: "Terminal content area")
+    }
+
+    override func accessibilityValue() -> Any? {
+        return cachedVisibleContents.get()
+    }
+
+    /// Range of text currently selected in the string exposed through AXValue.
+    /// Ghostty's offsets are terminal-cell coordinates, so only report a range
+    /// when the selected text maps unambiguously into that formatted string.
+    ///
+    /// The mapping is sound because both `ghostty_surface_read_selection` and
+    /// `ghostty_surface_read_text` funnel into the same core path
+    /// (`dumpTextLocked` → `selectionString` → `ScreenFormatter` with
+    /// `.unwrap = true, .trim = false`), so a linear selection's text is a
+    /// verbatim substring of the exposed text — soft-wrapped lines join the
+    /// same way in both, and trailing blank cells are trimmed by the same
+    /// per-row rule. Cases that can't map degrade to `NSNotFound` instead of
+    /// reporting a wrong range: rectangle (alt-drag) selections join partial
+    /// row segments with newlines that don't exist in the exposed text, and
+    /// selections extending into scrollback history aren't contained in the
+    /// viewport-only AXValue.
+    override func accessibilitySelectedTextRange() -> NSRange {
+        let notFound = NSRange(location: NSNotFound, length: 0)
+        guard let surface = surface else { return notFound }
+        var text = ghostty_text_s()
+        guard ghostty_surface_read_selection(surface, &text) else { return notFound }
+        defer { ghostty_surface_free_text(surface, &text) }
+        let selectedText = String(cString: text.text)
+        return AccessibilityText.uniqueRange(
+            of: selectedText,
+            in: cachedVisibleContents.get()
+        ) ?? notFound
+    }
+
+    override func accessibilitySelectedText() -> String? {
+        guard let surface = surface else { return nil }
+        var text = ghostty_text_s()
+        guard ghostty_surface_read_selection(surface, &text) else { return nil }
+        defer { ghostty_surface_free_text(surface, &text) }
+        let str = String(cString: text.text)
+        return str.isEmpty ? nil : str
+    }
+
+    /// Dictation-style insertion channel: setting AXSelectedText means "type
+    /// this at the cursor". A terminal has no editable text, so the text goes
+    /// straight down `insertText` — the IME-aware commit pipe — rather than a
+    /// copy of it, so preedit cleanup, the marked-text reset and the
+    /// chord-observation accumulator can't drift out of sync with it.
+    /// Implementing the setter also makes
+    /// `AXUIElementIsAttributeSettable(kAXSelectedText)` report true, which
+    /// Qianwen's editable-element detection checks.
+    ///
+    /// This is the third path that injects outside text into the pty, but
+    /// unlike clipboard paste and drag-drop it cannot *ask*: AX writes are
+    /// synchronous IPC, so raising `confirmUnsafeTextInjection`'s modal here
+    /// would block the caller until its AX request times out. Text a shell
+    /// would act on immediately (newlines, C0 controls) is therefore refused
+    /// outright instead of confirmed — dictation never needs it, and an AX
+    /// client that wants to run commands has to say so through a channel the
+    /// user can see.
+    override func setAccessibilitySelectedText(_ text: String?) {
+        guard let text, !text.isEmpty, surface != nil else { return }
+        guard !injectedTextLooksUnsafe(text) else { return }
+        insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
+    }
+
+    override func accessibilityNumberOfCharacters() -> Int {
+        let content = cachedVisibleContents.get()
+        return AccessibilityText.utf16Count(content)
+    }
+
+    /// For terminals, we typically show all content as visible.
+    override func accessibilityVisibleCharacterRange() -> NSRange {
+        let content = cachedVisibleContents.get()
+        return NSRange(location: 0, length: AccessibilityText.utf16Count(content))
+    }
+
+    override func accessibilityLine(for index: Int) -> Int {
+        let content = cachedVisibleContents.get()
+        return AccessibilityText.lineNumber(in: content, atUTF16Index: index)
+    }
+
+    override func accessibilityString(for range: NSRange) -> String? {
+        let content = cachedVisibleContents.get()
+        return AccessibilityText.substring(in: content, range: range)
+    }
+
+    /// Right now this only applies font information (same trade-off as
+    /// upstream ghostty; per-run colors would need ghostty core support).
+    override func accessibilityAttributedString(for range: NSRange) -> NSAttributedString? {
+        guard let surface = surface,
+              let plainString = accessibilityString(for: range) else { return nil }
+
+        var attributes: [NSAttributedString.Key: Any] = [:]
+        if let fontRaw = ghostty_surface_quicklook_font(surface) {
+            let font = Unmanaged<CTFont>.fromOpaque(fontRaw)
+            attributes[.font] = font.takeUnretainedValue()
+            font.release()
+        }
+        return NSAttributedString(string: plainString, attributes: attributes)
+    }
+}
+
+/// Pure-string helpers behind the `NSTextInputClient`-style accessibility
+/// overrides above. All indices/ranges are UTF-16 (`NSString`) coordinates,
+/// which is what the AX APIs expect.
+enum AccessibilityText {
+    static func utf16Count(_ text: String) -> Int {
+        (text as NSString).length
+    }
+
+    static func substring(in text: String, range: NSRange) -> String? {
+        let text = text as NSString
+        guard range.location != NSNotFound,
+              range.location <= text.length,
+              range.length <= text.length - range.location else { return nil }
+        return text.substring(with: range)
+    }
+
+    static func lineNumber(in text: String, atUTF16Index index: Int) -> Int {
+        let clampedIndex = min(max(index, 0), utf16Count(text))
+        return text.utf16.prefix(clampedIndex).reduce(into: 0) { line, codeUnit in
+            if codeUnit == 0x0A { line += 1 }
+        }
+    }
+
+    /// Maps selected text into the exposed text's UTF-16 coordinates. Returns
+    /// the range only when it is unambiguous: nil if the text is absent, or
+    /// occurs more than once (a wrong-but-plausible range is worse for AX
+    /// clients than no range at all).
+    static func uniqueRange(of selectedText: String, in exposedText: String) -> NSRange? {
+        let exposedText = exposedText as NSString
+        guard !selectedText.isEmpty else { return nil }
+
+        let first = exposedText.range(of: selectedText)
+        guard first.location != NSNotFound else { return nil }
+
+        let nextLocation = first.location + 1
+        if nextLocation <= exposedText.length {
+            let remaining = NSRange(
+                location: nextLocation,
+                length: exposedText.length - nextLocation
+            )
+            guard exposedText.range(of: selectedText, range: remaining).location == NSNotFound else {
+                return nil
+            }
+        }
+        return first
+    }
+}
+
+/// Caches a value for a short period on the AppKit main actor. Expiration is
+/// checked on demand so no background task can race with accessibility polls.
+@MainActor
+final class CachedValue<T> {
+    private var value: T?
+    private var expiresAt: ContinuousClock.Instant?
+    private let fetch: @MainActor () -> T
+    private let duration: Duration
+
+    init(duration: Duration, fetch: @escaping @MainActor () -> T) {
+        self.duration = duration
+        self.fetch = fetch
+    }
+
+    func get() -> T {
+        let now = ContinuousClock.now
+        if let value, let expiresAt, now < expiresAt {
+            return value
+        }
+
+        // No cached value (or it expired) — fetch and store.
+        let result = fetch()
+        self.value = result
+        self.expiresAt = now + duration
+
+        return result
+    }
+}

--- a/Glint/Pane/GhosttySurfaceView.swift
+++ b/Glint/Pane/GhosttySurfaceView.swift
@@ -33,7 +33,10 @@ struct SurfaceFocusUpdateGate {
 /// load-bearing for terminal frame pacing.
 final class GhosttySurfaceView: NSView, NSTextInputClient {
 
-    private var surface: ghostty_surface_t?
+    /// Internal (read-only) so the accessibility extension
+    /// (GhosttySurfaceAccessibility.swift) can query the surface; only this
+    /// file re-parents/replaces it.
+    private(set) var surface: ghostty_surface_t?
     /// The newest SwiftUI/AppKit container allowed to host this stable surface.
     /// Split-tree reshapes can briefly leave both the outgoing and incoming
     /// representables alive; the older one must not re-parent the surface back.
@@ -41,20 +44,26 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
     var paneHostGeneration: UInt64 = 0
     private var focusUpdateGate = SurfaceFocusUpdateGate()
     private var trackingArea: NSTrackingArea?
-    /// Screen contents for the accessibility layer. AX clients poll AXValue
+    /// Visible (viewport) contents for the accessibility layer, shared by the
+    /// overrides in GhosttySurfaceAccessibility.swift. AX clients poll AXValue
     /// aggressively and `ghostty_surface_read_text` takes the renderer lock,
-    /// so cache with a short TTL (mirrors upstream SurfaceView_AppKit).
-    private lazy var cachedScreenContents: CachedValue<String> = .init(duration: .milliseconds(500)) { [weak self] in
+    /// so cache with a short TTL. Viewport-scoped rather than the whole screen
+    /// (upstream SurfaceView_AppKit's `cachedScreenContents`) on purpose: the
+    /// viewport is bounded by window size so per-poll reads and
+    /// `accessibilityLine(for:)` walks stay cheap even with a huge scrollback,
+    /// and history contents (old tokens, secrets) are not handed to any AX
+    /// client that asks.
+    lazy var cachedVisibleContents: CachedValue<String> = .init(duration: .milliseconds(500)) { [weak self] in
         guard let self, let surface = self.surface else { return "" }
         var text = ghostty_text_s()
         let sel = ghostty_selection_s(
             top_left: ghostty_point_s(
-                tag: GHOSTTY_POINT_SCREEN,
+                tag: GHOSTTY_POINT_VIEWPORT,
                 coord: GHOSTTY_POINT_COORD_TOP_LEFT,
                 x: 0,
                 y: 0),
             bottom_right: ghostty_point_s(
-                tag: GHOSTTY_POINT_SCREEN,
+                tag: GHOSTTY_POINT_VIEWPORT,
                 coord: GHOSTTY_POINT_COORD_BOTTOM_RIGHT,
                 x: 0,
                 y: 0),
@@ -2378,8 +2387,9 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
     /// newlines (\n / \r — most shells and REPLs execute on CR even inside
     /// bracketed paste when the running program doesn't support it) or C0
     /// control characters other than tab (ESC can rewrite the line, ^C can
-    /// kill the foreground job, etc.).
-    private func injectedTextLooksUnsafe(_ text: String) -> Bool {
+    /// kill the foreground job, etc.). Internal so the accessibility
+    /// extension (GhosttySurfaceAccessibility.swift) can reuse the predicate.
+    func injectedTextLooksUnsafe(_ text: String) -> Bool {
         for scalar in text.unicodeScalars {
             let v = scalar.value
             if v == 0x09 { continue }                 // tab is fine
@@ -2681,193 +2691,6 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
 
     func characterIndex(for point: NSPoint) -> Int {
         0
-    }
-}
-
-// MARK: - Accessibility
-//
-// Voice-input assistants (Qianwen dictation and friends) and screen readers
-// probe the FOCUSED element's AX role to decide whether the frontmost app has
-// a text field they can type into. Terminal.app / iTerm2 / Ghostty.app all
-// expose their terminal surface as AXTextArea; without these overrides this
-// view reports the NSView default (AXGroup), so Qianwen's hotkey input falls
-// back to its "no input field" quick-action popup (记便签 / 问千问 / 复制)
-// instead of typing here. Mirrors upstream ghostty's SurfaceView_AppKit
-// accessibility extension, plus a settable AXSelectedText (the standard
-// dictation insertion attribute) routed into the same pipe as `insertText`.
-
-extension GhosttySurfaceView {
-    /// Indicates that this view should be exposed to accessibility tools like VoiceOver.
-    override func isAccessibilityElement() -> Bool {
-        return true
-    }
-
-    /// We use .textArea because the terminal surface is essentially an editable
-    /// text area where users can input commands and view output.
-    override func accessibilityRole() -> NSAccessibility.Role? {
-        return .textArea
-    }
-
-    override func accessibilityHelp() -> String? {
-        return String(localized: "Terminal content area")
-    }
-
-    override func accessibilityValue() -> Any? {
-        return cachedScreenContents.get()
-    }
-
-    /// Range of text currently selected in the string exposed through AXValue.
-    /// Ghostty's offsets are terminal-cell coordinates, so only report a range
-    /// when the selected text maps unambiguously into that formatted string.
-    override func accessibilitySelectedTextRange() -> NSRange {
-        let notFound = NSRange(location: NSNotFound, length: 0)
-        guard let surface = surface else { return notFound }
-        var text = ghostty_text_s()
-        guard ghostty_surface_read_selection(surface, &text) else { return notFound }
-        defer { ghostty_surface_free_text(surface, &text) }
-        let selectedText = String(cString: text.text)
-        return AccessibilityText.uniqueRange(
-            of: selectedText,
-            in: cachedScreenContents.get()
-        ) ?? notFound
-    }
-
-    override func accessibilitySelectedText() -> String? {
-        guard let surface = surface else { return nil }
-        var text = ghostty_text_s()
-        guard ghostty_surface_read_selection(surface, &text) else { return nil }
-        defer { ghostty_surface_free_text(surface, &text) }
-        let str = String(cString: text.text)
-        return str.isEmpty ? nil : str
-    }
-
-    /// Dictation-style insertion channel: setting AXSelectedText means "type
-    /// this at the cursor". A terminal has no editable text, so the text goes
-    /// straight down `insertText` — the IME-aware commit pipe — rather than a
-    /// copy of it, so preedit cleanup, the marked-text reset and the
-    /// chord-observation accumulator can't drift out of sync with it.
-    /// Implementing the setter also makes
-    /// `AXUIElementIsAttributeSettable(kAXSelectedText)` report true, which
-    /// Qianwen's editable-element detection checks.
-    ///
-    /// This is the third path that injects outside text into the pty, but
-    /// unlike clipboard paste and drag-drop it cannot *ask*: AX writes are
-    /// synchronous IPC, so raising `confirmUnsafeTextInjection`'s modal here
-    /// would block the caller until its AX request times out. Text a shell
-    /// would act on immediately (newlines, C0 controls) is therefore refused
-    /// outright instead of confirmed — dictation never needs it, and an AX
-    /// client that wants to run commands has to say so through a channel the
-    /// user can see.
-    override func setAccessibilitySelectedText(_ text: String?) {
-        guard let text, !text.isEmpty, surface != nil else { return }
-        guard !injectedTextLooksUnsafe(text) else { return }
-        insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
-    }
-
-    override func accessibilityNumberOfCharacters() -> Int {
-        let content = cachedScreenContents.get()
-        return AccessibilityText.utf16Count(content)
-    }
-
-    /// For terminals, we typically show all content as visible.
-    override func accessibilityVisibleCharacterRange() -> NSRange {
-        let content = cachedScreenContents.get()
-        return NSRange(location: 0, length: AccessibilityText.utf16Count(content))
-    }
-
-    override func accessibilityLine(for index: Int) -> Int {
-        let content = cachedScreenContents.get()
-        return AccessibilityText.lineNumber(in: content, atUTF16Index: index)
-    }
-
-    override func accessibilityString(for range: NSRange) -> String? {
-        let content = cachedScreenContents.get()
-        return AccessibilityText.substring(in: content, range: range)
-    }
-
-    /// Right now this only applies font information (same trade-off as
-    /// upstream ghostty; per-run colors would need ghostty core support).
-    override func accessibilityAttributedString(for range: NSRange) -> NSAttributedString? {
-        guard let surface = surface,
-              let plainString = accessibilityString(for: range) else { return nil }
-
-        var attributes: [NSAttributedString.Key: Any] = [:]
-        if let fontRaw = ghostty_surface_quicklook_font(surface) {
-            let font = Unmanaged<CTFont>.fromOpaque(fontRaw)
-            attributes[.font] = font.takeUnretainedValue()
-            font.release()
-        }
-        return NSAttributedString(string: plainString, attributes: attributes)
-    }
-}
-
-enum AccessibilityText {
-    static func utf16Count(_ text: String) -> Int {
-        (text as NSString).length
-    }
-
-    static func substring(in text: String, range: NSRange) -> String? {
-        let text = text as NSString
-        guard range.location != NSNotFound,
-              range.location <= text.length,
-              range.length <= text.length - range.location else { return nil }
-        return text.substring(with: range)
-    }
-
-    static func lineNumber(in text: String, atUTF16Index index: Int) -> Int {
-        let clampedIndex = min(max(index, 0), utf16Count(text))
-        return text.utf16.prefix(clampedIndex).reduce(into: 0) { line, codeUnit in
-            if codeUnit == 0x0A { line += 1 }
-        }
-    }
-
-    static func uniqueRange(of selectedText: String, in exposedText: String) -> NSRange? {
-        let exposedText = exposedText as NSString
-        guard !selectedText.isEmpty else { return nil }
-
-        let first = exposedText.range(of: selectedText)
-        guard first.location != NSNotFound else { return nil }
-
-        let nextLocation = first.location + 1
-        if nextLocation <= exposedText.length {
-            let remaining = NSRange(
-                location: nextLocation,
-                length: exposedText.length - nextLocation
-            )
-            guard exposedText.range(of: selectedText, range: remaining).location == NSNotFound else {
-                return nil
-            }
-        }
-        return first
-    }
-}
-
-/// Caches a value for a short period on the AppKit main actor. Expiration is
-/// checked on demand so no background task can race with accessibility polls.
-@MainActor
-final class CachedValue<T> {
-    private var value: T?
-    private var expiresAt: ContinuousClock.Instant?
-    private let fetch: @MainActor () -> T
-    private let duration: Duration
-
-    init(duration: Duration, fetch: @escaping @MainActor () -> T) {
-        self.duration = duration
-        self.fetch = fetch
-    }
-
-    func get() -> T {
-        let now = ContinuousClock.now
-        if let value, let expiresAt, now < expiresAt {
-            return value
-        }
-
-        // No cached value (or it expired) — fetch and store.
-        let result = fetch()
-        self.value = result
-        self.expiresAt = now + duration
-
-        return result
     }
 }
 

--- a/GlintTests/AccessibilityTests.swift
+++ b/GlintTests/AccessibilityTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+@testable import Glint
+
+/// String-level regression tests for the terminal accessibility layer
+/// (GhosttySurfaceAccessibility.swift). The shapes exercised here mirror
+/// what ghostty core's `ScreenFormatter` (`.plain`, `.unwrap = true`,
+/// `.trim = false`) emits for `read_text` / `read_selection`.
+@MainActor
+final class AccessibilityTests: XCTestCase {
+    func testTextUsesUTF16Coordinates() {
+        let content = "😀a\n界b"
+
+        XCTAssertEqual(AccessibilityText.utf16Count(content), 6)
+        XCTAssertEqual(
+            AccessibilityText.substring(in: content, range: NSRange(location: 0, length: 2)),
+            "😀"
+        )
+        XCTAssertEqual(
+            AccessibilityText.substring(in: content, range: NSRange(location: 2, length: 1)),
+            "a"
+        )
+        XCTAssertEqual(AccessibilityText.lineNumber(in: content, atUTF16Index: 4), 1)
+    }
+
+    func testSelectionMapsAgainstExposedText() {
+        let content = "short\nselected 😀 text\nend"
+        let selectedText = "selected 😀"
+
+        let range = AccessibilityText.uniqueRange(of: selectedText, in: content)
+
+        XCTAssertEqual(range, NSRange(location: 6, length: 11))
+        XCTAssertEqual(range.flatMap { AccessibilityText.substring(in: content, range: $0) }, selectedText)
+    }
+
+    func testSelectionRejectsMissingOrAmbiguousMapping() {
+        XCTAssertNil(AccessibilityText.uniqueRange(of: "padded", in: "trimmed"))
+        XCTAssertNil(AccessibilityText.uniqueRange(of: "same", in: "same\nsame"))
+    }
+
+    /// A soft-wrapped line is joined without a newline in the exposed text
+    /// (`.unwrap = true`), and a linear selection crossing the wrap junction
+    /// is formatted the same way — so it must still map into the exposed
+    /// text. This pins the assumption `uniqueRange` relies on.
+    func testSelectionSpansSoftWrapJunction() {
+        // A 16-col terminal shows "echo 一二三四 five six" as two visual
+        // rows ("prompt$ echo 一二三四" / "five six"); the dump joins them
+        // into one logical line with no newline at the junction.
+        let exposed = "prompt$ echo 一二三四 five six\ndone"
+        let selected = "三四 five"
+
+        let range = AccessibilityText.uniqueRange(of: selected, in: exposed)
+
+        XCTAssertEqual(range, NSRange(location: 15, length: 7))
+        XCTAssertEqual(range.flatMap { AccessibilityText.substring(in: exposed, range: $0) }, selected)
+    }
+
+    /// `.trim = false` keeps mid-line spaces; the formatter only drops blank
+    /// cells at the END of a row. A selection padded with trailing spaces
+    /// that the formatter trimmed on both sides must still map by its
+    /// non-blank text; one whose text simply isn't present must not map.
+    func testSelectionAgainstTrailingBlankTrimmedRows() {
+        // Visible rows "abc   " and "def" dump as "abc\ndef" — trailing blank
+        // cells are trimmed. A user selection of "abc" (or "abc   ") maps to
+        // the trimmed row text.
+        let exposed = "abc\ndef"
+        XCTAssertEqual(AccessibilityText.uniqueRange(of: "abc", in: exposed), NSRange(location: 0, length: 3))
+        // A selection spanning "abc" through the start of "def" crosses a
+        // hard newline and includes it verbatim.
+        XCTAssertEqual(AccessibilityText.uniqueRange(of: "abc\nd", in: exposed), NSRange(location: 0, length: 5))
+        // Spaces that were never on screen don't map.
+        XCTAssertNil(AccessibilityText.uniqueRange(of: "abc   ", in: exposed))
+    }
+
+    func testCacheRefetchesOnlyAfterExpiry() async throws {
+        var fetchCount = 0
+        let cache = CachedValue(duration: .milliseconds(20)) {
+            fetchCount += 1
+            return fetchCount
+        }
+
+        XCTAssertEqual(cache.get(), 1)
+        XCTAssertEqual(cache.get(), 1)
+        try await Task.sleep(for: .milliseconds(30))
+        XCTAssertEqual(cache.get(), 2)
+    }
+}

--- a/GlintTests/PerformanceRegressionTests.swift
+++ b/GlintTests/PerformanceRegressionTests.swift
@@ -526,49 +526,6 @@ final class PerformanceRegressionTests: XCTestCase {
         XCTAssertTrue(gate.shouldApply(false))
     }
 
-    func testAccessibilityTextUsesUTF16Coordinates() {
-        let content = "😀a\n界b"
-
-        XCTAssertEqual(AccessibilityText.utf16Count(content), 6)
-        XCTAssertEqual(
-            AccessibilityText.substring(in: content, range: NSRange(location: 0, length: 2)),
-            "😀"
-        )
-        XCTAssertEqual(
-            AccessibilityText.substring(in: content, range: NSRange(location: 2, length: 1)),
-            "a"
-        )
-        XCTAssertEqual(AccessibilityText.lineNumber(in: content, atUTF16Index: 4), 1)
-    }
-
-    func testAccessibilitySelectionMapsAgainstExposedText() {
-        let content = "short\nselected 😀 text\nend"
-        let selectedText = "selected 😀"
-
-        let range = AccessibilityText.uniqueRange(of: selectedText, in: content)
-
-        XCTAssertEqual(range, NSRange(location: 6, length: 11))
-        XCTAssertEqual(range.flatMap { AccessibilityText.substring(in: content, range: $0) }, selectedText)
-    }
-
-    func testAccessibilitySelectionRejectsMissingOrAmbiguousMapping() {
-        XCTAssertNil(AccessibilityText.uniqueRange(of: "padded", in: "trimmed"))
-        XCTAssertNil(AccessibilityText.uniqueRange(of: "same", in: "same\nsame"))
-    }
-
-    func testAccessibilityCacheRefetchesOnlyAfterExpiry() async throws {
-        var fetchCount = 0
-        let cache = CachedValue(duration: .milliseconds(20)) {
-            fetchCount += 1
-            return fetchCount
-        }
-
-        XCTAssertEqual(cache.get(), 1)
-        XCTAssertEqual(cache.get(), 1)
-        try await Task.sleep(for: .milliseconds(30))
-        XCTAssertEqual(cache.get(), 2)
-    }
-
     func testTerminalBackingSkipsIdenticalLayerWrites() {
         let layer = CALayer()
         let background = CGColor(red: 0.1, green: 0.2, blue: 0.3, alpha: 1)


### PR DESCRIPTION
## What & why

Follow-up to the #108 review notes — three items:

1. **Viewport-scoped AXValue.** `accessibilityValue` and friends now read `GHOSTTY_POINT_VIEWPORT` (via the renamed `cachedVisibleContents`, matching upstream's prepared-but-unused property) instead of the whole screen. Two wins: VoiceOver's per-poll reads and `accessibilityLine(for:)` walks stay bounded by window size even with a large user-configurable scrollback (line navigation was effectively O(scrollback²)), and scrollback history (old tokens) is no longer handed to any AX client that asks. This also makes `accessibilityVisibleCharacterRange` honest — AXValue now *is* the visible content. The only behavior change for external AX clients is that history beyond the viewport is no longer exposed, by design.
2. **`uniqueRange` assumption verified.** The #108 review flagged that the selection→AXValue mapping assumed `read_selection` text appears verbatim in `read_text` output. Verified from ghostty source: both funnel into `dumpTextLocked` → `selectionString` → the same `ScreenFormatter` (`.plain`, `.unwrap = true`, `.trim = false`), so a linear selection's text is a verbatim substring — soft-wrapped lines join identically in both, trailing blank cells are trimmed by the same per-row rule. Degradation cases (alt-drag rectangle selections, selections extending into scrollback) are now documented on `accessibilitySelectedTextRange`; both correctly return `NSNotFound` rather than a wrong-but-plausible range.
3. **File organization.** AX overrides + `AccessibilityText` + `CachedValue` moved out of the 4000-line `GhosttySurfaceView.swift` into `GhosttySurfaceAccessibility.swift`; the AX tests moved from `PerformanceRegressionTests.swift` into a dedicated `AccessibilityTests.swift`.

## How

- `surface` is now `private(set)` (internal read) and `injectedTextLooksUnsafe` internal, so the cross-file extension can use them — writes stay confined to `GhosttySurfaceView.swift`.
- Two new regression tests pin the verified shapes: a selection spanning a soft-wrap junction (no newline at the junction in the dumped text), and trailing-blank-trimmed rows.

## Testing / verification

- `xcodebuild test -project Glint.xcodeproj -scheme Glint -configuration Debug -sdk macosx -arch arm64`: 326 tests, 0 failures (was 324; +2 new AX shape tests).
- Full build succeeded; `git diff --check` clean.
- Checked for in-repo consumers of the terminal AXValue: none (sidebar uses are unrelated SwiftUI badges), so viewport-scoping affects only external AX clients.

## 中文

### 做了什么、为什么

对应 #108 评审留言的三个后续点：

1. **AXValue 改为可视区范围。** `accessibilityValue` 等改读 `GHOSTTY_POINT_VIEWPORT`（重命名为 `cachedVisibleContents`，对齐上游备而未用的属性），不再读整个 screen。收益：VoiceOver 轮询与 `accessibilityLine(for:)` 遍历被窗口大小约束（此前按行导航实际是 O(scrollback²)）；scrollback 历史内容（旧 token）不再外泄给任何 AX 客户端。`accessibilityVisibleCharacterRange` 也因此名副其实——AXValue 就是可见内容。对外部 AX 客户端唯一的行为变化是 viewport 之外的历史不再暴露，这是有意为之。
2. **验证了 `uniqueRange` 的假设。** 评审中指出选中→AXValue 映射依赖「`read_selection` 文本逐字出现在 `read_text` 输出里」。已从 ghostty 源码核实：两条路径汇聚到 `dumpTextLocked` → `selectionString` → 同一个 `ScreenFormatter`（`.plain`、`.unwrap = true`、`.trim = false`），线性选区文本是逐字子串——软换行在两侧同样拼接、行尾空白按同一规则裁剪。退化场景（alt-drag 矩形选区、延伸进 scrollback 的选区）已写入 `accessibilitySelectedTextRange` 注释，二者均正确返回 `NSNotFound`，而不是返回一个似是而非的范围。
3. **文件组织。** AX 覆写 + `AccessibilityText` + `CachedValue` 从 4000 行的 `GhosttySurfaceView.swift` 挪到 `GhosttySurfaceAccessibility.swift`；AX 测试从 `PerformanceRegressionTests.swift` 挪到独立的 `AccessibilityTests.swift`。

### 怎么做的

- `surface` 改为 `private(set)`（读 internal）、`injectedTextLooksUnsafe` 放宽为 internal，供跨文件扩展使用——写权限仍只在 `GhosttySurfaceView.swift`。
- 新增两个回归测试钉住已核实的形状：跨软换行 junction 的选区（dump 文本在 junction 处无换行）、行尾空白被裁剪的行。

### 验证

- `xcodebuild test`（`-sdk macosx -arch arm64`）：326 个测试，0 失败（原 324，新增 2 个形状测试）。
- 完整构建通过；`git diff --check` 无问题。
- 排查过仓库内终端 AXValue 的消费者：没有（侧边栏的是无关 SwiftUI badge），viewport 化只影响外部 AX 客户端。
