### PR TITLE
fix(pane): recover stale pending surfaces when recycled hosts mount

### DIFF
--- a/Glint/Pane/PaneSurfaceRepresentable.swift
+++ b/Glint/Pane/PaneSurfaceRepresentable.swift
@@ -459,6 +459,10 @@ struct PaneSurfaceRepresentable: NSViewRepresentable {
     private static func armPendingRecovery(_ surface: GhosttySurfaceView,
                                            host: NoDragContainerView,
                                            visible: @escaping () -> Bool) {
+        if let displacedSurface = host.pendingRecoverySurface,
+           displacedSurface !== surface {
+            disarmPendingRecovery(displacedSurface)
+        }
         if let previous = surface.pendingRecoveryHost as? NoDragContainerView,
            previous !== host,
            previous.pendingRecoverySurface === surface {

--- a/Glint/Pane/PaneSurfaceRepresentable.swift
+++ b/Glint/Pane/PaneSurfaceRepresentable.swift
@@ -336,6 +336,14 @@ struct PaneSurfaceRepresentable: NSViewRepresentable {
             }
         }
 
+        // A successful claim recycles this candidate for `surface`, so any
+        // different surface still waiting for the candidate has been
+        // superseded. Clear both sides (and bump its epoch) before the mount
+        // callback can revive that stale claim and evict the new owner.
+        if let displacedPendingSurface = container.pendingRecoverySurface,
+           displacedPendingSurface !== surface {
+            disarmPendingRecovery(displacedPendingSurface)
+        }
         disarmPendingRecovery(surface)
         surface.paneHostView = container
         surface.paneHostGeneration = container.hostGeneration

--- a/Glint/Pane/PaneSurfaceRepresentable.swift
+++ b/Glint/Pane/PaneSurfaceRepresentable.swift
@@ -176,6 +176,21 @@ struct PaneSurfaceRepresentable: NSViewRepresentable {
         /// Paired with the surface-side host claim for the post-commit recheck.
         weak var expectedSurface: GhosttySurfaceView?
 
+        /// The surface whose declined claim is waiting for this candidate to
+        /// enter a window. Weak in both directions: the surface already keeps
+        /// `pendingRecoveryHost` weak, and neither side should prolong a stale
+        /// SwiftUI tree. `viewDidMoveToWindow` turns the mount itself into the
+        /// recovery event that invalidation/backstop cannot provide while the
+        /// candidate is still window-less.
+        weak var pendingRecoverySurface: GhosttySurfaceView?
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            guard window != nil, let surface = pendingRecoverySurface else { return }
+            PaneSurfaceRepresentable.recoverPendingClaim(
+                for: surface, afterCandidateMount: self)
+        }
+
         deinit {
             // A host dismantled without an ownership hand-off nils the
             // surface's weak paneHostView silently — no invalidation event
@@ -436,9 +451,15 @@ struct PaneSurfaceRepresentable: NSViewRepresentable {
     private static func armPendingRecovery(_ surface: GhosttySurfaceView,
                                            host: NoDragContainerView,
                                            visible: @escaping () -> Bool) {
+        if let previous = surface.pendingRecoveryHost as? NoDragContainerView,
+           previous !== host,
+           previous.pendingRecoverySurface === surface {
+            previous.pendingRecoverySurface = nil
+        }
         surface.pendingRecoveryHost = host
         surface.pendingRecoveryVisibility = visible
         surface.pendingRecoveryEpoch += 1
+        host.pendingRecoverySurface = surface
     }
 
     /// Clears the pending recovery (successful claim, or a gate-blocked
@@ -447,6 +468,10 @@ struct PaneSurfaceRepresentable: NSViewRepresentable {
     private static func disarmPendingRecovery(_ surface: GhosttySurfaceView) {
         guard surface.pendingRecoveryHost != nil ||
               surface.pendingRecoveryVisibility != nil else { return }
+        if let candidate = surface.pendingRecoveryHost as? NoDragContainerView,
+           candidate.pendingRecoverySurface === surface {
+            candidate.pendingRecoverySurface = nil
+        }
         surface.pendingRecoveryHost = nil
         surface.pendingRecoveryVisibility = nil
         surface.pendingRecoveryEpoch += 1
@@ -459,6 +484,21 @@ struct PaneSurfaceRepresentable: NSViewRepresentable {
     /// hard-coding a number that silently stops clearing the budget if this
     /// one ever grows.
     static let recoveryRetryBudget = 8
+
+    /// Mount follow-up for a declined candidate that missed both recovery
+    /// paths while it was window-less. The candidate/surface cross-checks make
+    /// the event generation-safe: a container recycled onto another pane, or
+    /// a surface re-armed for a newer candidate, has no authority here. Re-enter
+    /// the FULL `.initial` pass so visibility, generation arbitration, and the
+    /// pre-commit defer all keep their existing semantics.
+    static func recoverPendingClaim(for surface: GhosttySurfaceView,
+                                    afterCandidateMount candidate: NoDragContainerView) {
+        guard candidate.window != nil,
+              candidate.pendingRecoverySurface === surface,
+              surface.pendingRecoveryHost === candidate,
+              let visible = surface.pendingRecoveryVisibility else { return }
+        performAttach(surface, to: candidate, isPaneVisible: visible, pass: .initial)
+    }
 
     /// Deallocation follow-up for a host that died without an ownership
     /// hand-off — the last eventless path. The weak paneHostView nils

--- a/GlintTests/PerformanceRegressionTests.swift
+++ b/GlintTests/PerformanceRegressionTests.swift
@@ -595,6 +595,48 @@ final class PerformanceRegressionTests: XCTestCase {
         XCTAssertNil(surfaceA.pendingRecoveryHost)
     }
 
+    /// In a 3/4-pane switch, two surfaces can both have their claim for the
+    /// same window-less candidate declined before either owner is reclaimed.
+    /// Arming B must retire A's candidate link; otherwise A's later
+    /// invalidation can evict B after B has mounted and claimed the container.
+    func testRejectedClaimDisarmsPreviousSurfacePendingOnSameCandidate() {
+        let stage = PaneHostStage()
+        let hostB = PaneSurfaceRepresentable.NoDragContainerView()
+        stage.window.contentView?.addSubview(hostB)
+        let surfaceA = GhosttySurfaceView(frame: .zero)
+        let surfaceB = GhosttySurfaceView(frame: .zero)
+        let replacementA = GhosttySurfaceView(frame: .zero)
+        let replacementB = GhosttySurfaceView(frame: .zero)
+
+        stage.older.removeFromSuperview()
+        stage.attach(surfaceA, to: stage.newer, visible: true)
+        stage.attach(surfaceB, to: hostB, visible: true)
+
+        stage.attach(surfaceA, to: stage.older, visible: true) // declined
+        stage.attach(surfaceB, to: stage.older, visible: true) // declined, replaces A
+
+        XCTAssertNil(surfaceA.pendingRecoveryHost,
+                     "a candidate can have only one pending surface")
+        XCTAssertTrue(surfaceB.pendingRecoveryHost === stage.older)
+        XCTAssertTrue(stage.older.pendingRecoverySurface === surfaceB)
+
+        // B's owner is reclaimed while the candidate is still window-less;
+        // mounting the candidate then lets B take it over.
+        stage.attach(replacementB, to: hostB, visible: true)
+        stage.window.contentView?.addSubview(stage.older)
+        XCTAssertTrue(surfaceB.superview === stage.older)
+
+        // A's old owner is reclaimed later. A's superseded pending claim must
+        // not reattach and drive B out of the candidate.
+        stage.attach(replacementA, to: stage.newer, visible: true)
+
+        XCTAssertTrue(surfaceB.superview === stage.older,
+                      "A's stale recovery must not evict B")
+        XCTAssertTrue(surfaceB.paneHostView === stage.older)
+        XCTAssertTrue(stage.older.expectedSurface === surfaceB)
+        XCTAssertFalse(surfaceA.superview === stage.older)
+    }
+
     /// Mount is an event, not permission to bypass arbitration. If the live
     /// recorded host still expects the surface, entering the window must
     /// re-run `.initial`, lose the generation verdict, and stay pending.

--- a/GlintTests/PerformanceRegressionTests.swift
+++ b/GlintTests/PerformanceRegressionTests.swift
@@ -563,6 +563,38 @@ final class PerformanceRegressionTests: XCTestCase {
                        "the recycled container must not keep showing the outgoing workspace")
     }
 
+    /// A candidate armed for A can be recycled onto visible surface B before
+    /// it mounts. The successful claim must retire A's pending recovery so the
+    /// mount callback cannot revive A and evict B from its new container.
+    func testReusedCandidateDoesNotRecoverPreviousPendingSurfaceOnMount() {
+        let stage = PaneHostStage()
+        let surfaceA = GhosttySurfaceView(frame: .zero)
+        let surfaceB = GhosttySurfaceView(frame: .zero)
+        let replacement = GhosttySurfaceView(frame: .zero)
+
+        stage.older.removeFromSuperview()
+        stage.attach(surfaceA, to: stage.newer, visible: true)
+        stage.attach(surfaceA, to: stage.older, visible: true) // declined, pending armed
+
+        // A's owner is reclaimed while its candidate is still window-less.
+        stage.attach(replacement, to: stage.newer, visible: true)
+        XCTAssertNil(surfaceA.paneHostView)
+        XCTAssertTrue(surfaceA.pendingRecoveryHost === stage.older)
+
+        // SwiftUI reuses the detached candidate for B before mounting it.
+        stage.attach(surfaceB, to: stage.older, visible: true)
+        XCTAssertTrue(surfaceB.superview === stage.older)
+        XCTAssertTrue(stage.older.expectedSurface === surfaceB)
+
+        stage.window.contentView?.addSubview(stage.older)
+
+        XCTAssertTrue(surfaceB.superview === stage.older,
+                      "mount must not revive the previous pending surface")
+        XCTAssertTrue(surfaceB.paneHostView === stage.older)
+        XCTAssertTrue(stage.older.expectedSurface === surfaceB)
+        XCTAssertNil(surfaceA.pendingRecoveryHost)
+    }
+
     /// Mount is an event, not permission to bypass arbitration. If the live
     /// recorded host still expects the surface, entering the window must
     /// re-run `.initial`, lose the generation verdict, and stay pending.

--- a/GlintTests/PerformanceRegressionTests.swift
+++ b/GlintTests/PerformanceRegressionTests.swift
@@ -526,12 +526,15 @@ final class PerformanceRegressionTests: XCTestCase {
     /// nil by then, so `shouldClaim` passes); pinning early would strand the
     /// surface in a window-less container whose reassert bails on
     /// `containerIsAttached`.
-    func testInvalidationRedriveSkipsUnmountedCandidate() {
+    func testUnmountedCandidateRecoversWhenItEntersWindow() {
         let stage = PaneHostStage()
         let surfaceA = GhosttySurfaceView(frame: .zero)
         let surfaceB = GhosttySurfaceView(frame: .zero)
+        let outgoingSurface = GhosttySurfaceView(frame: .zero)
 
-        // The candidate `older` is mid-commit: not in the window yet.
+        // The candidate is a recycled container that still renders the
+        // outgoing workspace's surface, then leaves the window mid-commit.
+        stage.attach(outgoingSurface, to: stage.older, visible: true)
         stage.older.removeFromSuperview()
 
         stage.attach(surfaceA, to: stage.newer, visible: true)
@@ -549,13 +552,41 @@ final class PerformanceRegressionTests: XCTestCase {
         XCTAssertTrue(surfaceA.pendingRecoveryHost === stage.older,
                       "the pending claim stays armed for the candidate's own mount")
 
-        // The candidate's commit lands: its representable mounts and claims
-        // (host nil → shouldClaim passes).
+        // The candidate's commit lands. Entering the window must itself
+        // re-drive the armed claim; SwiftUI is not required to issue another
+        // updateNSView after mounting an already-created representable.
         stage.window.contentView?.addSubview(stage.older)
-        stage.attach(surfaceA, to: stage.older, visible: true)
 
         XCTAssertTrue(surfaceA.superview === stage.older)
         XCTAssertTrue(surfaceA.paneHostView === stage.older)
+        XCTAssertFalse(outgoingSurface.superview === stage.older,
+                       "the recycled container must not keep showing the outgoing workspace")
+    }
+
+    /// Mount is an event, not permission to bypass arbitration. If the live
+    /// recorded host still expects the surface, entering the window must
+    /// re-run `.initial`, lose the generation verdict, and stay pending.
+    func testMountedCandidateDoesNotStealFromLiveHost() async {
+        let stage = PaneHostStage()
+        let surface = GhosttySurfaceView(frame: .zero)
+
+        stage.attach(surface, to: stage.newer, visible: true)
+        stage.older.removeFromSuperview()
+        stage.attach(surface, to: stage.older, visible: true) // declined
+
+        stage.window.contentView?.addSubview(stage.older)
+        await drainMainQueue(turns: pastBackstopBudget)
+
+        XCTAssertTrue(surface.superview === stage.newer)
+        XCTAssertTrue(surface.paneHostView === stage.newer)
+        XCTAssertNil(stage.older.expectedSurface)
+        XCTAssertTrue(surface.pendingRecoveryHost === stage.older,
+                      "mount must keep waiting while the rightful host still vetoes")
+
+        // Leave no pending backstop state for later tests.
+        stage.attach(surface, to: stage.older, visible: false)
+        XCTAssertNil(surface.pendingRecoveryHost)
+        XCTAssertNil(stage.older.pendingRecoverySurface)
     }
 
     /// P1 from the #109 review: a backstop chain queued for an OLD pending
@@ -671,6 +702,7 @@ final class PerformanceRegressionTests: XCTestCase {
         XCTAssertTrue(surfaceA.superview === newest)
         XCTAssertNil(surfaceA.pendingRecoveryHost)
         XCTAssertNil(surfaceA.pendingRecoveryVisibility)
+        XCTAssertNil(stage.older.pendingRecoverySurface)
     }
 
     func testSplitLayoutExplicitlyAccountsForBothBranchesAndDivider() {


### PR DESCRIPTION
## Summary

- make a window-less candidate host re-drive its pending surface claim from `viewDidMoveToWindow`
- keep the re-entry on the full `.initial` arbitration path, preserving visibility, generation, and pre-commit defer guards
- enforce the candidate↔surface pending claim as one-to-one for both successful and rejected candidate reuse
- add NSView lifecycle regressions for stale-content recovery, live-owner non-steal, and the real 3/4-pane A-rejected/B-rejected reuse sequence

## Root cause

A declined candidate could miss both invalidation and the bounded backstop while it was outside a window. SwiftUI could then mount that already-created container without another `updateNSView`, leaving the outgoing workspace surface visible until relaunch.

The bidirectional pending association also had two reuse holes. A successful claim initially left the displaced surface armed, and a later rejected claim could overwrite `candidate.pendingRecoverySurface` without clearing the previous surface-side `pendingRecoveryHost`. That stale reverse link let a later host invalidation revive the old surface and evict the new mounted owner.

## Validation

- red-to-green regression for A rejected → B rejected on the same unmounted candidate → B mounts → A owner is reclaimed
- `PerformanceRegressionTests`: 43/43 passed
- full `GlintTests` passed
- `git diff --check` passed

## Scope

Only `PaneSurfaceRepresentable.swift` and `PerformanceRegressionTests.swift` are changed. Follow-up to the host-claim recovery in #109.