### PR TITLE
fix(agent): prevent socket takeover across Glint instances

### DIFF
--- a/Glint/Agent/AgentBridge.swift
+++ b/Glint/Agent/AgentBridge.swift
@@ -18,9 +18,71 @@ final class AgentBridge {
     private(set) var socketPath: String = ""
     private var listenFD: Int32 = -1
     private var acceptSource: DispatchSourceRead?
+    private var socketLease: SocketLease?
     private let queue = DispatchQueue(label: "glint.agent.bridge", qos: .utility)
 
     private init() {}
+
+    final class SocketLease {
+        let path: String
+        private let lockFD: Int32
+
+        fileprivate init(path: String, lockFD: Int32 = -1) {
+            self.path = path
+            self.lockFD = lockFD
+        }
+
+        deinit {
+            if lockFD >= 0 { close(lockFD) }
+        }
+    }
+
+    /// The first process of each build flavor keeps the stable socket name;
+    /// another same-flavor process gets a PID-scoped fallback instead of
+    /// unlinking the first process' live endpoint.
+    static func acquireSocketLease(in runDir: URL, processID: Int32 = getpid()) -> SocketLease {
+        #if DEBUG
+        let stem = "agent-debug"
+        #else
+        let stem = "agent"
+        #endif
+        let canonical = runDir.appendingPathComponent("\(stem).sock").path
+        let fallback = runDir.appendingPathComponent("\(stem)-\(processID).sock").path
+        let lockPath = runDir.appendingPathComponent("\(stem).lock").path
+        let fd = open(lockPath, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)
+        guard fd >= 0 else { return SocketLease(path: fallback) }
+        chmod(lockPath, 0o600)
+        guard flock(fd, LOCK_EX | LOCK_NB) == 0 else {
+            close(fd)
+            return SocketLease(path: fallback)
+        }
+        // Older Glint builds do not hold the lock. Keep their reachable
+        // canonical socket intact during the upgrade transition too.
+        if socketIsReachable(canonical) {
+            close(fd)
+            return SocketLease(path: fallback)
+        }
+        return SocketLease(path: canonical, lockFD: fd)
+    }
+
+    private static func socketIsReachable(_ path: String) -> Bool {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return false }
+        defer { close(fd) }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        path.withCString { src in
+            withUnsafeMutableBytes(of: &addr.sun_path) { dst in
+                _ = strlcpy(dst.baseAddress!.assumingMemoryBound(to: CChar.self), src, dst.count)
+            }
+        }
+        return withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.connect(fd, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        } == 0
+    }
 
     /// Bind + listen. Path is short on purpose (sun_path is 104 chars on Darwin).
     ///
@@ -30,15 +92,14 @@ final class AgentBridge {
     /// a small race window in a world-readable directory. A 0700 parent
     /// closes both holes — nobody else can reach the socket at all.
     ///
-    /// Debug builds use a separate socket filename so a running dev Glint
-    /// and a running production Glint don't fight over the same path.
-    /// Without this split, whichever process started last `unlink()`s the
-    /// other's bound entry and steals every incoming hook event — the other
-    /// Glint's sidebar would freeze on whatever status the pane was in when
-    /// the steal happened (e.g. "thinking" with no Stop to clear it).
+    /// Debug builds use a separate socket namespace from production. Within
+    /// one flavor, a file lock keeps the first process on the stable name and
+    /// moves any later process to a PID-scoped fallback instead of letting its
+    /// `unlink()` strand the first process' listener.
     /// The path is baked into each pane's `$GLINT_AGENT_SOCK` at creation,
     /// so panes consistently report back to the Glint that launched them.
     func start() {
+        guard listenFD < 0 else { return }
         let home = FileManager.default.homeDirectoryForCurrentUser
         let runDir = home
             .appendingPathComponent(".glint", isDirectory: true)
@@ -58,11 +119,9 @@ final class AgentBridge {
         }
         chmod(runDir.path, 0o700)
 
-        #if DEBUG
-        let path = runDir.appendingPathComponent("agent-debug.sock").path
-        #else
-        let path = runDir.appendingPathComponent("agent.sock").path
-        #endif
+        let lease = Self.acquireSocketLease(in: runDir)
+        let path = lease.path
+        socketLease = lease
         socketPath = path
 
         // Reap any stale socket from a previous run.
@@ -71,6 +130,7 @@ final class AgentBridge {
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
         guard fd >= 0 else {
             NSLog("[glint] agent socket() failed: \(String(cString: strerror(errno)))")
+            socketLease = nil
             return
         }
 
@@ -92,6 +152,7 @@ final class AgentBridge {
         guard bindRC == 0 else {
             NSLog("[glint] agent bind(\(path)) failed: \(String(cString: strerror(errno)))")
             close(fd)
+            socketLease = nil
             return
         }
         chmod(path, 0o600)
@@ -99,6 +160,7 @@ final class AgentBridge {
         guard listen(fd, 16) == 0 else {
             NSLog("[glint] agent listen() failed: \(String(cString: strerror(errno)))")
             close(fd)
+            socketLease = nil
             return
         }
 

--- a/Glint/Agent/AgentBridge.swift
+++ b/Glint/Agent/AgentBridge.swift
@@ -49,7 +49,7 @@ final class AgentBridge {
         let canonical = runDir.appendingPathComponent("\(stem).sock").path
         let fallback = runDir.appendingPathComponent("\(stem)-\(processID).sock").path
         let lockPath = runDir.appendingPathComponent("\(stem).lock").path
-        let fd = open(lockPath, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)
+        let fd = open(lockPath, O_CREAT | O_RDWR | O_CLOEXEC, S_IRUSR | S_IWUSR)
         guard fd >= 0 else { return SocketLease(path: fallback) }
         chmod(lockPath, 0o600)
         guard flock(fd, LOCK_EX | LOCK_NB) == 0 else {

--- a/Glint/Agent/AgentBridge.swift
+++ b/Glint/Agent/AgentBridge.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Darwin
 
-/// Listens on a per-user Unix domain socket. CLI agents (Claude Code,
+/// Listens on a per-process Unix domain socket. CLI agents (Claude Code,
 /// Codex, …) post one JSON line per hook event:
 ///
 ///     {"pane":"<workspace-uuid>:<pane-seq>","hook":"UserPromptSubmit"}
@@ -18,70 +18,20 @@ final class AgentBridge {
     private(set) var socketPath: String = ""
     private var listenFD: Int32 = -1
     private var acceptSource: DispatchSourceRead?
-    private var socketLease: SocketLease?
     private let queue = DispatchQueue(label: "glint.agent.bridge", qos: .utility)
 
     private init() {}
 
-    final class SocketLease {
-        let path: String
-        private let lockFD: Int32
-
-        fileprivate init(path: String, lockFD: Int32 = -1) {
-            self.path = path
-            self.lockFD = lockFD
-        }
-
-        deinit {
-            if lockFD >= 0 { close(lockFD) }
-        }
-    }
-
-    /// The first process of each build flavor keeps the stable socket name;
-    /// another same-flavor process gets a PID-scoped fallback instead of
-    /// unlinking the first process' live endpoint.
-    static func acquireSocketLease(in runDir: URL, processID: Int32 = getpid()) -> SocketLease {
+    /// Every Glint process owns a distinct path. A shared stable name cannot be
+    /// made safe across legacy/test builds: any process that unlinks and rebinds
+    /// it strands the original listener even while that owner remains alive.
+    static func processSocketPath(in runDir: URL, processID: Int32 = getpid()) -> String {
         #if DEBUG
         let stem = "agent-debug"
         #else
         let stem = "agent"
         #endif
-        let canonical = runDir.appendingPathComponent("\(stem).sock").path
-        let fallback = runDir.appendingPathComponent("\(stem)-\(processID).sock").path
-        let lockPath = runDir.appendingPathComponent("\(stem).lock").path
-        let fd = open(lockPath, O_CREAT | O_RDWR | O_CLOEXEC, S_IRUSR | S_IWUSR)
-        guard fd >= 0 else { return SocketLease(path: fallback) }
-        chmod(lockPath, 0o600)
-        guard flock(fd, LOCK_EX | LOCK_NB) == 0 else {
-            close(fd)
-            return SocketLease(path: fallback)
-        }
-        // Older Glint builds do not hold the lock. Keep their reachable
-        // canonical socket intact during the upgrade transition too.
-        if socketIsReachable(canonical) {
-            close(fd)
-            return SocketLease(path: fallback)
-        }
-        return SocketLease(path: canonical, lockFD: fd)
-    }
-
-    private static func socketIsReachable(_ path: String) -> Bool {
-        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
-        guard fd >= 0 else { return false }
-        defer { close(fd) }
-
-        var addr = sockaddr_un()
-        addr.sun_family = sa_family_t(AF_UNIX)
-        path.withCString { src in
-            withUnsafeMutableBytes(of: &addr.sun_path) { dst in
-                _ = strlcpy(dst.baseAddress!.assumingMemoryBound(to: CChar.self), src, dst.count)
-            }
-        }
-        return withUnsafePointer(to: &addr) { ptr in
-            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-                Darwin.connect(fd, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
-            }
-        } == 0
+        return runDir.appendingPathComponent("\(stem)-\(processID).sock").path
     }
 
     static func createListeningSocket(at path: String) -> Int32 {
@@ -135,10 +85,8 @@ final class AgentBridge {
     /// a small race window in a world-readable directory. A 0700 parent
     /// closes both holes — nobody else can reach the socket at all.
     ///
-    /// Debug builds use a separate socket namespace from production. Within
-    /// one flavor, a file lock keeps the first process on the stable name and
-    /// moves any later process to a PID-scoped fallback instead of letting its
-    /// `unlink()` strand the first process' listener.
+    /// Debug builds use a separate socket namespace from production, and every
+    /// process includes its PID so no other Glint instance can unlink its path.
     /// The path is baked into each pane's `$GLINT_AGENT_SOCK` at creation,
     /// so panes consistently report back to the Glint that launched them.
     func start() {
@@ -162,19 +110,14 @@ final class AgentBridge {
         }
         chmod(runDir.path, 0o700)
 
-        let lease = Self.acquireSocketLease(in: runDir)
-        let path = lease.path
-        socketLease = lease
+        let path = Self.processSocketPath(in: runDir)
         socketPath = path
 
         // Reap any stale socket from a previous run.
         unlink(path)
 
         let fd = Self.createListeningSocket(at: path)
-        guard fd >= 0 else {
-            socketLease = nil
-            return
-        }
+        guard fd >= 0 else { return }
 
         listenFD = fd
         let src = DispatchSource.makeReadSource(fileDescriptor: fd, queue: queue)

--- a/Glint/Agent/AgentBridge.swift
+++ b/Glint/Agent/AgentBridge.swift
@@ -84,6 +84,49 @@ final class AgentBridge {
         } == 0
     }
 
+    static func createListeningSocket(at path: String) -> Int32 {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            NSLog("[glint] agent socket() failed: \(String(cString: strerror(errno)))")
+            return -1
+        }
+        guard fcntl(fd, F_SETFD, FD_CLOEXEC) == 0 else {
+            let error = errno
+            close(fd)
+            NSLog("[glint] agent socket close-on-exec failed: \(String(cString: strerror(error)))")
+            return -1
+        }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        path.withCString { src in
+            withUnsafeMutableBytes(of: &addr.sun_path) { dst in
+                let dstPtr = dst.baseAddress!.assumingMemoryBound(to: CChar.self)
+                _ = strlcpy(dstPtr, src, dst.count)
+            }
+        }
+
+        let addrLen = socklen_t(MemoryLayout<sockaddr_un>.size)
+        let bindRC = withUnsafePointer(to: &addr) { ptr -> Int32 in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { saPtr in
+                Darwin.bind(fd, saPtr, addrLen)
+            }
+        }
+        guard bindRC == 0 else {
+            NSLog("[glint] agent bind(\(path)) failed: \(String(cString: strerror(errno)))")
+            close(fd)
+            return -1
+        }
+        chmod(path, 0o600)
+
+        guard listen(fd, 16) == 0 else {
+            NSLog("[glint] agent listen() failed: \(String(cString: strerror(errno)))")
+            close(fd)
+            return -1
+        }
+        return fd
+    }
+
     /// Bind + listen. Path is short on purpose (sun_path is 104 chars on Darwin).
     ///
     /// The socket lives under `~/.glint/run/` (0700) rather than `/tmp`:
@@ -127,39 +170,8 @@ final class AgentBridge {
         // Reap any stale socket from a previous run.
         unlink(path)
 
-        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        let fd = Self.createListeningSocket(at: path)
         guard fd >= 0 else {
-            NSLog("[glint] agent socket() failed: \(String(cString: strerror(errno)))")
-            socketLease = nil
-            return
-        }
-
-        var addr = sockaddr_un()
-        addr.sun_family = sa_family_t(AF_UNIX)
-        path.withCString { src in
-            withUnsafeMutableBytes(of: &addr.sun_path) { dst in
-                let dstPtr = dst.baseAddress!.assumingMemoryBound(to: CChar.self)
-                _ = strlcpy(dstPtr, src, dst.count)
-            }
-        }
-
-        let addrLen = socklen_t(MemoryLayout<sockaddr_un>.size)
-        let bindRC = withUnsafePointer(to: &addr) { ptr -> Int32 in
-            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { saPtr in
-                Darwin.bind(fd, saPtr, addrLen)
-            }
-        }
-        guard bindRC == 0 else {
-            NSLog("[glint] agent bind(\(path)) failed: \(String(cString: strerror(errno)))")
-            close(fd)
-            socketLease = nil
-            return
-        }
-        chmod(path, 0o600)
-
-        guard listen(fd, 16) == 0 else {
-            NSLog("[glint] agent listen() failed: \(String(cString: strerror(errno)))")
-            close(fd)
             socketLease = nil
             return
         }

--- a/GlintTests/AgentHookRoutingTests.swift
+++ b/GlintTests/AgentHookRoutingTests.swift
@@ -1,7 +1,59 @@
+import Darwin
 import XCTest
 @testable import Glint
 
 final class AgentHookRoutingTests: XCTestCase {
+    func testCanonicalLeaseIsReleasedWhileExecDescendantRemainsAlive() throws {
+        let root = URL(fileURLWithPath: "/tmp/gb-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        var owner: AgentBridge.SocketLease? = AgentBridge.acquireSocketLease(
+            in: root,
+            processID: 101
+        )
+        let canonical = try XCTUnwrap(owner?.path)
+
+        let executable = strdup("/bin/sleep")!
+        let arg0 = strdup("sleep")!
+        let arg1 = strdup("5")!
+        let argv = UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>.allocate(capacity: 3)
+        argv.initialize(repeating: nil, count: 3)
+        argv[0] = arg0
+        argv[1] = arg1
+        defer {
+            free(executable)
+            free(arg0)
+            free(arg1)
+            argv.deallocate()
+        }
+
+        var child: pid_t = 0
+        let spawnRC = posix_spawn(
+            &child,
+            executable,
+            nil,
+            nil,
+            argv,
+            nil
+        )
+        XCTAssertEqual(spawnRC, 0)
+        XCTAssertGreaterThan(child, 0)
+        guard spawnRC == 0, child > 0 else { return }
+        defer {
+            kill(child, SIGTERM)
+            waitpid(child, nil, 0)
+        }
+
+        // posix_spawn returns after exec; the descendant remains alive in sleep.
+        XCTAssertEqual(kill(child, 0), 0, "the exec descendant should still be alive")
+
+        owner = nil
+        let replacement = AgentBridge.acquireSocketLease(in: root, processID: 202)
+        XCTAssertEqual(replacement.path, canonical,
+                       "an exec descendant must not keep the canonical lease alive")
+    }
+
     func testSecondSameFlavorBridgeUsesIndependentSocketPath() throws {
         let root = URL(fileURLWithPath: "/tmp/gb-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)

--- a/GlintTests/AgentHookRoutingTests.swift
+++ b/GlintTests/AgentHookRoutingTests.swift
@@ -2,6 +2,50 @@ import XCTest
 @testable import Glint
 
 final class AgentHookRoutingTests: XCTestCase {
+    func testSecondSameFlavorBridgeUsesIndependentSocketPath() throws {
+        let root = URL(fileURLWithPath: "/tmp/gb-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        var first: AgentBridge.SocketLease? = AgentBridge.acquireSocketLease(
+            in: root,
+            processID: 101
+        )
+        let second = AgentBridge.acquireSocketLease(in: root, processID: 202)
+
+        XCTAssertNotEqual(first?.path, second.path,
+                          "a second Glint process must not unlink the first process' agent socket")
+        XCTAssertTrue(second.path.hasSuffix("-202.sock"))
+
+        let canonical = first?.path
+        first = nil
+        let replacement = AgentBridge.acquireSocketLease(in: root, processID: 303)
+        XCTAssertEqual(replacement.path, canonical,
+                       "the stable socket name should be reusable after its owner exits")
+    }
+
+    func testReachableLegacySocketIsNotClaimedDuringUpgrade() throws {
+        let root = URL(fileURLWithPath: "/tmp/gb-\(UUID().uuidString)", isDirectory: true)
+        let socket = root.appendingPathComponent("agent-debug.sock")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let listener = Process()
+        listener.executableURL = URL(fileURLWithPath: "/usr/bin/nc")
+        listener.arguments = ["-lkU", socket.path]
+        try listener.run()
+        defer { if listener.isRunning { listener.terminate() } }
+        let deadline = Date().addingTimeInterval(1)
+        while !FileManager.default.fileExists(atPath: socket.path), Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: socket.path))
+
+        let lease = AgentBridge.acquireSocketLease(in: root, processID: 404)
+        XCTAssertNotEqual(lease.path, socket.path)
+        XCTAssertTrue(lease.path.hasSuffix("-404.sock"))
+    }
+
     func testAttentionRankDoesNotLetThinkingHideCompletedSibling() {
         XCTAssertEqual(
             PaneAgentStatus.bestAttentionRank(in: [.thinking, .justCompleted]),

--- a/GlintTests/AgentHookRoutingTests.swift
+++ b/GlintTests/AgentHookRoutingTests.swift
@@ -13,6 +13,10 @@ final class AgentHookRoutingTests: XCTestCase {
             processID: 101
         )
         let canonical = try XCTUnwrap(owner?.path)
+        var listenerFD = AgentBridge.createListeningSocket(at: canonical)
+        XCTAssertGreaterThanOrEqual(listenerFD, 0)
+        guard listenerFD >= 0 else { return }
+        defer { if listenerFD >= 0 { close(listenerFD) } }
 
         let executable = strdup("/bin/sleep")!
         let arg0 = strdup("sleep")!
@@ -48,6 +52,8 @@ final class AgentHookRoutingTests: XCTestCase {
         // posix_spawn returns after exec; the descendant remains alive in sleep.
         XCTAssertEqual(kill(child, 0), 0, "the exec descendant should still be alive")
 
+        close(listenerFD)
+        listenerFD = -1
         owner = nil
         let replacement = AgentBridge.acquireSocketLease(in: root, processID: 202)
         XCTAssertEqual(replacement.path, canonical,

--- a/GlintTests/AgentHookRoutingTests.swift
+++ b/GlintTests/AgentHookRoutingTests.swift
@@ -3,105 +3,67 @@ import XCTest
 @testable import Glint
 
 final class AgentHookRoutingTests: XCTestCase {
-    func testCanonicalLeaseIsReleasedWhileExecDescendantRemainsAlive() throws {
+    func testLegacyCanonicalRebindCannotStrandActiveBridge() throws {
         let root = URL(fileURLWithPath: "/tmp/gb-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
 
-        var owner: AgentBridge.SocketLease? = AgentBridge.acquireSocketLease(
-            in: root,
-            processID: 101
+        let activePath = AgentBridge.processSocketPath(in: root, processID: 101)
+        let activeFD = AgentBridge.createListeningSocket(at: activePath)
+        XCTAssertGreaterThanOrEqual(activeFD, 0)
+        guard activeFD >= 0 else { return }
+        defer { close(activeFD) }
+
+        // Simulate a legacy/same-bundle Glint that still unlinks and rebinds the
+        // old stable name while this process remains alive.
+        let canonical = root.appendingPathComponent("agent-debug.sock").path
+        unlink(canonical)
+        let replacementFD = AgentBridge.createListeningSocket(at: canonical)
+        XCTAssertGreaterThanOrEqual(replacementFD, 0)
+        guard replacementFD >= 0 else { return }
+        defer { close(replacementFD) }
+
+        let clientFD = try connectUnixSocket(at: activePath)
+        defer { close(clientFD) }
+        let flags = fcntl(activeFD, F_GETFL)
+        XCTAssertGreaterThanOrEqual(flags, 0)
+        XCTAssertEqual(fcntl(activeFD, F_SETFL, flags | O_NONBLOCK), 0)
+        let acceptedFD = accept(activeFD, nil, nil)
+        if acceptedFD >= 0 { close(acceptedFD) }
+        XCTAssertGreaterThanOrEqual(
+            acceptedFD,
+            0,
+            "rebinding the legacy canonical path must not strand the active bridge"
         )
-        let canonical = try XCTUnwrap(owner?.path)
-        var listenerFD = AgentBridge.createListeningSocket(at: canonical)
+    }
+
+    func testListeningSocketIsCloseOnExec() throws {
+        let root = URL(fileURLWithPath: "/tmp/gb-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let path = AgentBridge.processSocketPath(in: root, processID: 101)
+        let listenerFD = AgentBridge.createListeningSocket(at: path)
         XCTAssertGreaterThanOrEqual(listenerFD, 0)
         guard listenerFD >= 0 else { return }
-        defer { if listenerFD >= 0 { close(listenerFD) } }
+        defer { close(listenerFD) }
 
-        let executable = strdup("/bin/sleep")!
-        let arg0 = strdup("sleep")!
-        let arg1 = strdup("5")!
-        let argv = UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>.allocate(capacity: 3)
-        argv.initialize(repeating: nil, count: 3)
-        argv[0] = arg0
-        argv[1] = arg1
-        defer {
-            free(executable)
-            free(arg0)
-            free(arg1)
-            argv.deallocate()
-        }
-
-        var child: pid_t = 0
-        let spawnRC = posix_spawn(
-            &child,
-            executable,
-            nil,
-            nil,
-            argv,
-            nil
-        )
-        XCTAssertEqual(spawnRC, 0)
-        XCTAssertGreaterThan(child, 0)
-        guard spawnRC == 0, child > 0 else { return }
-        defer {
-            kill(child, SIGTERM)
-            waitpid(child, nil, 0)
-        }
-
-        // posix_spawn returns after exec; the descendant remains alive in sleep.
-        XCTAssertEqual(kill(child, 0), 0, "the exec descendant should still be alive")
-
-        close(listenerFD)
-        listenerFD = -1
-        owner = nil
-        let replacement = AgentBridge.acquireSocketLease(in: root, processID: 202)
-        XCTAssertEqual(replacement.path, canonical,
-                       "an exec descendant must not keep the canonical lease alive")
+        let descriptorFlags = fcntl(listenerFD, F_GETFD)
+        XCTAssertGreaterThanOrEqual(descriptorFlags, 0)
+        XCTAssertNotEqual(descriptorFlags & FD_CLOEXEC, 0)
     }
 
-    func testSecondSameFlavorBridgeUsesIndependentSocketPath() throws {
+    func testEachBridgeUsesProcessScopedSocketPath() throws {
         let root = URL(fileURLWithPath: "/tmp/gb-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
 
-        var first: AgentBridge.SocketLease? = AgentBridge.acquireSocketLease(
-            in: root,
-            processID: 101
-        )
-        let second = AgentBridge.acquireSocketLease(in: root, processID: 202)
+        let first = AgentBridge.processSocketPath(in: root, processID: 101)
+        let second = AgentBridge.processSocketPath(in: root, processID: 202)
 
-        XCTAssertNotEqual(first?.path, second.path,
-                          "a second Glint process must not unlink the first process' agent socket")
-        XCTAssertTrue(second.path.hasSuffix("-202.sock"))
-
-        let canonical = first?.path
-        first = nil
-        let replacement = AgentBridge.acquireSocketLease(in: root, processID: 303)
-        XCTAssertEqual(replacement.path, canonical,
-                       "the stable socket name should be reusable after its owner exits")
-    }
-
-    func testReachableLegacySocketIsNotClaimedDuringUpgrade() throws {
-        let root = URL(fileURLWithPath: "/tmp/gb-\(UUID().uuidString)", isDirectory: true)
-        let socket = root.appendingPathComponent("agent-debug.sock")
-        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: root) }
-
-        let listener = Process()
-        listener.executableURL = URL(fileURLWithPath: "/usr/bin/nc")
-        listener.arguments = ["-lkU", socket.path]
-        try listener.run()
-        defer { if listener.isRunning { listener.terminate() } }
-        let deadline = Date().addingTimeInterval(1)
-        while !FileManager.default.fileExists(atPath: socket.path), Date() < deadline {
-            RunLoop.current.run(until: Date().addingTimeInterval(0.01))
-        }
-        XCTAssertTrue(FileManager.default.fileExists(atPath: socket.path))
-
-        let lease = AgentBridge.acquireSocketLease(in: root, processID: 404)
-        XCTAssertNotEqual(lease.path, socket.path)
-        XCTAssertTrue(lease.path.hasSuffix("-404.sock"))
+        XCTAssertNotEqual(first, second)
+        XCTAssertTrue(first.hasSuffix("-101.sock"))
+        XCTAssertTrue(second.hasSuffix("-202.sock"))
     }
 
     func testAttentionRankDoesNotLetThinkingHideCompletedSibling() {
@@ -315,6 +277,34 @@ final class AgentHookRoutingTests: XCTestCase {
             "agent": "claude",
             "session": "claude-sess-1",
         ])
+    }
+
+    private func connectUnixSocket(at path: String) throws -> Int32 {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        XCTAssertGreaterThanOrEqual(fd, 0)
+        guard fd >= 0 else { return fd }
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        path.withCString { source in
+            withUnsafeMutableBytes(of: &address.sun_path) { destination in
+                _ = strlcpy(
+                    destination.baseAddress!.assumingMemoryBound(to: CChar.self),
+                    source,
+                    destination.count
+                )
+            }
+        }
+        let result = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.connect(fd, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        if result != 0 {
+            close(fd)
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        return fd
     }
 
     /// Shared helper: spin up a Unix-domain listener, run the reporter once,


### PR DESCRIPTION
## 问题

多个 Glint 实例曾共享 canonical `agent.sock`。后启动实例一旦 unlink 并重新绑定该路径，旧实例虽然仍持有原 listener FD，但 pane 中的 `GLINT_AGENT_SOCK` 路径已经指向新 socket；新实例退出后，hook 对该路径只会得到 `ECONNREFUSED`。结果是 `UserPromptSubmit` 和 `Stop` 都被 reporter 静默丢弃，侧边栏可能既不显示开始思考，也一直不结束思考。

## 现场证据

- 原 Glint PID 仍运行并持有旧 listener。
- 同一路径的 socket 文件却在第二个 `/Applications/Glint.app` 启动时被重新创建；该实例约 24 秒后退出。
- 通过真实 `connect(2)` 连接该路径返回 `ECONNREFUSED`。
- Codex 0.153.0 连续 5 个普通 turn 均完整发出 `SessionStart → UserPromptSubmit → Stop`，reporter 并发转发 100/100，故本次故障位于 Glint socket 生命周期。

## 修复

- 每个 Glint 进程始终绑定 `agent[-debug]-<pid>.sock`，不再使用可被其它实例覆盖的 canonical 路径。
- pane 继续通过环境变量继承其所属 Glint 的精确 socket 路径。
- listener 保留 `FD_CLOEXEC`，避免 exec 后代延长 listener 生命周期。
- 删除不再需要的 canonical lock/lease 分支。

## 验证

- 新增 canonical 被重新绑定的回归测试：修复前稳定失败，修复后通过。
- 新增 PID 路径隔离与 listener `FD_CLOEXEC` 测试。
- `AgentHookRoutingTests`：18/18 通过。
- 除本机端口冲突的 `WebRemoteServerIntegrationTests` 外，其余 `GlintTests`：324/324 通过。
- 真实启动两个 Debug Glint：两个进程均存活，分别绑定不同 PID socket，两个路径均可通过 `connect(2)` 连接。
- `git diff --check` 通过。

完整套件中的 WebRemote 集成测试因当前 Release Glint 占用测试端口而无法进入 `.ready`；失败发生在未改动的 WebRemote 测试边界。