### PR TITLE
fix(web-remote): restore offline history and arbitrate pending grid sizes

### DIFF
--- a/Glint/Pane/GhosttySurfaceView.swift
+++ b/Glint/Pane/GhosttySurfaceView.swift
@@ -153,6 +153,10 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
     /// fill at the launch-time width; waiting for the width to settle fills to
     /// the final window width. -1 = no probe yet.
     private var lastRestoreProbeCols = -1
+    /// Web Remote pane selection waits here while an offline surface restores
+    /// its archive. Sending the snapshot before this completes permanently
+    /// loses the history from the browser's first frame.
+    private var pendingWebRemoteSnapshotWaiters: [(WebRemoteTerminalSnapshot?) -> Void] = []
 
     /// Nil while this pane is the active first responder; otherwise the point
     /// from which the configurable idle timeout is measured.
@@ -474,6 +478,10 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
         // pane, so echoing full-width history here would wrap every line and a
         // later resize doesn't reliably reflow it back. We stash the bytes and
         // echo once the surface has its real pane width (see syncSurfaceSize).
+        // These probes belong to this surface generation. Carrying them across
+        // an idle-offline recreation can suppress the new generation's fallback.
+        restoreFallbackArmed = false
+        lastRestoreProbeCols = -1
         pendingRestoreData = restoreData
         requiredRestoreCols = restoreData.map { Self.maxDisplayWidth(of: $0) } ?? 0
 
@@ -507,6 +515,30 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
         // it must never go through text_input or the shell would execute it.
         payload.withCString { ghostty_surface_process_output(s, $0, UInt(strlen($0))) }
         markScrollbackDirty()
+        finishPendingWebRemoteSnapshots()
+    }
+
+    private func armRestoreFallbackIfNeeded() {
+        guard !restoreFallbackArmed else { return }
+        restoreFallbackArmed = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) { [weak self] in
+            guard let self, let s = self.surface, let data = self.pendingRestoreData
+            else { return }
+            self.pendingRestoreData = nil
+            self.restoreScrollback(into: s, data: data)
+        }
+    }
+
+    private func finishPendingWebRemoteSnapshots() {
+        guard !pendingWebRemoteSnapshotWaiters.isEmpty else { return }
+        let waiters = pendingWebRemoteSnapshotWaiters
+        pendingWebRemoteSnapshotWaiters.removeAll()
+        // Let Ghostty publish the just-processed output to its render-grid
+        // snapshot before reading it back for the browser.
+        DispatchQueue.main.async { [weak self] in
+            let snapshot = self?.webRemoteSnapshot()
+            waiters.forEach { $0(snapshot) }
+        }
     }
 
     /// Snapshot the pane's current scrollback to disk as colored text (ANSI SGR).
@@ -1479,12 +1511,13 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
         let scale = window?.backingScaleFactor ?? 2.0
         let pixelWidth = floor(pointsSize.width * scale)
         let pixelHeight = floor(pointsSize.height * scale)
-        guard pixelWidth > 0, pixelHeight > 0 else { return }
+        let hasLocalSize = pixelWidth > 0 && pixelHeight > 0
+        guard hasLocalSize || webRemoteGridSize != nil else { return }
 
-        var targetWidth = UInt32(pixelWidth)
-        var targetHeight = UInt32(pixelHeight)
+        let current = ghostty_surface_size(s)
+        var targetWidth = hasLocalSize ? UInt32(pixelWidth) : current.width_px
+        var targetHeight = hasLocalSize ? UInt32(pixelHeight) : current.height_px
         if let remoteSize = webRemoteGridSize {
-            let current = ghostty_surface_size(s)
             let cellWidth = Int(current.cell_width_px)
             let cellHeight = Int(current.cell_height_px)
             if cellWidth > 0, cellHeight > 0 {
@@ -1500,6 +1533,7 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
                 targetHeight = UInt32(remoteSize.rows * cellHeight + verticalRemainder)
             }
         }
+        guard targetWidth > 0, targetHeight > 0 else { return }
 
         CATransaction.begin()
         CATransaction.setDisableActions(true)
@@ -1530,15 +1564,7 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
                 restoreScrollback(into: s, data: data)
             } else if cols > 0 {
                 lastRestoreProbeCols = cols
-                if !restoreFallbackArmed {
-                    restoreFallbackArmed = true
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) { [weak self] in
-                        guard let self, let s = self.surface, let data = self.pendingRestoreData
-                        else { return }
-                        self.pendingRestoreData = nil
-                        self.restoreScrollback(into: s, data: data)
-                    }
-                }
+                armRestoreFallbackIfNeeded()
             }
         }
 
@@ -2339,6 +2365,29 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
         guard let pointer = json.ptr, json.len > 0 else { return nil }
         let grid = Data(bytes: pointer, count: Int(json.len))
         return Self.webRemoteSnapshot(fromRenderGrid: grid, maxLines: maxLines)
+    }
+
+    /// Prepare an offline/recreated surface at the browser's stable grid size,
+    /// then include any archived scrollback in the very first snapshot. Waiting
+    /// for the normal delayed width fallback would send an empty snapshot first
+    /// and make correctness depend on post-selection output replay.
+    func webRemoteSnapshot(
+        size: WebRemoteTerminalSize,
+        completion: @escaping (WebRemoteTerminalSnapshot?) -> Void
+    ) {
+        guard ensureLiveForWebRemoteControl() else {
+            completion(nil)
+            return
+        }
+        let waitsForRestore = pendingRestoreData != nil
+        if waitsForRestore { pendingWebRemoteSnapshotWaiters.append(completion) }
+        setWebRemoteGridSize(size)
+        if pendingRestoreData != nil {
+            armRestoreFallbackIfNeeded()
+            return
+        }
+        if waitsForRestore { return }
+        DispatchQueue.main.async { [weak self] in completion(self?.webRemoteSnapshot()) }
     }
 
     fileprivate func forwardWebRemoteOutput(

--- a/Glint/WebRemote/WebRemoteServer.swift
+++ b/Glint/WebRemote/WebRemoteServer.swift
@@ -213,6 +213,10 @@ final class WebRemoteServer: @unchecked Sendable {
         pendingPane == pane && pendingGeneration == generation
     }
 
+    static func shouldReleaseTerminalSize(hasPendingSelection: Bool) -> Bool {
+        !hasPendingSelection
+    }
+
     private enum ListenerKind: Hashable {
         case http
         case webSocket
@@ -1167,11 +1171,16 @@ final class WebRemoteServer: @unchecked Sendable {
             .filter { $0.authenticated && $0.subscribedPane == pane && $0.terminalSize != nil }
             .max { $0.terminalSizeRevision < $1.terminalSizeRevision }?
             .terminalSize
+        let hasPendingSelection = clients.values.contains {
+            $0.authenticated && $0.pendingPane == pane
+        }
         DispatchQueue.main.async {
             guard let store = WorkspaceStore.current else { return }
+            // Snapshot preparation owns the browser grid until the pending
+            // selection succeeds or fails; releasing here would undo it mid-restore.
             if let size {
                 _ = store.webRemoteSetTerminalSize(pane: pane, size: size)
-            } else {
+            } else if Self.shouldReleaseTerminalSize(hasPendingSelection: hasPendingSelection) {
                 store.webRemoteReleaseTerminalSize(pane: pane)
             }
         }

--- a/Glint/WebRemote/WebRemoteServer.swift
+++ b/Glint/WebRemote/WebRemoteServer.swift
@@ -929,52 +929,45 @@ final class WebRemoteServer: @unchecked Sendable {
                 }
                 return
             }
-            let result = store.webRemoteTerminalSnapshot(pane: pane)
-            self.queue.async { [weak self, weak store] in
-                guard let self,
-                      let store
-                else { return }
-                guard let client = clients[clientID],
-                      client.authenticated,
-                      Self.isCurrentPaneSelection(
-                          pendingPane: client.pendingPane,
-                          pendingGeneration: client.paneSelectionGeneration,
-                          pane: pane,
-                          generation: selectionGeneration
-                      )
-                else { return }
-                switch result {
-                case let .success(snapshot):
-                    let bufferedOutput = client.pendingSelectionOutput.take(
-                        after: snapshot.outputSequence
-                    )
-                    client.pendingPane = nil
-                    client.subscribedPane = pane
-                    recordTerminalSizeLocked(size, for: client)
-                    updateSubscribedPanesLocked()
-                    sendJSON([
-                        "type": "snapshot",
-                        "pane": pane,
-                        "data": snapshot.payload.base64EncodedString(),
-                    ], to: clientID)
-                    if !bufferedOutput.isEmpty,
-                       !client.sendTerminalOutput(bufferedOutput, pane: pane) {
-                        dropSlowClientLocked(clientID)
-                        return
-                    }
-                    DispatchQueue.main.async { [weak self, weak store] in
-                        guard let self, let store else { return }
-                        if let error = store.webRemoteSetTerminalSize(pane: pane, size: size) {
-                            self.queue.async { [weak self] in self?.sendError(error, to: clientID) }
+            store.webRemoteTerminalSnapshot(pane: pane, size: size) { [weak self] result in
+                self?.queue.async { [weak self] in
+                    guard let self else { return }
+                    guard let client = clients[clientID],
+                          client.authenticated,
+                          Self.isCurrentPaneSelection(
+                              pendingPane: client.pendingPane,
+                              pendingGeneration: client.paneSelectionGeneration,
+                              pane: pane,
+                              generation: selectionGeneration
+                          )
+                    else { return }
+                    switch result {
+                    case let .success(snapshot):
+                        let bufferedOutput = client.pendingSelectionOutput.take(
+                            after: snapshot.outputSequence
+                        )
+                        client.pendingPane = nil
+                        client.subscribedPane = pane
+                        recordTerminalSizeLocked(size, for: client)
+                        updateSubscribedPanesLocked()
+                        sendJSON([
+                            "type": "snapshot",
+                            "pane": pane,
+                            "data": snapshot.payload.base64EncodedString(),
+                        ], to: clientID)
+                        if !bufferedOutput.isEmpty,
+                           !client.sendTerminalOutput(bufferedOutput, pane: pane) {
+                            dropSlowClientLocked(clientID)
+                            return
                         }
+                    case let .failure(error):
+                        finishSelectionFailure(
+                            error,
+                            pane: pane,
+                            generation: selectionGeneration,
+                            clientID: clientID
+                        )
                     }
-                case let .failure(error):
-                    finishSelectionFailure(
-                        error,
-                        pane: pane,
-                        generation: selectionGeneration,
-                        clientID: clientID
-                    )
                 }
             }
         }

--- a/Glint/WebRemote/WebRemoteServer.swift
+++ b/Glint/WebRemote/WebRemoteServer.swift
@@ -213,10 +213,6 @@ final class WebRemoteServer: @unchecked Sendable {
         pendingPane == pane && pendingGeneration == generation
     }
 
-    static func shouldReleaseTerminalSize(hasPendingSelection: Bool) -> Bool {
-        !hasPendingSelection
-    }
-
     private enum ListenerKind: Hashable {
         case http
         case webSocket
@@ -916,7 +912,8 @@ final class WebRemoteServer: @unchecked Sendable {
         client.pendingSelectionOutput = WebRemoteOutputBuffer(
             byteLimit: Self.maxSelectionOutputBytes
         )
-        client.terminalSize = nil
+        // Order size ownership by request arrival, not asynchronous snapshot completion.
+        recordTerminalSizeLocked(size, for: client)
         updateSubscribedPanesLocked()
         previousPanes.forEach { reconcileTerminalSizeLocked(for: $0) }
 
@@ -952,7 +949,6 @@ final class WebRemoteServer: @unchecked Sendable {
                         )
                         client.pendingPane = nil
                         client.subscribedPane = pane
-                        recordTerminalSizeLocked(size, for: client)
                         updateSubscribedPanesLocked()
                         sendJSON([
                             "type": "snapshot",
@@ -993,6 +989,7 @@ final class WebRemoteServer: @unchecked Sendable {
         else { return }
         _ = client.pendingSelectionOutput.take()
         client.pendingPane = nil
+        client.terminalSize = nil
         updateSubscribedPanesLocked()
         reconcileTerminalSizeLocked(for: pane)
         sendError(error, to: clientID)
@@ -1088,6 +1085,7 @@ final class WebRemoteServer: @unchecked Sendable {
             }
             if client.pendingPane == pane {
                 client.pendingPane = nil
+                client.terminalSize = nil
                 _ = client.pendingSelectionOutput.take()
             }
         }
@@ -1168,19 +1166,18 @@ final class WebRemoteServer: @unchecked Sendable {
 
     private func reconcileTerminalSizeLocked(for pane: String) {
         let size = clients.values
-            .filter { $0.authenticated && $0.subscribedPane == pane && $0.terminalSize != nil }
+            .filter {
+                $0.authenticated
+                    && ($0.subscribedPane == pane || $0.pendingPane == pane)
+                    && $0.terminalSize != nil
+            }
             .max { $0.terminalSizeRevision < $1.terminalSizeRevision }?
             .terminalSize
-        let hasPendingSelection = clients.values.contains {
-            $0.authenticated && $0.pendingPane == pane
-        }
         DispatchQueue.main.async {
             guard let store = WorkspaceStore.current else { return }
-            // Snapshot preparation owns the browser grid until the pending
-            // selection succeeds or fails; releasing here would undo it mid-restore.
             if let size {
                 _ = store.webRemoteSetTerminalSize(pane: pane, size: size)
-            } else if Self.shouldReleaseTerminalSize(hasPendingSelection: hasPendingSelection) {
+            } else {
                 store.webRemoteReleaseTerminalSize(pane: pane)
             }
         }

--- a/Glint/Workspace/WorkspaceStore.swift
+++ b/Glint/Workspace/WorkspaceStore.swift
@@ -2912,15 +2912,27 @@ final class WorkspaceStore: ObservableObject {
         ]
     }
 
-    func webRemoteTerminalSnapshot(pane: String) -> WebRemoteTerminalSnapshotResult {
-        guard let key = Self.parsePaneKey(pane) else { return .failure("bad-request") }
-        guard paneExists(key) else { return .failure("unknown-pane") }
-        guard let view = surfaceViews[key], view.ensureLiveForWebRemoteControl() else {
-            return .failure("pane-not-ready")
+    func webRemoteTerminalSnapshot(
+        pane: String,
+        size: WebRemoteTerminalSize,
+        completion: @escaping (WebRemoteTerminalSnapshotResult) -> Void
+    ) {
+        guard let key = Self.parsePaneKey(pane) else {
+            completion(.failure("bad-request")); return
+        }
+        guard paneExists(key) else {
+            completion(.failure("unknown-pane")); return
+        }
+        guard let view = surfaceViews[key] else {
+            completion(.failure("pane-not-ready")); return
         }
         webRemoteControlledPanes.insert(key)
-        guard let snapshot = view.webRemoteSnapshot() else { return .failure("pane-not-ready") }
-        return .success(snapshot)
+        view.webRemoteSnapshot(size: size) { snapshot in
+            guard let snapshot else {
+                completion(.failure("pane-not-ready")); return
+            }
+            completion(.success(snapshot))
+        }
     }
 
     func webRemoteSetTerminalSize(pane: String, size: WebRemoteTerminalSize) -> String? {

--- a/GlintTests/WebRemoteProtocolTests.swift
+++ b/GlintTests/WebRemoteProtocolTests.swift
@@ -3,6 +3,48 @@ import XCTest
 @testable import Glint
 
 final class WebRemoteProtocolTests: XCTestCase {
+    @MainActor
+    func testWebRemoteWakeSnapshotsPendingHistoryAtBrowserSize() throws {
+        let paneKey = "\(UUID().uuidString):0"
+        let archiveID = ScrollbackArchive.fileID(forPaneKey: paneKey)
+        let support = try XCTUnwrap(SupportDir.url)
+        let archiveDir = support.appendingPathComponent("scrollback", isDirectory: true)
+        let archive = archiveDir.appendingPathComponent("\(archiveID).ansi")
+        try FileManager.default.createDirectory(at: archiveDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: archive) }
+
+        let sentinel = "WEB_REMOTE_OFFLINE_HISTORY_SENTINEL"
+        let history = String(repeating: "W", count: 180) + sentinel
+        let historyData = Data(history.utf8)
+        try historyData.write(to: archive, options: [.atomic])
+        XCTAssertEqual(ScrollbackArchive.read(id: archiveID), historyData)
+
+        let defaults = UserDefaults.standard
+        let key = "glint.restoreTerminalScrollback"
+        let previous = defaults.object(forKey: key)
+        defaults.set(true, forKey: key)
+        defer {
+            if let previous { defaults.set(previous, forKey: key) }
+            else { defaults.removeObject(forKey: key) }
+        }
+
+        let view = GhosttySurfaceView(
+            frame: NSRect(x: 0, y: 0, width: 160, height: 120),
+            paneKey: paneKey
+        )
+        var receivedSnapshot: WebRemoteTerminalSnapshot?
+        view.webRemoteSnapshot(size: WebRemoteTerminalSize(columns: 240, rows: 40)) {
+            receivedSnapshot = $0
+        }
+        let deadline = Date().addingTimeInterval(1)
+        while receivedSnapshot == nil, Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+        }
+
+        let snapshot = try XCTUnwrap(receivedSnapshot)
+        XCTAssertTrue(String(decoding: snapshot.payload, as: UTF8.self).contains(sentinel))
+    }
+
     func testTerminalSizeAcceptsBrowserGridWithinSafeBounds() {
         XCTAssertEqual(
             WebRemoteTerminalSize.parse(["columns": 132, "rows": 43]),

--- a/GlintTests/WebRemoteProtocolTests.swift
+++ b/GlintTests/WebRemoteProtocolTests.swift
@@ -438,6 +438,19 @@ final class WebRemoteProtocolTests: XCTestCase {
         )
     }
 
+    func testPendingPaneSelectionPreventsTerminalSizeRelease() {
+        XCTAssertFalse(
+            WebRemoteServer.shouldReleaseTerminalSize(
+                hasPendingSelection: true
+            )
+        )
+        XCTAssertTrue(
+            WebRemoteServer.shouldReleaseTerminalSize(
+                hasPendingSelection: false
+            )
+        )
+    }
+
     func testHeadResponseKeepsContentLengthWithoutBody() {
         let body = Data("hello".utf8)
         let response = WebRemoteHTTPResponse.make(

--- a/GlintTests/WebRemoteProtocolTests.swift
+++ b/GlintTests/WebRemoteProtocolTests.swift
@@ -438,19 +438,6 @@ final class WebRemoteProtocolTests: XCTestCase {
         )
     }
 
-    func testPendingPaneSelectionPreventsTerminalSizeRelease() {
-        XCTAssertFalse(
-            WebRemoteServer.shouldReleaseTerminalSize(
-                hasPendingSelection: true
-            )
-        )
-        XCTAssertTrue(
-            WebRemoteServer.shouldReleaseTerminalSize(
-                hasPendingSelection: false
-            )
-        )
-    }
-
     func testHeadResponseKeepsContentLengthWithoutBody() {
         let body = Data("hello".utf8)
         let response = WebRemoteHTTPResponse.make(

--- a/scripts/test-web-remote-size.py
+++ b/scripts/test-web-remote-size.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Run production selection/arbitration methods with deterministic snapshot/queue stubs.
+
+No sockets or running Glint instance are needed. Method bodies are extracted
+verbatim so this tests the actual lifecycle, including when revisions are recorded.
+"""
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+
+root = Path(__file__).resolve().parents[1]
+source = (root / "Glint/WebRemote/WebRemoteServer.swift").read_text()
+
+
+def method(name):
+    match = re.search(r"^    (?:private |fileprivate |static )*func " + name + r"\(", source, re.M)
+    if match is None:
+        raise RuntimeError(f"Missing production method: {name}")
+    # Server methods end at their class-level indentation.
+    end = source.index("\n    }", match.end()) + len("\n    }")
+    return source[match.start():end].replace("private func", "func").replace("fileprivate func", "func")
+
+
+methods = [
+    "panesToReconcileWhenSelecting", "isCurrentPaneSelection", "selectPane",
+    "finishSelectionFailure", "resizePane", "removeClientLocked",
+    "recordTerminalSizeLocked", "reconcileTerminalSizeLocked",
+]
+if "func shouldReleaseTerminalSize(" in source:
+    methods.append("shouldReleaseTerminalSize")
+
+stub = r'''
+import Foundation
+
+// Explicit FIFO drains preserve the server/main queue boundary without sleeps.
+final class DispatchQueue {
+    static let main = DispatchQueue()
+    var jobs: [() -> Void] = []
+    func async(execute: @escaping () -> Void) { jobs.append(execute) }
+    func drain() { while !jobs.isEmpty { jobs.removeFirst()() } }
+}
+struct WebRemoteTerminalSize: Equatable { let columns: Int; let rows: Int }
+struct Snapshot { let outputSequence: UInt64 = 0; let payload = Data() }
+enum SnapshotResult { case success(Snapshot), failure(String) }
+struct WebRemoteOutputBuffer {
+    init(byteLimit: Int) {}
+    mutating func take(after: UInt64? = nil) -> Data { Data() }
+}
+final class WorkspaceStore {
+    static var current: WorkspaceStore? = WorkspaceStore()
+    var grids: [String: WebRemoteTerminalSize] = [:]
+    var snapshots: [(SnapshotResult) -> Void] = []
+    func controlFocus(pane: String, activateApp: Bool) -> String? { nil }
+    func webRemoteTerminalSnapshot(pane: String, size: WebRemoteTerminalSize,
+                                   completion: @escaping (SnapshotResult) -> Void) {
+        grids[pane] = size
+        snapshots.append(completion)
+    }
+    func webRemoteSetTerminalSize(pane: String, size: WebRemoteTerminalSize) -> String? {
+        grids[pane] = size
+        return nil
+    }
+    func webRemoteReleaseTerminalSize(pane: String) { grids.removeValue(forKey: pane) }
+}
+final class WebRemoteClientConnection {
+    var authenticated = true
+    var subscribedPane: String?
+    var pendingPane: String?
+    var paneSelectionGeneration: UInt64 = 0
+    var pendingSelectionOutput = WebRemoteOutputBuffer(byteLimit: 0)
+    var terminalSize: WebRemoteTerminalSize?
+    var terminalSizeRevision: UInt64 = 0
+    func cancel() {}
+    func sendTerminalOutput(_ data: Data, pane: String) -> Bool { true }
+}
+final class WebRemoteServer {
+    static let maxSelectionOutputBytes = 1024
+    let queue = DispatchQueue()
+    var clients: [UUID: WebRemoteClientConnection] = [:]
+    var terminalSizeRevision: UInt64 = 0
+    func updateSubscribedPanesLocked() {}
+    func sendJSON(_ object: [String: Any], to: UUID) {}
+    func sendError(_ error: String, to: UUID) {}
+    func dropSlowClientLocked(_ id: UUID) { removeClientLocked(id, cancelConnection: true) }
+    // PRODUCTION_METHODS
+}
+
+let narrow = WebRemoteTerminalSize(columns: 80, rows: 24)
+let wide = WebRemoteTerminalSize(columns: 120, rows: 40)
+var failures = 0
+func check(_ condition: Bool, _ message: String) {
+    if !condition { print("FAIL: \(message)"); failures += 1 }
+}
+func drain(_ server: WebRemoteServer) {
+    while !DispatchQueue.main.jobs.isEmpty || !server.queue.jobs.isEmpty {
+        DispatchQueue.main.drain()
+        server.queue.drain()
+    }
+}
+func fixture() -> (WebRemoteServer, WorkspaceStore, UUID, UUID) {
+    let server = WebRemoteServer(), store = WorkspaceStore()
+    WorkspaceStore.current = store
+    let a = UUID(), b = UUID()
+    server.clients[a] = WebRemoteClientConnection()
+    server.clients[b] = WebRemoteClientConnection()
+    server.selectPane("pane", size: narrow, for: a)
+    server.selectPane("pane", size: wide, for: b)
+    drain(server)
+    check(store.grids["pane"] == wide, "latest selection initially sets 120 columns")
+    return (server, store, a, b)
+}
+
+for departure in ["disconnect", "switch", "failure"] {
+    let (server, store, a, b) = fixture()
+    switch departure {
+    case "disconnect": server.removeClientLocked(b, cancelConnection: false)
+    case "switch": server.selectPane("other", size: wide, for: b)
+    default: store.snapshots[1](.failure("pane-not-ready"))
+    }
+    drain(server)
+    check(store.grids["pane"] == narrow, "\(departure): pending A restores 80 columns")
+    store.snapshots[0](.success(Snapshot()))
+    drain(server)
+    check(store.grids["pane"] == narrow, "\(departure): A stays at 80 after snapshot")
+    if departure != "failure" {
+        store.snapshots[1](.success(Snapshot()))
+        drain(server)
+        check(store.grids["pane"] == narrow, "\(departure): stale B callback is ignored")
+    }
+    server.removeClientLocked(a, cancelConnection: false)
+    drain(server)
+    check(store.grids["pane"] == nil, "\(departure): last owner releases grid")
+}
+
+// Completion order must not replace request order in last-request-wins arbitration.
+for completionOrder in [[0, 1], [1, 0]] {
+    let (server, store, _, _) = fixture()
+    for index in completionOrder { store.snapshots[index](.success(Snapshot())); drain(server) }
+    server.reconcileTerminalSizeLocked(for: "pane")
+    drain(server)
+    check(store.grids["pane"] == wide, "completion order \(completionOrder): B remains newest")
+}
+
+// An unrelated departure must not let an older subscribed request override pending B.
+do {
+    let (server, store, _, _) = fixture()
+    store.snapshots[0](.success(Snapshot()))
+    drain(server)
+    let c = UUID(), client = WebRemoteClientConnection()
+    client.subscribedPane = "pane"
+    client.terminalSize = narrow
+    server.clients[c] = client
+    server.removeClientLocked(c, cancelConnection: false)
+    drain(server)
+    check(store.grids["pane"] == wide, "pending B wins over subscribed A")
+}
+
+// A real resize received after B's select must retain priority when B completes.
+do {
+    let (server, store, a, _) = fixture()
+    store.snapshots[0](.success(Snapshot()))
+    drain(server)
+    server.resizePane("pane", size: narrow, for: a)
+    drain(server)
+    store.snapshots[1](.success(Snapshot()))
+    drain(server)
+    server.reconcileTerminalSizeLocked(for: "pane")
+    drain(server)
+    check(store.grids["pane"] == narrow, "newer resize wins over older snapshot completion")
+}
+
+if failures > 0 { exit(1) }
+print("PASS: 7 terminal-size lifecycle scenarios")
+'''
+
+with tempfile.TemporaryDirectory(prefix="glint-web-remote-size-") as directory:
+    path = Path(directory) / "main.swift"
+    path.write_text(stub.replace("    // PRODUCTION_METHODS", "\n".join(map(method, methods))))
+    subprocess.run(["swift", "-swift-version", "5", str(path)], check=True)


### PR DESCRIPTION
## 问题与结果

Web Remote 打开离线终端时，原先会在浏览器尺寸应用和归档历史恢复完成前抓取 snapshot，导致首帧缺少已保存的 scrollback。现在先设置浏览器 grid，再等待历史恢复完成并在下一次主队列 tick 抓取首帧。

多客户端等待同一终端快照时，尺寸仲裁还需要包含 pending selection。例如 A 请求 80 列、B 随后请求 120 列，若 B 在历史恢复期间断开、切走或选择失败，grid 现在会立即恢复为 A 的 80 列；所有有效请求退出后才释放远控尺寸。

## 实现

- 将浏览器尺寸传入 snapshot 准备阶段；无待恢复历史的 live pane 仍立即异步返回。
- surface 重建时重置宽度 probe/fallback 状态，并允许 detached/零 AppKit bounds 的 surface 使用 Web Remote grid 推进恢复。
- 在 select 请求到达时记录尺寸和递增序号，让 pending 与已订阅客户端按请求顺序共同参与仲裁。
- snapshot 成功回调保留原请求序号，避免倒序完成覆盖较新的 select 或 resize；选择失败和终端关闭时清理尺寸状态。
- 保留 selection generation 检查和 snapshot/output sequence 去重。

## 验证

- `python3 scripts/test-web-remote-size.py`：7 个生命周期场景通过。测试提取生产方法，使用可控队列与快照桩，覆盖断开、切换、失败、过期回调、最后请求释放、快照完成顺序，以及 pending/subscribed/resize 的优先级。修复前可复现尺寸恢复失败，修复后通过。
- `WebRemoteProtocolTests`：38/38 通过，包含真实归档与 live Ghostty surface 的首帧历史恢复测试。原先仅验证布尔释放条件的测试已由上述生命周期回归替代。
- `git diff --check` 通过。
- 未运行完整 Swift/App 测试或真实多客户端网络端到端测试。
