### PR TITLE
fix(web-remote): improve mobile scrolling and focus

### DIFF
--- a/Glint/Resources/WebRemote/ime-input.mjs
+++ b/Glint/Resources/WebRemote/ime-input.mjs
@@ -13,6 +13,84 @@ export function shouldUseNativeTouchInput(navigatorLike, targetWindow) {
   return targetWindow?.matchMedia?.("(hover: none) and (pointer: coarse)").matches ?? true;
 }
 
+export function installTwoFingerTerminalScrolling(
+  terminal,
+  target,
+  WheelEventLike = WheelEvent
+) {
+  let touchScrollY = null;
+  let touchScrollRemainder = 0;
+
+  const reset = () => {
+    touchScrollY = null;
+    touchScrollRemainder = 0;
+  };
+  const touchCenterY = touches => (touches[0].clientY + touches[1].clientY) / 2;
+  const terminalLineHeight = () => {
+    const row = target.querySelector(".xterm-rows > div");
+    const measured = row?.getBoundingClientRect().height;
+    return measured > 0
+      ? measured
+      : terminal.options.fontSize * terminal.options.lineHeight;
+  };
+  const scrollLines = (lines, clientX, clientY) => {
+    // When xterm owns scrollback, scroll it directly. Synthetic one-line wheel
+    // events only move its viewport once on touch browsers, then stall.
+    if (terminal.buffer.active.baseY > 0
+        && terminal.modes?.mouseTrackingMode === "none") {
+      terminal.scrollLines(lines);
+      return;
+    }
+
+    // Full-screen TUIs may own the mouse. Preserve wheel delivery for those
+    // applications so they can scroll themselves.
+    const screen = target.querySelector(".xterm-screen");
+    if (!screen) return;
+    const direction = Math.sign(lines);
+    for (let index = 0; index < Math.abs(lines); index += 1) {
+      screen.dispatchEvent(new WheelEventLike("wheel", {
+        bubbles: true,
+        cancelable: true,
+        clientX,
+        clientY,
+        deltaMode: WheelEventLike.DOM_DELTA_LINE,
+        deltaY: direction,
+      }));
+    }
+  };
+
+  target.addEventListener("touchstart", event => {
+    if (event.touches.length !== 2) {
+      reset();
+      return;
+    }
+    event.preventDefault();
+    touchScrollY = touchCenterY(event.touches);
+    touchScrollRemainder = 0;
+  }, { passive: false });
+
+  target.addEventListener("touchmove", event => {
+    if (event.touches.length !== 2 || touchScrollY === null) {
+      reset();
+      return;
+    }
+    event.preventDefault();
+    const nextY = touchCenterY(event.touches);
+    touchScrollRemainder += touchScrollY - nextY;
+    touchScrollY = nextY;
+
+    const lineHeight = terminalLineHeight();
+    const lines = Math.trunc(touchScrollRemainder / lineHeight);
+    if (lines === 0) return;
+    const clientX = (event.touches[0].clientX + event.touches[1].clientX) / 2;
+    scrollLines(lines, clientX, nextY);
+    touchScrollRemainder -= lines * lineHeight;
+  }, { passive: false });
+
+  target.addEventListener("touchend", reset);
+  target.addEventListener("touchcancel", reset);
+}
+
 function pastedTextFromInput(baseline, newValue, eventData) {
   if (baseline) {
     const prefix = baseline.value.slice(0, baseline.start);

--- a/Glint/Resources/WebRemote/web-remote-index.html
+++ b/Glint/Resources/WebRemote/web-remote-index.html
@@ -48,6 +48,10 @@
                       aria-label="关闭项目与终端" data-i18n-aria="close_sidebar">×</button>
             </div>
           </div>
+          <label class="remote-option">
+            <input id="auto-focus-terminal" type="checkbox">
+            <span data-i18n="auto_focus_terminal">自动聚焦</span>
+          </label>
           <div id="workspace-list" class="workspace-list"></div>
         </section>
       </aside>

--- a/Glint/Resources/WebRemote/web-remote.css
+++ b/Glint/Resources/WebRemote/web-remote.css
@@ -184,6 +184,16 @@ input:focus {
 
 .project-list-section { min-height: 0; display: flex; flex: 1; flex-direction: column; padding-top: 15px; }
 .list-heading { padding: 0 16px 11px; }
+.remote-option {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin: 0 16px 10px;
+  color: var(--muted);
+  font-size: 10px;
+  cursor: pointer;
+}
+.remote-option input { accent-color: var(--accent); }
 .workspace-list { min-height: 0; flex: 1; overflow: auto; padding: 0 9px 18px; }
 .workspace-group { margin-bottom: 8px; }
 .workspace-pane-list { min-height: 0; }

--- a/Glint/Resources/WebRemote/web-remote.js
+++ b/Glint/Resources/WebRemote/web-remote.js
@@ -1,6 +1,10 @@
 import { Terminal } from "/xterm.mjs";
 import { FitAddon } from "/addon-fit.mjs";
-import { installIOSIMEInputFallback, installIOSNativeTouchInput } from "/ime-input.mjs";
+import {
+  installIOSIMEInputFallback,
+  installIOSNativeTouchInput,
+  installTwoFingerTerminalScrolling,
+} from "/ime-input.mjs";
 import {
   hmacSha256,
   hkdfExtractExpand,
@@ -57,6 +61,7 @@ const translations = {
   zh: {
     access_key: "访问密钥",
     access_key_help: "请在 Glint 设置 → Terminal → Web remote control 中单独复制访问密钥。",
+    auto_focus_terminal: "自动聚焦",
     bad_request: "请求格式错误",
     choose_terminal_heading: "从左侧选择一个终端",
     close_new_project: "关闭新建项目",
@@ -107,6 +112,7 @@ const translations = {
   en: {
     access_key: "Access key",
     access_key_help: "Copy the access key from Glint Settings → Terminal → Web remote control.",
+    auto_focus_terminal: "Open keyboard after switching terminal",
     bad_request: "Invalid request",
     choose_terminal_heading: "Choose a terminal from the sidebar",
     close_new_project: "Close new project",
@@ -179,6 +185,7 @@ const elements = {
   authDialog: document.querySelector("#auth-dialog"),
   authError: document.querySelector("#auth-error"),
   authForm: document.querySelector("#auth-form"),
+  autoFocusTerminal: document.querySelector("#auto-focus-terminal"),
   brandFallback: document.querySelector("#brand-fallback"),
   brandIcon: document.querySelector("#brand-icon"),
   createClose: document.querySelector("#create-close"),
@@ -246,83 +253,11 @@ const iosIMEInputFallback = installIOSIMEInputFallback(
   data => sendInputBytes(textEncoder.encode(data))
 );
 installIOSNativeTouchInput(terminal, text => terminal.paste(text));
+installTwoFingerTerminalScrolling(terminal, elements.terminal);
 document.fonts?.load('13px "Glint Nerd Symbols"').then(() => {
   terminal.refresh(0, terminal.rows - 1);
   fitTerminal();
 });
-
-let touchScrollY = null;
-let touchScrollRemainder = 0;
-
-function resetTouchScroll() {
-  touchScrollY = null;
-  touchScrollRemainder = 0;
-}
-
-function touchCenterY(touches) {
-  return (touches[0].clientY + touches[1].clientY) / 2;
-}
-
-function terminalLineHeight() {
-  const row = elements.terminal.querySelector(".xterm-rows > div");
-  const measured = row?.getBoundingClientRect().height;
-  return measured > 0
-    ? measured
-    : terminal.options.fontSize * terminal.options.lineHeight;
-}
-
-function scrollTerminalLinesFromTouch(lines, clientX, clientY) {
-  const screen = elements.terminal.querySelector(".xterm-screen");
-  let handledByTerminal = false;
-  if (screen) {
-    const direction = Math.sign(lines);
-    for (let index = 0; index < Math.abs(lines); index += 1) {
-      const wheelEvent = new WheelEvent("wheel", {
-        bubbles: true,
-        cancelable: true,
-        clientX,
-        clientY,
-        deltaMode: WheelEvent.DOM_DELTA_LINE,
-        deltaY: direction,
-      });
-      if (!screen.dispatchEvent(wheelEvent)) handledByTerminal = true;
-    }
-  }
-  if (!handledByTerminal && terminal.buffer.active.baseY > 0) {
-    terminal.scrollLines(lines);
-  }
-}
-
-elements.terminal.addEventListener("touchstart", event => {
-  if (event.touches.length !== 2) {
-    resetTouchScroll();
-    return;
-  }
-  event.preventDefault();
-  touchScrollY = touchCenterY(event.touches);
-  touchScrollRemainder = 0;
-}, { passive: false });
-
-elements.terminal.addEventListener("touchmove", event => {
-  if (event.touches.length !== 2 || touchScrollY === null) {
-    resetTouchScroll();
-    return;
-  }
-  event.preventDefault();
-  const nextY = touchCenterY(event.touches);
-  touchScrollRemainder += touchScrollY - nextY;
-  touchScrollY = nextY;
-
-  const lineHeight = terminalLineHeight();
-  const lines = Math.trunc(touchScrollRemainder / lineHeight);
-  if (lines === 0) return;
-  const clientX = (event.touches[0].clientX + event.touches[1].clientX) / 2;
-  scrollTerminalLinesFromTouch(lines, clientX, nextY);
-  touchScrollRemainder -= lines * lineHeight;
-}, { passive: false });
-
-elements.terminal.addEventListener("touchend", resetTouchScroll);
-elements.terminal.addEventListener("touchcancel", resetTouchScroll);
 
 let socket;
 let reconnectTimer;
@@ -356,6 +291,12 @@ let appliedThemeSignature = "";
 const mobileSidebarLayout = matchMedia(
   "(max-width: 760px), (max-width: 900px) and (max-height: 520px) and (orientation: landscape)"
 );
+const autoFocusStorageKey = "glint-auto-focus-terminal";
+const storedAutoFocus = localStorage.getItem(autoFocusStorageKey);
+let autoFocusTerminal = storedAutoFocus === null
+  ? !matchMedia("(hover: none) and (pointer: coarse)").matches
+  : storedAutoFocus === "true";
+elements.autoFocusTerminal.checked = autoFocusTerminal;
 
 function loadToken() {
   const fragment = new URLSearchParams(location.hash.slice(1));
@@ -546,7 +487,7 @@ function handleMessage(raw) {
       terminal.write(decodeBase64(message.data), () => {
         controllingPane = message.pane;
         fitTerminal();
-        terminal.focus();
+        if (autoFocusTerminal) terminal.focus();
       });
       elements.emptyState.classList.add("hidden");
       elements.terminal.classList.add("visible");
@@ -887,6 +828,10 @@ elements.authForm.addEventListener("submit", event => {
 
 elements.reconnect.addEventListener("click", connect);
 elements.refresh.addEventListener("click", () => send({ type: "list" }));
+elements.autoFocusTerminal.addEventListener("change", () => {
+  autoFocusTerminal = elements.autoFocusTerminal.checked;
+  localStorage.setItem(autoFocusStorageKey, String(autoFocusTerminal));
+});
 elements.sidebarToggle.addEventListener("click", () => setSidebarOpen(true));
 elements.sidebarClose.addEventListener("click", () => setSidebarOpen(false));
 elements.sidebarBackdrop.addEventListener("click", () => setSidebarOpen(false));

--- a/GlintTests/WebRemoteProtocolTests.swift
+++ b/GlintTests/WebRemoteProtocolTests.swift
@@ -322,17 +322,39 @@ final class WebRemoteProtocolTests: XCTestCase {
         let styleURL = try XCTUnwrap(
             Bundle.main.url(forResource: "web-remote", withExtension: "css")
         )
+        let inputURL = try XCTUnwrap(
+            Bundle.main.url(forResource: "ime-input", withExtension: "mjs")
+        )
         let script = try String(contentsOf: scriptURL, encoding: .utf8)
         let style = try String(contentsOf: styleURL, encoding: .utf8)
+        let input = try String(contentsOf: inputURL, encoding: .utf8)
 
-        XCTAssertTrue(script.contains("\"touchstart\""))
-        XCTAssertTrue(script.contains("\"touchmove\""))
-        XCTAssertTrue(script.contains("terminal.scrollLines"))
-        XCTAssertTrue(script.contains("terminal.buffer.active.baseY > 0"))
-        XCTAssertTrue(script.contains("new WheelEvent(\"wheel\""))
-        XCTAssertTrue(script.contains(".xterm-screen"))
-        XCTAssertTrue(script.contains("passive: false"))
+        XCTAssertTrue(script.contains("installTwoFingerTerminalScrolling"))
+        XCTAssertTrue(input.contains("\"touchstart\""))
+        XCTAssertTrue(input.contains("\"touchmove\""))
+        XCTAssertTrue(input.contains("terminal.scrollLines"))
+        XCTAssertTrue(input.contains("terminal.buffer.active.baseY > 0"))
+        XCTAssertTrue(input.contains("terminal.modes?.mouseTrackingMode === \"none\""))
+        XCTAssertTrue(input.contains("new WheelEventLike(\"wheel\""))
+        XCTAssertTrue(input.contains(".xterm-screen"))
+        XCTAssertTrue(input.contains("passive: false"))
         XCTAssertTrue(style.contains("touch-action: none"))
+    }
+
+    func testBundledClientCanDisableTerminalAutoFocus() throws {
+        let scriptURL = try XCTUnwrap(
+            Bundle.main.url(forResource: "web-remote", withExtension: "js")
+        )
+        let htmlURL = try XCTUnwrap(
+            Bundle.main.url(forResource: "web-remote-index", withExtension: "html")
+        )
+        let script = try String(contentsOf: scriptURL, encoding: .utf8)
+        let html = try String(contentsOf: htmlURL, encoding: .utf8)
+
+        XCTAssertTrue(html.contains("id=\"auto-focus-terminal\""))
+        XCTAssertTrue(script.contains("glint-auto-focus-terminal"))
+        XCTAssertTrue(script.contains("(hover: none) and (pointer: coarse)"))
+        XCTAssertTrue(script.contains("if (autoFocusTerminal) terminal.focus()"))
     }
 
     func testBundledClientRecoversStaleWebSocketConnections() throws {

--- a/scripts/test-web-remote-ime.mjs
+++ b/scripts/test-web-remote-ime.mjs
@@ -5,10 +5,80 @@ import {
   IOSIMEInputFallback,
   installIOSNativeTouchInput,
   installIOSIMEInputFallback,
+  installTwoFingerTerminalScrolling,
   isIOSInputEnvironment,
   shouldUseNativeTouchInput,
   textareaDelta,
 } from "../Glint/Resources/WebRemote/ime-input.mjs";
+
+function makeTouchScrollHarness(baseY, mouseTrackingMode = "none") {
+  const listeners = new Map();
+  const wheelEvents = [];
+  const scrollCalls = [];
+  const row = { getBoundingClientRect: () => ({ height: 10 }) };
+  const screen = { dispatchEvent: event => wheelEvents.push(event) };
+  const target = {
+    addEventListener(type, listener) { listeners.set(type, listener); },
+    querySelector(selector) {
+      if (selector === ".xterm-screen") return screen;
+      if (selector === ".xterm-rows > div") return row;
+      return null;
+    },
+  };
+  const terminal = {
+    buffer: { active: { baseY } },
+    modes: { mouseTrackingMode },
+    options: { fontSize: 13, lineHeight: 1 },
+    scrollLines(lines) { scrollCalls.push(lines); },
+  };
+  class MockWheelEvent {
+    static DOM_DELTA_LINE = 1;
+    constructor(type, options) {
+      this.type = type;
+      Object.assign(this, options);
+    }
+  }
+  installTwoFingerTerminalScrolling(terminal, target, MockWheelEvent);
+  const dispatchTouch = (type, centerY) => listeners.get(type)({
+    touches: centerY === null ? [] : [
+      { clientX: 100, clientY: centerY },
+      { clientX: 140, clientY: centerY },
+    ],
+    preventDefault() {},
+  });
+  return { dispatchTouch, scrollCalls, wheelEvents };
+}
+
+test("keeps scrolling terminal history across consecutive two-finger moves", () => {
+  const harness = makeTouchScrollHarness(40);
+  harness.dispatchTouch("touchstart", 100);
+  harness.dispatchTouch("touchmove", 110);
+  harness.dispatchTouch("touchmove", 120);
+  harness.dispatchTouch("touchmove", 130);
+
+  assert.deepEqual(harness.scrollCalls, [-1, -1, -1]);
+  assert.deepEqual(harness.wheelEvents, []);
+});
+
+test("forwards two-finger scrolling to full-screen applications without terminal history", () => {
+  const harness = makeTouchScrollHarness(0, "vt200");
+  harness.dispatchTouch("touchstart", 100);
+  harness.dispatchTouch("touchmove", 120);
+
+  assert.deepEqual(harness.scrollCalls, []);
+  assert.equal(harness.wheelEvents.length, 2);
+  assert.equal(harness.wheelEvents[0].deltaY, -1);
+  assert.equal(harness.wheelEvents[0].deltaMode, 1);
+});
+
+test("keeps forwarding wheel events when an application captures the mouse", () => {
+  const harness = makeTouchScrollHarness(40, "vt200");
+  harness.dispatchTouch("touchstart", 100);
+  harness.dispatchTouch("touchmove", 110);
+
+  assert.deepEqual(harness.scrollCalls, []);
+  assert.equal(harness.wheelEvents.length, 1);
+});
 
 function makeTerminal() {
   const listeners = new Map();


### PR DESCRIPTION
## Summary

- keep consecutive two-finger gestures scrolling xterm history instead of stalling after the first line
- preserve wheel-event delivery when a terminal application owns mouse input
- add a persisted auto-focus toggle; touch devices default to not reopening the software keyboard after pane switches
- use the concise Chinese label `自动聚焦`

## Root cause

The mobile gesture adapter always converted line deltas into synthetic wheel events first. When xterm owned normal scrollback, the touch browser consumed only the first synthetic one-line step and subsequent movement stopped advancing the viewport. Pane snapshots also focused xterm unconditionally, which reopened the mobile keyboard and reduced the visible terminal area.

## Validation

- `node --check Glint/Resources/WebRemote/web-remote.js`
- `node --check Glint/Resources/WebRemote/ime-input.mjs`
- `node --test scripts/test-web-remote-ime.mjs` — 19 passed
- `WebRemoteProtocolTests` passed on macOS
- real two-touch browser replay advanced the viewport on every consecutive move
- `git diff --check`

## Scope

This keeps terminal-native behavior and does not add Codex/Claude-specific shortcuts or `Ctrl+T` handling.