### PR TITLE
feat: Grok quota row in the sidebar usage panel / 侧栏用量面板新增 Grok 额度行

### DIFF
--- a/Glint.xcodeproj/project.pbxproj
+++ b/Glint.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		47BB527385B84454ABF8FC40 /* themes.json in Resources */ = {isa = PBXBuildFile; fileRef = 6860F8F626EFDB9A289FC727 /* themes.json */; };
 		4971664CE7FBF0629C8DD709 /* ReleaseNotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 407B3A9D15F4B9E613DA1CF8 /* ReleaseNotes.swift */; };
 		49DF8EE59313B7CFE29DA303 /* PaneTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E646AABA8ADCE8A2A5C6F55 /* PaneTreeView.swift */; };
+		4E46C7DC654185D9E8A07CDF /* GrokUsageReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCEE44600B0EBF18542EA3E7 /* GrokUsageReaderTests.swift */; };
 		4EC47B8DA99A679D88935CB8 /* PerformanceRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B43EEEA275BAC1522032064C /* PerformanceRegressionTests.swift */; };
 		4ED4428EEC2AFB777092FAEF /* ShellRcBlockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3B91F000C01FEA1C7E61F5A /* ShellRcBlockTests.swift */; };
 		5157C5439862F21202BCC44D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E67CF5D8552AE1F51386161 /* AppDelegate.swift */; };
@@ -206,6 +207,7 @@
 		D36068DE0F0DDDECA779C743 /* AgentElapsedTimerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentElapsedTimerTests.swift; sourceTree = "<group>"; };
 		D7F8C1899F93B387843907FF /* ReviewScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewScopeTests.swift; sourceTree = "<group>"; };
 		DB20921E3CAC1006A8FBD3AE /* SettingsSafety.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSafety.swift; sourceTree = "<group>"; };
+		DCEE44600B0EBF18542EA3E7 /* GrokUsageReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrokUsageReaderTests.swift; sourceTree = "<group>"; };
 		DEEB37F39E654EF9574D8098 /* WebRemoteProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRemoteProtocolTests.swift; sourceTree = "<group>"; };
 		E298AD81B1615CBBFD69F48A /* GhosttySurfaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttySurfaceView.swift; sourceTree = "<group>"; };
 		E94AB23640CA1E6007F8B2B4 /* GlintTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GlintTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -309,6 +311,7 @@
 				65BE76E8E627A5347D565968 /* GitRefreshCoordinatorTests.swift */,
 				49C888E59D1091BFC22A9EA4 /* GitRepositoryWatcherTests.swift */,
 				5BDAAD70DC4C2FC80F6DEA51 /* GrokHookInstallerTests.swift */,
+				DCEE44600B0EBF18542EA3E7 /* GrokUsageReaderTests.swift */,
 				349714D49AE52D84995314FD /* MascotAssetTests.swift */,
 				FDE16D678B1BC67A99EBA74F /* OmpHookInstallerTests.swift */,
 				EBCC04C19D745AA867D961FD /* PaneAgentKindTests.swift */,
@@ -608,6 +611,7 @@
 				2D9012046800A06555DEA381 /* GitRefreshCoordinatorTests.swift in Sources */,
 				0FB9792E290FC2A8B527B2D0 /* GitRepositoryWatcherTests.swift in Sources */,
 				57D99FDEAF8596DCDBC55ABE /* GrokHookInstallerTests.swift in Sources */,
+				4E46C7DC654185D9E8A07CDF /* GrokUsageReaderTests.swift in Sources */,
 				04E75EAD5165E8D96C1C5517 /* MascotAssetTests.swift in Sources */,
 				DFDF7E690BD53E885484EA00 /* OmpHookInstallerTests.swift in Sources */,
 				ED46CD7A6E09551A775AD3B8 /* PaneAgentKindTests.swift in Sources */,

--- a/Glint/Agent/UsageStore.swift
+++ b/Glint/Agent/UsageStore.swift
@@ -19,6 +19,11 @@ struct AgentQuota: Hashable, Codable {
     /// Source-reported window sizes. nil keeps legacy 5h / 7d labels.
     var primaryWindowMinutes: Int? = nil
     var secondaryWindowMinutes: Int? = nil
+    /// True when the source confirms the window but not its usage numbers
+    /// (Grok team/unified billing: xAI's endpoint reports cap 0). The row
+    /// still renders — period countdown and all — with "—" in place of a
+    /// fabricated percent. nil/absent decodes as "known" for old snapshots.
+    var percentUnknown: Bool? = nil
 
     var primaryWindowLabel: String {
         Self.windowLabel(minutes: primaryWindowMinutes, fallback: "5h")
@@ -53,7 +58,8 @@ struct AgentQuota: Hashable, Codable {
             weeklyResetsAt: finite(weeklyResetsAt),
             planType: planType,
             primaryWindowMinutes: primaryWindowMinutes,
-            secondaryWindowMinutes: secondaryWindowMinutes
+            secondaryWindowMinutes: secondaryWindowMinutes,
+            percentUnknown: percentUnknown
         )
     }
 
@@ -600,9 +606,11 @@ enum CodexLiveReader {
 /// Account-surface caveat — the same conclusion CodexBar's Grok provider
 /// shipped (steipete/CodexBar): team / unified-billing accounts report
 /// `onDemandCap: {val: 0}`; the surface exposes the billing period but not
-/// usage numbers for them. Those reads decode to nil on purpose rather than
-/// drawing a fake 0% bar. Personal / credits accounts (cap > 0) get real
-/// numbers; if xAI ever exposes team usage here, it starts working unchanged.
+/// usage numbers for them. Those reads still produce a quota (window + reset
+/// countdown) with `percentUnknown` set, so the sidebar shows a "—" track
+/// instead of a fabricated 0% bar. Personal / credits accounts (cap > 0, or
+/// a source-reported `creditUsagePercent`) get real numbers; if xAI ever
+/// exposes team usage here, it starts working unchanged.
 enum GrokUsageReader {
     private static let endpoint = URL(string: "https://cli-chat-proxy.grok.com/v1/billing?format=credits")!
 
@@ -626,6 +634,8 @@ enum GrokUsageReader {
         let currentPeriod: Period?
         let onDemandCap: Amount?
         let onDemandUsed: Amount?
+        /// Reported by prepaid/credits surfaces; absent for team accounts.
+        let creditUsagePercent: Double?
     }
 
     private struct Payload: Decodable { let config: Config? }
@@ -660,16 +670,46 @@ enum GrokUsageReader {
     /// Maps a billing config onto the sidebar's quota model. The billing
     /// surface has ONE window (the weekly usage period), so it lands in the
     /// primary slot; `weeklyPercent` stays nil to avoid drawing the same
-    /// numbers twice. A zero cap means the account type doesn't expose usage
-    /// here (team / unified billing) → nil, not a fake 0%.
+    /// numbers twice.
+    ///
+    /// A zero cap means the account type doesn't expose usage numbers here
+    /// (team / unified billing — CodexBar shipped the same conclusion). The
+    /// row still renders: the period and its reset countdown are real, and
+    /// the percent degrades to "—" (`percentUnknown`) instead of drawing a
+    /// fabricated 0% bar. A source-reported `creditUsagePercent` wins over
+    /// the derived math when present.
     private static func quota(from config: Config) -> AgentQuota? {
-        let cap = config.onDemandCap?.val ?? 0
-        let used = config.onDemandUsed?.val ?? 0
-        guard cap > 0, used.isFinite else { return nil }
-        let percent = max(0, min(used / cap * 100, 100))
         let start = config.currentPeriod?.start.flatMap(Self.parseDate)
         let end = config.currentPeriod?.end.flatMap(Self.parseDate)
         let minutes = Self.windowMinutes(start: start, end: end)
+
+        if let reported = config.creditUsagePercent, reported.isFinite {
+            return AgentQuota(
+                sessionPercent: max(0, min(reported, 100)),
+                weeklyPercent: nil,
+                sessionResetsAt: end,
+                weeklyResetsAt: nil,
+                planType: nil,
+                primaryWindowMinutes: minutes,
+                secondaryWindowMinutes: nil
+            )
+        }
+
+        let cap = config.onDemandCap?.val ?? 0
+        let used = config.onDemandUsed?.val ?? 0
+        guard cap > 0, used.isFinite else {
+            return AgentQuota(
+                sessionPercent: 0,
+                weeklyPercent: nil,
+                sessionResetsAt: end,
+                weeklyResetsAt: nil,
+                planType: nil,
+                primaryWindowMinutes: minutes,
+                secondaryWindowMinutes: nil,
+                percentUnknown: true
+            )
+        }
+        let percent = max(0, min(used / cap * 100, 100))
         return AgentQuota(
             sessionPercent: percent,
             weeklyPercent: nil,

--- a/Glint/Agent/UsageStore.swift
+++ b/Glint/Agent/UsageStore.swift
@@ -125,6 +125,12 @@ struct CodexRefreshCoordinator {
 ///     them out-of-process is the OAuth usage endpoint using the token in the
 ///     login keychain. That path is best-effort (see `ClaudeUsageReader`); any
 ///     failure leaves `claude == nil` so the row simply doesn't render.
+///   • Grok exposes usage on the same billing endpoint its CLI polls,
+///     authorized by the plain-file token `grok login` keeps in
+///     `~/.grok/auth.json` — no keychain, so it can never prompt
+///     (`GrokUsageReader`). Team / unified-billing accounts don't get numbers
+///     on that surface (cap reports 0); those reads stay nil instead of
+///     drawing a fake 0% bar.
 ///
 /// Each agent has its own switch. With both off, polling stops entirely and
 /// nothing is read from disk or network. With one off, only that agent's
@@ -136,6 +142,7 @@ struct CodexRefreshCoordinator {
 final class UsageStore: ObservableObject {
     @Published private(set) var claude: AgentQuota?
     @Published private(set) var codex: AgentQuota?
+    @Published private(set) var grok: AgentQuota?
     @Published private(set) var codexHomeStatuses: [CodexHomeStatus] = []
 
     var codexSidebarQuotas: [CodexSidebarQuota] {
@@ -171,24 +178,36 @@ final class UsageStore: ObservableObject {
             if codexEnabled { refreshNow() }
         }
     }
+    @Published var grokEnabled: Bool {
+        didSet {
+            guard grokEnabled != oldValue else { return }
+            UserDefaults.standard.set(grokEnabled, forKey: Self.grokKey)
+            if !grokEnabled { grok = nil; Self.saveQuota(nil, agent: .grok) }
+            syncTimer()
+            if grokEnabled { refreshNow() }
+        }
+    }
 
     private static let claudeKey = "glint.showClaudeUsage"
     private static let codexKey = "glint.showCodexUsage"
+    private static let grokKey = "glint.showGrokUsage"
     private var timer: Timer?
     private var codexRefreshCoordinator = CodexRefreshCoordinator()
     /// Refresh cadence. Rate-limit windows move on the order of minutes, so a
     /// minute of staleness is invisible and keeps disk/network churn trivial.
     private let interval: TimeInterval = 60
 
-    private var anyEnabled: Bool { claudeEnabled || codexEnabled }
+    private var anyEnabled: Bool { claudeEnabled || codexEnabled || grokEnabled }
 
     init() {
         self.claudeEnabled = (UserDefaults.standard.object(forKey: Self.claudeKey) as? Bool) ?? false
         self.codexEnabled = (UserDefaults.standard.object(forKey: Self.codexKey) as? Bool) ?? false
+        self.grokEnabled = (UserDefaults.standard.object(forKey: Self.grokKey) as? Bool) ?? false
         // Show the last-known numbers immediately so the bars don't pop in blank
         // on launch; the first poll refreshes them a moment later.
         if claudeEnabled { self.claude = Self.loadQuota(.claude) }
         if codexEnabled { self.codex = Self.loadQuota(.codex) }
+        if grokEnabled { self.grok = Self.loadQuota(.grok) }
         syncTimer()
     }
 
@@ -263,6 +282,14 @@ final class UsageStore: ObservableObject {
                 }
             }
         }
+        if grokEnabled {
+            Task { [weak self] in
+                let quota = await GrokUsageReader.read()
+                await MainActor.run {
+                    self?.apply(quota, to: .grok)
+                }
+            }
+        }
     }
 
     private func applyCodex(_ statuses: [CodexHomeStatus]) {
@@ -310,12 +337,16 @@ final class UsageStore: ObservableObject {
             guard codexEnabled, let quota else { return }
             codex = quota
             Self.saveQuota(quota, agent: agent)
+        case .grok:
+            guard grokEnabled, let quota else { return }
+            grok = quota
+            Self.saveQuota(quota, agent: agent)
         }
     }
 
     // MARK: Snapshot persistence (non-sensitive — UserDefaults is fine)
 
-    private enum Agent: String { case claude, codex }
+    private enum Agent: String { case claude, codex, grok }
 
     private static func snapshotKey(_ agent: Agent) -> String {
         "glint.usage.snapshot.\(agent.rawValue)"
@@ -552,6 +583,127 @@ enum CodexLiveReader {
             primaryWindowMinutes: primary.limit_window_seconds.map { $0 / 60 },
             secondaryWindowMinutes: secondary?.limit_window_seconds.map { $0 / 60 }
         )
+    }
+}
+
+// MARK: - Grok (billing endpoint via the CLI's auth token)
+
+/// Reads Grok's usage from the same billing endpoint the Grok CLI's own
+/// billing extension polls (`cli-chat-proxy.grok.com/v1/billing`), authorizing
+/// with the access token `grok login` stores in `~/.grok/auth.json` — a plain
+/// file, so this path can never trigger a macOS prompt (unlike Claude's
+/// keychain). The token is owned and rotated by the Grok CLI; we only read it.
+///
+/// Fails closed like the other readers: a missing token, network error, or
+/// unexpected shape yields nil and the sidebar row simply doesn't render.
+///
+/// Account-surface caveat — the same conclusion CodexBar's Grok provider
+/// shipped (steipete/CodexBar): team / unified-billing accounts report
+/// `onDemandCap: {val: 0}`; the surface exposes the billing period but not
+/// usage numbers for them. Those reads decode to nil on purpose rather than
+/// drawing a fake 0% bar. Personal / credits accounts (cap > 0) get real
+/// numbers; if xAI ever exposes team usage here, it starts working unchanged.
+enum GrokUsageReader {
+    private static let endpoint = URL(string: "https://cli-chat-proxy.grok.com/v1/billing?format=credits")!
+
+    /// The observed weekly window, used as the bar's kind label when the
+    /// period dates can't be parsed ("7d", same rendering as Claude's weekly).
+    private static let fallbackWindowMinutes = 10_080
+
+    /// `~/.grok/auth.json` maps issuer URLs to credential objects; `key`
+    /// holds the OIDC access token the CLI refreshes on its own schedule.
+    private struct Auth: Decodable { let key: String? }
+
+    /// Proto-JSON money wrapper: `{"val": <number>}`.
+    private struct Amount: Decodable { let val: Double? }
+
+    private struct Period: Decodable {
+        let start: String?
+        let end: String?
+    }
+
+    private struct Config: Decodable {
+        let currentPeriod: Period?
+        let onDemandCap: Amount?
+        let onDemandUsed: Amount?
+    }
+
+    private struct Payload: Decodable { let config: Config? }
+
+    static func read(grokHome: URL = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".grok", isDirectory: true)) async -> AgentQuota? {
+        guard let token = loadToken(from: grokHome) else { return nil }
+        var req = URLRequest(url: endpoint)
+        req.httpMethod = "GET"
+        req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        req.setValue("grok-cli", forHTTPHeaderField: "User-Agent")
+        req.timeoutInterval = 10
+        guard let (data, resp) = try? await URLSession.shared.data(for: req),
+              let http = resp as? HTTPURLResponse, http.statusCode == 200 else { return nil }
+        return decode(data)
+    }
+
+    /// First non-empty access token in the auth map (single-login reality —
+    /// the file has exactly one issuer entry in practice).
+    static func loadToken(from grokHome: URL) -> String? {
+        let path = grokHome.appendingPathComponent("auth.json")
+        guard let data = try? Data(contentsOf: path),
+              let map = try? JSONDecoder().decode([String: Auth].self, from: data) else { return nil }
+        return map.values.compactMap(\.key).first { !$0.isEmpty }
+    }
+
+    static func decode(_ data: Data) -> AgentQuota? {
+        guard let config = (try? JSONDecoder().decode(Payload.self, from: data))?.config else { return nil }
+        return quota(from: config)
+    }
+
+    /// Maps a billing config onto the sidebar's quota model. The billing
+    /// surface has ONE window (the weekly usage period), so it lands in the
+    /// primary slot; `weeklyPercent` stays nil to avoid drawing the same
+    /// numbers twice. A zero cap means the account type doesn't expose usage
+    /// here (team / unified billing) → nil, not a fake 0%.
+    private static func quota(from config: Config) -> AgentQuota? {
+        let cap = config.onDemandCap?.val ?? 0
+        let used = config.onDemandUsed?.val ?? 0
+        guard cap > 0, used.isFinite else { return nil }
+        let percent = max(0, min(used / cap * 100, 100))
+        let start = config.currentPeriod?.start.flatMap(Self.parseDate)
+        let end = config.currentPeriod?.end.flatMap(Self.parseDate)
+        let minutes = Self.windowMinutes(start: start, end: end)
+        return AgentQuota(
+            sessionPercent: percent,
+            weeklyPercent: nil,
+            sessionResetsAt: end,
+            weeklyResetsAt: nil,
+            planType: nil,
+            primaryWindowMinutes: minutes,
+            secondaryWindowMinutes: nil
+        )
+    }
+
+    /// ISO8601 with microseconds and offset, e.g.
+    /// `2026-09-02T07:39:39.262344+00:00` (fractional optional in practice).
+    private static func parseDate(_ raw: String) -> Date? {
+        if let d = Self.fractionalFormatter.date(from: raw) { return d }
+        return Self.plainFormatter.date(from: raw)
+    }
+    private static let fractionalFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+    private static let plainFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    private static func windowMinutes(start: Date?, end: Date?) -> Int? {
+        if let start, let end, end > start {
+            let minutes = Int((end.timeIntervalSince(start) / 60).rounded())
+            if minutes > 0 { return minutes }
+        }
+        return fallbackWindowMinutes
     }
 }
 

--- a/Glint/Chrome/SettingsView.swift
+++ b/Glint/Chrome/SettingsView.swift
@@ -1721,7 +1721,7 @@ private struct AgentsPane: View {
             }
             SettingsDivider()
             SettingsRow("Show usage in sidebar",
-                        subtitle: "Display Grok's weekly usage credits in the sidebar. Reads the token `grok login` keeps in ~/.grok — team plans report no numbers on this surface, so the row stays hidden there.") {
+                        subtitle: "Display Grok's weekly usage credits in the sidebar. Reads the token `grok login` keeps in ~/.grok. Team plans get no numbers from xAI's billing surface — the row then shows the window's reset countdown with a “—” in place of a percent.") {
                 Toggle("", isOn: $usage.grokEnabled)
                     .toggleStyle(.switch).labelsHidden()
             }

--- a/Glint/Chrome/SettingsView.swift
+++ b/Glint/Chrome/SettingsView.swift
@@ -1720,6 +1720,12 @@ private struct AgentsPane: View {
                 }
             }
             SettingsDivider()
+            SettingsRow("Show usage in sidebar",
+                        subtitle: "Display Grok's weekly usage credits in the sidebar. Reads the token `grok login` keeps in ~/.grok — team plans report no numbers on this surface, so the row stays hidden there.") {
+                Toggle("", isOn: $usage.grokEnabled)
+                    .toggleStyle(.switch).labelsHidden()
+            }
+            SettingsDivider()
             SettingsRow("Resume session on launch",
                         subtitle: "When Glint reopens, each pane that was running Grok at last quit is resumed via `grok --resume <session-id>` — so multiple Grok panes in one workspace land back in their own sessions. Falls back to `grok --continue` for panes whose session id wasn't captured.") {
                 Toggle("", isOn: $store.restoreGrokSession)

--- a/Glint/Chrome/SidebarView.swift
+++ b/Glint/Chrome/SidebarView.swift
@@ -422,7 +422,8 @@ private struct QuotaSection: View {
                     QuotaRow(name: "Grok",
                              iconAsset: MascotAsset.grok(for: nil),
                              quota: grok,
-                             color: Self.grokColor, warn: Self.warnColor)
+                             color: Self.grokColor, warn: Self.warnColor,
+                             rowHelp: "Signed in via `grok login`, but team plans don't expose usage numbers on xAI's billing surface — showing the weekly window's reset only.")
                 }
                 ForEach(codexHomes) { item in
                     QuotaRow(name: item.name,
@@ -452,6 +453,16 @@ private struct QuotaRow: View {
     let quota: AgentQuota
     let color: Color
     let warn: Color
+    /// Optional row-level tooltip elaborating on the icon's name-only one
+    /// (e.g. Grok's "team plans don't expose numbers" explanation).
+    var rowHelp: String? = nil
+
+    /// The Grok row renders an unknown-percent track when xAI's billing
+    /// surface reports no numbers (team/unified accounts) — pass nil so the
+    /// column degrades to "—" instead of drawing a fabricated 0%.
+    private var primaryPercent: Double? {
+        quota.percentUnknown == true ? nil : quota.sessionPercent
+    }
 
     var body: some View {
         HStack(spacing: 12) {
@@ -469,7 +480,7 @@ private struct QuotaRow: View {
                 HStack(spacing: 8) {
                     QuotaColumn(
                         kind: quota.primaryWindowLabel,
-                        percent: quota.sessionPercent,
+                        percent: primaryPercent,
                         resetsAt: quota.sessionResetsAt,
                         now: ctx.date,
                         fill: color,
@@ -488,6 +499,7 @@ private struct QuotaRow: View {
                 }
             }
         }
+        .help(rowHelp ?? name)
     }
 }
 
@@ -526,6 +538,12 @@ private struct QuotaColumn: View {
                     }
                 } else {
                     Text("—").foregroundStyle(Theme.text4)
+                    // Unknown percent (Grok team accounts) still counts the
+                    // window down — the period is real even when usage isn't.
+                    if let reset = resetText {
+                        Text(reset)
+                            .foregroundStyle(Theme.text4)
+                    }
                 }
             }
             .font(.system(size: 9.5, design: .monospaced))

--- a/Glint/Chrome/SidebarView.swift
+++ b/Glint/Chrome/SidebarView.swift
@@ -98,7 +98,9 @@ struct SidebarView: View {
                 .scrollContentBackground(.hidden)
 
                 VStack(spacing: 0) {
-                    QuotaSection(claude: usage.claude, codexHomes: usage.codexSidebarQuotas)
+                    QuotaSection(claude: usage.claude,
+                                 grok: usage.grok,
+                                 codexHomes: usage.codexSidebarQuotas)
                     newWorkspaceCard
                         .padding(.horizontal, 10)
                         .padding(.top, 10)
@@ -392,15 +394,20 @@ struct SidebarView: View {
 private struct QuotaSection: View {
     @EnvironmentObject var store: WorkspaceStore
     let claude: AgentQuota?
+    let grok: AgentQuota?
     let codexHomes: [CodexSidebarQuota]
 
     /// Brand fills, matching the sidebar mascot shadows.
     private static let claudeColor = Color(red: 235/255, green: 140/255, blue: 82/255)
     private static let codexColor = Color(red: 82/255, green: 97/255, blue: 255/255)
+    /// xAI keeps Grok monochrome, so pick a violet that reads as "Grok" next
+    /// to the warm Claude orange and cool Codex blue without impersonating
+    /// either.
+    private static let grokColor = Color(red: 157/255, green: 134/255, blue: 255/255)
     private static let warnColor = Color(red: 1.0, green: 0.745, blue: 0.18) // #FFBE2E
 
     var body: some View {
-        if claude == nil && codexHomes.isEmpty {
+        if claude == nil && grok == nil && codexHomes.isEmpty {
             EmptyView()
         } else {
             VStack(spacing: 10) {
@@ -410,6 +417,12 @@ private struct QuotaSection: View {
                                                            isSpark: store.claudeIconStyle == .spark),
                              quota: claude,
                              color: Self.claudeColor, warn: Self.warnColor)
+                }
+                if let grok {
+                    QuotaRow(name: "Grok",
+                             iconAsset: MascotAsset.grok(for: nil),
+                             quota: grok,
+                             color: Self.grokColor, warn: Self.warnColor)
                 }
                 ForEach(codexHomes) { item in
                     QuotaRow(name: item.name,

--- a/Glint/Resources/Localizable.xcstrings
+++ b/Glint/Resources/Localizable.xcstrings
@@ -212,6 +212,39 @@
         }
       }
     },
+    "Access URL": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "访问地址"
+          }
+        }
+      }
+    },
+    "Access key": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "访问密钥"
+          }
+        }
+      }
+    },
+    "Access key and ports reset": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "访问密钥和端口已重置"
+          }
+        }
+      }
+    },
     "Add": {
       "extractionState": "manual",
       "localizations": {
@@ -311,6 +344,17 @@
         }
       }
     },
+    "All interfaces (less secure)": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部网卡（较不安全）"
+          }
+        }
+      }
+    },
     "Allow": {
       "extractionState": "manual",
       "localizations": {
@@ -333,39 +377,6 @@
         }
       }
     },
-    "Allow external control": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "允许外部控制"
-          }
-        }
-      }
-    },
-    "Access key": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "访问密钥"
-          }
-        }
-      }
-    },
-    "Access URL": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "访问地址"
-          }
-        }
-      }
-    },
     "Allow browser control": {
       "extractionState": "manual",
       "localizations": {
@@ -377,222 +388,13 @@
         }
       }
     },
-    "Copy key": {
+    "Allow external control": {
       "extractionState": "manual",
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "复制密钥"
-          }
-        }
-      }
-    },
-    "Copy link": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "复制链接"
-          }
-        }
-      }
-    },
-    "Could not start: %@": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无法启动：%@"
-          }
-        }
-      }
-    },
-    "Access key and ports reset": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "访问密钥和端口已重置"
-          }
-        }
-      }
-    },
-    "New ports: %d (web) and %d (terminal). Copy the new link and key to reconnect.": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "新端口：%d（网页）和 %d（终端）。请复制新链接和密钥重新连接。"
-          }
-        }
-      }
-    },
-    "Port %d is already in use.": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "端口 %d 已被占用。"
-          }
-        }
-      }
-    },
-    "Port %d is already in use. Resetting will generate a new key and ports, disconnect browsers, and invalidate old links.": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "端口 %d 已被占用。重置会生成新密钥和端口、断开浏览器，并使旧链接失效。"
-          }
-        }
-      }
-    },
-    "Port conflict": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "端口冲突"
-          }
-        }
-      }
-    },
-    "Web remote control unavailable": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网页远程控制不可用"
-          }
-        }
-      }
-    },
-    "Web remote port conflict": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网页远程控制端口冲突"
-          }
-        }
-      }
-    },
-    "Controlled from web": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在通过网页控制"
-          }
-        }
-      }
-    },
-    "Layout may be inaccurate while controlled. It will restore automatically after disconnecting.": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "控制期间布局可能不准确，断开后会自动恢复。"
-          }
-        }
-      }
-    },
-    "Off — no network ports are bound.": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已关闭 — 未监听任何网络端口。"
-          }
-        }
-      }
-    },
-    "Ready — copy a session link to another browser.": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已就绪 — 可复制会话链接到其他浏览器。"
-          }
-        }
-      }
-    },
-    "Reset access key and ports?": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "重置访问密钥和端口？"
-          }
-        }
-      }
-    },
-    "Reset key and ports": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "重置密钥和端口"
-          }
-        }
-      }
-    },
-    "Connected browsers will be disconnected. A new key and ports will be generated, so old links will stop working.": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已连接的浏览器将断开。系统会生成新密钥和端口，旧链接将失效。"
-          }
-        }
-      }
-    },
-    "Serves Glint's bundled browser terminal on this Mac for trusted LAN or VPN use. The copied link or access key grants terminal input; traffic is not TLS-encrypted. Off by default.": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "在这台 Mac 上提供 Glint 内置的浏览器终端，供可信的局域网或 VPN 使用。复制的链接或访问密钥可直接输入终端；流量未使用 TLS 加密。默认关闭。"
-          }
-        }
-      }
-    },
-    "Starting the local web server…": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在启动本地网页服务器…"
-          }
-        }
-      }
-    },
-    "Web remote control": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网页远程控制"
+            "value": "允许外部控制"
           }
         }
       }
@@ -1178,6 +980,17 @@
         }
       }
     },
+    "Click a workspace card with the middle mouse button to close it. Same as the context menu's “Close Workspace”.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用鼠标中键点击工作区卡片即可关闭,等同于右键菜单的「关闭工作区」。"
+          }
+        }
+      }
+    },
     "Close (Esc)": {
       "extractionState": "stale",
       "localizations": {
@@ -1451,6 +1264,28 @@
         }
       }
     },
+    "Connected browsers will be disconnected. A new key and ports will be generated, so old links will stop working.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已连接的浏览器将断开。系统会生成新密钥和端口，旧链接将失效。"
+          }
+        }
+      }
+    },
+    "Controlled from web": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在通过网页控制"
+          }
+        }
+      }
+    },
     "Copied in; your original checkout keeps them too.": {
       "extractionState": "manual",
       "localizations": {
@@ -1480,6 +1315,28 @@
           "stringUnit": {
             "state": "translated",
             "value": "拷贝路径"
+          }
+        }
+      }
+    },
+    "Copy key": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制密钥"
+          }
+        }
+      }
+    },
+    "Copy link": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制链接"
           }
         }
       }
@@ -1524,6 +1381,17 @@
           "stringUnit": {
             "state": "translated",
             "value": "无法读取 hooks.json:%@"
+          }
+        }
+      }
+    },
+    "Could not start: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法启动：%@"
           }
         }
       }
@@ -1896,6 +1764,17 @@
           "stringUnit": {
             "state": "translated",
             "value": "在侧边栏显示 Codex 的 5 小时和每周额度。"
+          }
+        }
+      }
+    },
+    "Display Grok's weekly usage credits in the sidebar. Reads the token `grok login` keeps in ~/.grok. Team plans get no numbers from xAI's billing surface — the row then shows the window's reset countdown with a “—” in place of a percent.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在侧栏显示 Grok 的每周用量积分。读取 `grok login` 存在 ~/.grok 的令牌。团队套餐在 xAI 计费接口上没有数字 —— 此时该行显示窗口重置倒计时，百分比位置为“—”。"
           }
         }
       }
@@ -2881,6 +2760,17 @@
         }
       }
     },
+    "Layout may be inaccurate while controlled. It will restore automatically after disconnecting.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "控制期间布局可能不准确，断开后会自动恢复。"
+          }
+        }
+      }
+    },
     "Left in your original checkout; the worktree starts clean at base's HEAD.": {
       "extractionState": "manual",
       "localizations": {
@@ -2910,6 +2800,17 @@
           "stringUnit": {
             "state": "translated",
             "value": "每个面板保留的行数。"
+          }
+        }
+      }
+    },
+    "Listen on": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "监听网卡"
           }
         }
       }
@@ -2979,6 +2880,17 @@
         }
       }
     },
+    "Localhost only": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅本机"
+          }
+        }
+      }
+    },
     "Manually look for a new release right now.": {
       "extractionState": "stale",
       "localizations": {
@@ -3012,17 +2924,6 @@
         }
       }
     },
-    "Minimize": {
-      "extractionState": "stale",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "最小化"
-          }
-        }
-      }
-    },
     "Middle-click closes workspace": {
       "extractionState": "manual",
       "localizations": {
@@ -3034,13 +2935,13 @@
         }
       }
     },
-    "Click a workspace card with the middle mouse button to close it. Same as the context menu's \u201cClose Workspace\u201d.": {
-      "extractionState": "manual",
+    "Minimize": {
+      "extractionState": "stale",
       "localizations": {
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "用鼠标中键点击工作区卡片即可关闭,等同于右键菜单的「关闭工作区」。"
+            "value": "最小化"
           }
         }
       }
@@ -3205,6 +3106,17 @@
           "stringUnit": {
             "state": "translated",
             "value": "新分支"
+          }
+        }
+      }
+    },
+    "New ports: %d (web) and %d (terminal). Copy the new link and key to reconnect.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新端口：%d（网页）和 %d（终端）。请复制新链接和密钥重新连接。"
           }
         }
       }
@@ -3449,6 +3361,17 @@
       },
       "extractionState": "manual"
     },
+    "Off — no network ports are bound.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已关闭 — 未监听任何网络端口。"
+          }
+        }
+      }
+    },
     "Off — no socket bound, no external access.": {
       "extractionState": "manual",
       "localizations": {
@@ -3489,6 +3412,17 @@
           "stringUnit": {
             "state": "translated",
             "value": "仅未聚焦的 shell 提示符会被释放。"
+          }
+        }
+      }
+    },
+    "Only this Mac (127.0.0.1) can connect.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅本机（127.0.0.1）可连接。"
           }
         }
       }
@@ -3852,6 +3786,39 @@
         }
       }
     },
+    "Port %d is already in use.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "端口 %d 已被占用。"
+          }
+        }
+      }
+    },
+    "Port %d is already in use. Resetting will generate a new key and ports, disconnect browsers, and invalidate old links.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "端口 %d 已被占用。重置会生成新密钥和端口、断开浏览器，并使旧链接失效。"
+          }
+        }
+      }
+    },
+    "Port conflict": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "端口冲突"
+          }
+        }
+      }
+    },
     "Preview": {
       "extractionState": "manual",
       "localizations": {
@@ -3951,6 +3918,28 @@
         }
       }
     },
+    "Reachable from any network this Mac joins (least secure).": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本机加入的任何网络均可访问（最不安全）。"
+          }
+        }
+      }
+    },
+    "Ready — copy a session link to another browser.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已就绪 — 可复制会话链接到其他浏览器。"
+          }
+        }
+      }
+    },
     "Receive beta updates": {
       "extractionState": "stale",
       "localizations": {
@@ -3991,6 +3980,17 @@
           "stringUnit": {
             "state": "translated",
             "value": "刷新"
+          }
+        }
+      }
+    },
+    "Refresh interfaces": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刷新网卡列表"
           }
         }
       }
@@ -4123,6 +4123,28 @@
           "stringUnit": {
             "state": "translated",
             "value": "仓库"
+          }
+        }
+      }
+    },
+    "Reset access key and ports?": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置访问密钥和端口？"
+          }
+        }
+      }
+    },
+    "Reset key and ports": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置密钥和端口"
           }
         }
       }
@@ -4380,6 +4402,28 @@
         }
       }
     },
+    "Selected interface is no longer available. Pick another or use All interfaces.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所选网卡已不可用。请另选一个或使用“全部网卡”。"
+          }
+        }
+      }
+    },
+    "Serves Glint's bundled browser terminal on this Mac for trusted LAN or VPN use. The copied link or access key grants terminal input; traffic is not TLS-encrypted. Off by default.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在这台 Mac 上提供 Glint 内置的浏览器终端，供可信的局域网或 VPN 使用。复制的链接或访问密钥可直接输入终端；流量未使用 TLS 加密。默认关闭。"
+          }
+        }
+      }
+    },
     "Sets the highlight color across selection, focus rings, and active states.": {
       "extractionState": "stale",
       "localizations": {
@@ -4605,6 +4649,17 @@
           "stringUnit": {
             "state": "translated",
             "value": "侧栏毛玻璃"
+          }
+        }
+      }
+    },
+    "Signed in via `grok login`, but team plans don't expose usage numbers on xAI's billing surface — showing the weekly window's reset only.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已通过 `grok login` 登录，但团队套餐在 xAI 计费接口上不提供用量数字 —— 仅显示每周窗口的重置倒计时。"
           }
         }
       }
@@ -4847,6 +4902,17 @@
           "stringUnit": {
             "state": "translated",
             "value": "启动时隐藏侧栏。⌘\\ 切换。"
+          }
+        }
+      }
+    },
+    "Starting the local web server…": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在启动本地网页服务器…"
           }
         }
       }
@@ -5401,6 +5467,39 @@
         }
       }
     },
+    "Web remote control": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网页远程控制"
+          }
+        }
+      }
+    },
+    "Web remote control unavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网页远程控制不可用"
+          }
+        }
+      }
+    },
+    "Web remote port conflict": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网页远程控制端口冲突"
+          }
+        }
+      }
+    },
     "What's New": {
       "extractionState": "manual",
       "localizations": {
@@ -5507,6 +5606,17 @@
           "stringUnit": {
             "state": "translated",
             "value": "窗口"
+          }
+        }
+      }
+    },
+    "Without TLS, encryption only blocks passive sniffing. An active attacker on this network can replace the web client and capture the access key or terminal input.": {
+      "extractionState": "manual",
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未使用 TLS 时，加密仅能防止被动嗅探。同一网络中的主动攻击者可以替换网页客户端，窃取访问密钥或终端输入。"
           }
         }
       }
@@ -5841,347 +5951,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "✗ 名称非法"
-          }
-        }
-      }
-    },
-    "Claude Code, Codex, OMP, hook routing": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Claude Code、Codex、OMP、hook 路由"
-          }
-        }
-      },
-      "extractionState": "manual"
-    },
-    "OMP": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OMP"
-          }
-        }
-      },
-      "extractionState": "manual"
-    },
-    "OMP detected — install the extension to show its status.": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已检测到 OMP — 安装扩展以显示其状态。"
-          }
-        }
-      },
-      "extractionState": "manual"
-    },
-    "OMP not detected on this Mac.": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "此 Mac 上未检测到 OMP。"
-          }
-        }
-      },
-      "extractionState": "manual"
-    },
-    "When Glint reopens, each pane that was running OMP at last quit is resumed via `omp -r <session-id>` — so multiple OMP panes in one workspace land back in their own sessions. Falls back to `omp -c` for panes whose session id wasn't captured.": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Glint 重新打开时，上次退出时在跑 OMP 的每个 pane 会通过 `omp -r <session-id>` 恢复会话，多个 OMP pane 各自回到自己的会话。未捕获 session id 时回退为 `omp -c`。"
-          }
-        }
-      },
-      "extractionState": "manual"
-    },
-    "Extension file": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "扩展文件"
-          }
-        }
-      },
-      "extractionState": "manual"
-    },
-    "Extension installed and registered with OMP.": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "扩展已安装并注册到 OMP。"
-          }
-        }
-      },
-      "extractionState": "manual"
-    },
-    "Registered via ~/.omp/agent/settings.json; only reports when Glint's pane environment variables are present.": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "通过 ~/.omp/agent/settings.json 注册；仅在存在 Glint 的 pane 环境变量时上报。"
-          }
-        }
-      },
-      "extractionState": "manual"
-    },
-    "~/.glint/hooks/omp-agent-bridge.ts": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "~/.glint/hooks/omp-agent-bridge.ts"
-          }
-        }
-      },
-      "extractionState": "manual"
-    },
-    "Glint installs a portable TypeScript extension at ~/.glint/hooks/omp-agent-bridge.ts and registers that path in ~/.omp/agent/settings.json so Oh My Pi sessions report status like Claude. Uses a tilde path (not an absolute home path) so the same install works on any Mac.": {
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Glint 会在 ~/.glint/hooks/omp-agent-bridge.ts 安装可移植的 TypeScript 扩展，并在 ~/.omp/agent/settings.json 中注册该路径，使 Oh My Pi 会话像 Claude 一样上报状态。使用波浪线路径（而非绝对 home 路径），同一套安装在任意 Mac 上都能生效。"
-          }
-        }
-      },
-      "extractionState": "manual"
-    },
-    "awaiting reply": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "待回复"
-          }
-        }
-      }
-    },
-    "thinking…": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "思考中…"
-          }
-        }
-      }
-    },
-    "reply": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "待回复"
-          }
-        }
-      }
-    },
-    "Agent is waiting for your reply": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Agent 等待你的回复"
-          }
-        }
-      }
-    },
-    "Claude Code, Codex, OMP, Grok, hook routing": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Claude Code、Codex、OMP、Grok、hook 路由"
-          }
-        }
-      }
-    },
-    "Grok": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Grok"
-          }
-        }
-      }
-    },
-    "Hooks installed into your Grok hooks directory.": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hook 已安装到你的 Grok hooks 目录。"
-          }
-        }
-      }
-    },
-    "Grok detected — install the reporter to show its status.": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已检测到 Grok — 安装 reporter 即可显示其状态。"
-          }
-        }
-      }
-    },
-    "Grok not detected on this Mac.": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "本机未检测到 Grok。"
-          }
-        }
-      }
-    },
-    "When Glint reopens, each pane that was running Grok at last quit is resumed via `grok --resume <session-id>` — so multiple Grok panes in one workspace land back in their own sessions. Falls back to `grok --continue` for panes whose session id wasn't captured.": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Glint 重新打开时，上次退出时正在运行 Grok 的每个窗格会通过 `grok --resume <session-id>` 恢复，因此同一工作区里的多个 Grok 窗格会回到各自会话。未捕获到 session id 的窗格会回退到 `grok --continue`。"
-          }
-        }
-      }
-    },
-    "Dedicated Glint hook file under Grok's global hooks directory; only reports when Glint's pane environment variables are present.": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Grok 全局 hooks 目录下的独立 Glint hook 文件；仅在存在 Glint 窗格环境变量时上报。"
-          }
-        }
-      }
-    },
-    "~/.grok/hooks/glint.json": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "~/.grok/hooks/glint.json"
-          }
-        }
-      }
-    },
-    "Glint writes ~/.grok/hooks/glint.json so Grok Build sessions report thinking, tools, and ask_user_question (awaiting reply). Dedicated file — not Claude's settings — so Grok is attributed as Grok. The reporter ignores Claude-compat dual-fires under Grok (GROK_SESSION_ID present).": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Glint 会写入 ~/.grok/hooks/glint.json，使 Grok Build 会话上报思考、工具调用，以及 ask_user_question（待回复）。使用独立文件（而非 Claude 的 settings），因此 Grok 会话会正确归到 Grok。在 Grok 下 reporter 会忽略 Claude 兼容 hooks 的双触发（存在 GROK_SESSION_ID 时）。"
-          }
-        }
-      }
-    },
-    "Listen on": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "监听网卡"
-          }
-        }
-      }
-    },
-    "Localhost only": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "仅本机"
-          }
-        }
-      }
-    },
-    "Only this Mac (127.0.0.1) can connect.": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "仅本机（127.0.0.1）可连接。"
-          }
-        }
-      }
-    },
-    "Reachable from any network this Mac joins (least secure).": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "本机加入的任何网络均可访问（最不安全）。"
-          }
-        }
-      }
-    },
-    "Without TLS, encryption only blocks passive sniffing. An active attacker on this network can replace the web client and capture the access key or terminal input.": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未使用 TLS 时，加密仅能防止被动嗅探。同一网络中的主动攻击者可以替换网页客户端，窃取访问密钥或终端输入。"
-          }
-        }
-      }
-    },
-    "All interfaces (less secure)": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "全部网卡（较不安全）"
-          }
-        }
-      }
-    },
-    "Refresh interfaces": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "刷新网卡列表"
-          }
-        }
-      }
-    },
-    "Selected interface is no longer available. Pick another or use All interfaces.": {
-      "extractionState": "manual",
-      "localizations": {
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "所选网卡已不可用。请另选一个或使用“全部网卡”。"
           }
         }
       }

--- a/GlintTests/GrokUsageReaderTests.swift
+++ b/GlintTests/GrokUsageReaderTests.swift
@@ -47,14 +47,46 @@ final class GrokUsageReaderTests: XCTestCase {
     }
 
     /// Team / unified-billing accounts report cap 0 — the surface doesn't
-    /// expose usage numbers, so the read must yield nil rather than a
-    /// misleading 0% bar (same call CodexBar made for its Grok provider).
-    func testTeamAccountWithZeroCapYieldsNoQuota() throws {
+    /// expose usage numbers. The read still yields a quota so the row
+    /// renders: period + reset countdown real, percent flagged unknown
+    /// (rendered "—", never a fabricated 0%).
+    func testTeamAccountWithZeroCapRendersUnknownPercent() throws {
         let data = Data(#"""
         {"config":{"currentPeriod":{"type":"USAGE_PERIOD_TYPE_WEEKLY","start":"2026-09-02T07:39:39.262344+00:00","end":"2026-09-09T07:39:39.262344+00:00"},"onDemandCap":{"val":0},"onDemandUsed":{"val":0},"isUnifiedBillingUser":true,"prepaidBalance":{"val":0},"topUpMethod":"TOP_UP_METHOD_SAVED_PAYMENT_METHOD","billingPeriodStart":"2026-09-02T07:39:39.262344+00:00","billingPeriodEnd":"2026-09-09T07:39:39.262344+00:00"}}
         """#.utf8)
 
-        XCTAssertNil(GrokUsageReader.decode(data))
+        let quota = try XCTUnwrap(GrokUsageReader.decode(data))
+        XCTAssertEqual(quota.percentUnknown, true)
+        XCTAssertEqual(quota.sessionPercent, 0)
+        XCTAssertEqual(quota.primaryWindowLabel, "7d")
+        XCTAssertEqual(quota.sessionResetsAt,
+                       GrokUsageReaderTests.date("2026-09-09T07:39:39.262344+00:00"))
+        // Round-trips through the snapshot persistence path.
+        let persisted = try JSONEncoder().encode(quota)
+        let restored = try JSONDecoder().decode(AgentQuota.self, from: persisted)
+        XCTAssertEqual(restored.percentUnknown, true)
+    }
+
+    /// Old snapshots persisted before `percentUnknown` existed decode as
+    /// known — the field is absent from their JSON.
+    func testLegacySnapshotWithoutPercentUnknownDecodesAsKnown() throws {
+        let legacy = Data(#"""
+        {"sessionPercent":42,"weeklyPercent":null,"sessionResetsAt":null,"weeklyResetsAt":null,"planType":null,"primaryWindowMinutes":10080,"secondaryWindowMinutes":null,"scopedWeekly":null}
+        """#.utf8)
+        let restored = try JSONDecoder().decode(AgentQuota.self, from: legacy)
+        XCTAssertNotEqual(restored.percentUnknown, true)
+    }
+
+    /// A source-reported `creditUsagePercent` wins over cap math even when
+    /// the cap reads 0 (prepaid surface).
+    func testReportedCreditUsagePercentWins() throws {
+        let data = Data(#"""
+        {"config":{"currentPeriod":{"start":"2026-09-02T07:39:39+00:00","end":"2026-09-09T07:39:39+00:00"},"onDemandCap":{"val":0},"onDemandUsed":{"val":0},"creditUsagePercent":37.5,"isUnifiedBillingUser":false}}
+        """#.utf8)
+
+        let quota = try XCTUnwrap(GrokUsageReader.decode(data))
+        XCTAssertNil(quota.percentUnknown)
+        XCTAssertEqual(quota.sessionPercent, 37.5, accuracy: 0.001)
     }
 
     /// Over-cap readings clamp to 100 rather than blowing out the bar.
@@ -76,6 +108,7 @@ final class GrokUsageReaderTests: XCTestCase {
 
         let quota = try XCTUnwrap(GrokUsageReader.decode(data))
         XCTAssertNil(quota.sessionResetsAt)
+        XCTAssertNil(quota.percentUnknown)
         XCTAssertEqual(quota.primaryWindowLabel, "7d")
     }
 

--- a/GlintTests/GrokUsageReaderTests.swift
+++ b/GlintTests/GrokUsageReaderTests.swift
@@ -1,0 +1,132 @@
+import XCTest
+@testable import Glint
+
+final class GrokUsageReaderTests: XCTestCase {
+    private var home: URL!
+
+    override func setUpWithError() throws {
+        home = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("glint-grok-usage-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: home)
+    }
+
+    // MARK: - decode
+
+    /// The shape the billing endpoint returns for a personal / credits
+    /// account (on-demand cap > 0): percent, window label, and reset date
+    /// all land in the quota's primary slot.
+    func testDecodesCreditsAccountIntoPrimaryWindow() throws {
+        let data = Data(#"""
+        {"config":{"currentPeriod":{"type":"USAGE_PERIOD_TYPE_WEEKLY","start":"2026-09-02T07:39:39.262344+00:00","end":"2026-09-09T07:39:39.262344+00:00"},"onDemandCap":{"val":20},"onDemandUsed":{"val":5},"isUnifiedBillingUser":false,"prepaidBalance":{"val":0},"topUpMethod":"TOP_UP_METHOD_SAVED_PAYMENT_METHOD","billingPeriodStart":"2026-09-02T07:39:39.262344+00:00","billingPeriodEnd":"2026-09-09T07:39:39.262344+00:00"}}
+        """#.utf8)
+
+        let quota = try XCTUnwrap(GrokUsageReader.decode(data))
+
+        XCTAssertEqual(quota.sessionPercent, 25, accuracy: 0.001)
+        XCTAssertNil(quota.weeklyPercent)          // one window, not drawn twice
+        XCTAssertEqual(quota.primaryWindowMinutes, 10_080)
+        XCTAssertEqual(quota.primaryWindowLabel, "7d")
+        XCTAssertEqual(quota.sessionResetsAt,
+                       GrokUsageReaderTests.date("2026-09-09T07:39:39.262344+00:00"))
+        XCTAssertNil(quota.weeklyResetsAt)
+    }
+
+    /// Amounts are proto-JSON `{"val": …}`; a string-typed val (observed in
+    /// some payloads) must not crash the decode — it reads as nil.
+    func testStringValuedAmountsDecodeWithoutCrashing() throws {
+        let data = Data(#"""
+        {"config":{"currentPeriod":{"start":"2026-09-02T07:39:39+00:00","end":"2026-09-09T07:39:39+00:00"},"onDemandCap":{"val":"20"},"onDemandUsed":{"val":"5"},"isUnifiedBillingUser":false}}
+        """#.utf8)
+
+        // cap decodes as nil → treated as 0 → no numbers on this surface.
+        XCTAssertNil(GrokUsageReader.decode(data))
+    }
+
+    /// Team / unified-billing accounts report cap 0 — the surface doesn't
+    /// expose usage numbers, so the read must yield nil rather than a
+    /// misleading 0% bar (same call CodexBar made for its Grok provider).
+    func testTeamAccountWithZeroCapYieldsNoQuota() throws {
+        let data = Data(#"""
+        {"config":{"currentPeriod":{"type":"USAGE_PERIOD_TYPE_WEEKLY","start":"2026-09-02T07:39:39.262344+00:00","end":"2026-09-09T07:39:39.262344+00:00"},"onDemandCap":{"val":0},"onDemandUsed":{"val":0},"isUnifiedBillingUser":true,"prepaidBalance":{"val":0},"topUpMethod":"TOP_UP_METHOD_SAVED_PAYMENT_METHOD","billingPeriodStart":"2026-09-02T07:39:39.262344+00:00","billingPeriodEnd":"2026-09-09T07:39:39.262344+00:00"}}
+        """#.utf8)
+
+        XCTAssertNil(GrokUsageReader.decode(data))
+    }
+
+    /// Over-cap readings clamp to 100 rather than blowing out the bar.
+    func testUsedBeyondCapClampsTo100() throws {
+        let data = Data(#"""
+        {"config":{"currentPeriod":{"start":"2026-09-02T07:39:39+00:00","end":"2026-09-09T07:39:39+00:00"},"onDemandCap":{"val":10},"onDemandUsed":{"val":30},"isUnifiedBillingUser":false}}
+        """#.utf8)
+
+        let quota = try XCTUnwrap(GrokUsageReader.decode(data))
+        XCTAssertEqual(quota.sessionPercent, 100, accuracy: 0.001)
+    }
+
+    /// A missing period still produces a quota with the observed weekly
+    /// window as the label (never the AgentQuota default "5h").
+    func testMissingPeriodFallsBackToWeeklyLabel() throws {
+        let data = Data(#"""
+        {"config":{"onDemandCap":{"val":100},"onDemandUsed":{"val":10},"isUnifiedBillingUser":false}}
+        """#.utf8)
+
+        let quota = try XCTUnwrap(GrokUsageReader.decode(data))
+        XCTAssertNil(quota.sessionResetsAt)
+        XCTAssertEqual(quota.primaryWindowLabel, "7d")
+    }
+
+    func testMalformedPayloadYieldsNoQuota() {
+        XCTAssertNil(GrokUsageReader.decode(Data("not json".utf8)))
+        XCTAssertNil(GrokUsageReader.decode(Data("{}".utf8)))
+        XCTAssertNil(GrokUsageReader.decode(Data(#"{"config":null}"#.utf8)))
+    }
+
+    // MARK: - token loading
+
+    /// `~/.grok/auth.json` maps issuer URLs to credential objects; the first
+    /// non-empty `key` (access token) wins across the map's entries.
+    func testLoadsFirstNonEmptyTokenFromAuthMap() throws {
+        let auth = home.appendingPathComponent("auth.json")
+        try Data(#"""
+        {"https://auth.x.ai::issuer":{"key":"","auth_mode":"oidc"},"https://auth.x.ai::other":{"key":"tok-123","auth_mode":"oidc"}}
+        """#.utf8).write(to: auth)
+
+        XCTAssertEqual(GrokUsageReader.loadToken(from: home), "tok-123")
+    }
+
+    /// An auth map whose entries carry no usable token behaves like no login.
+    func testEmptyTokensYieldNoToken() throws {
+        let auth = home.appendingPathComponent("auth.json")
+        try Data(#"""
+        {"https://auth.x.ai::issuer":{"key":"","auth_mode":"api_key"}}
+        """#.utf8).write(to: auth)
+
+        XCTAssertNil(GrokUsageReader.loadToken(from: home))
+    }
+
+    /// A malformed auth.json (not issuer-keyed JSON) yields nil, no crash.
+    func testMalformedAuthYieldsNoToken() throws {
+        let auth = home.appendingPathComponent("auth.json")
+        try Data("[1,2,3]".utf8).write(to: auth)
+
+        XCTAssertNil(GrokUsageReader.loadToken(from: home))
+    }
+
+    /// No auth.json (grok not installed / never logged in) → nil, no crash.
+    func testMissingAuthYieldsNoQuota() async {
+        let quota = await GrokUsageReader.read(grokHome: home)
+        XCTAssertNil(quota)
+    }
+
+    // MARK: - helpers
+
+    private static func date(_ iso: String) -> Date {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f.date(from: iso)!
+    }
+}


### PR DESCRIPTION
Completes the sidebar usage panel (Claude + Codex homes + now Grok).

## What / 做了什么

- **`GrokUsageReader`**: reads the same billing endpoint the Grok CLI itself polls (`cli-chat-proxy.grok.com/v1/billing?format=credits`), authorizing with the access token `grok login` keeps in `~/.grok/auth.json` — a plain file, so the poll can never trigger a macOS keychain prompt. Fails closed like the other readers.
- The single weekly window lands in the quota's primary slot with the period end as the reset countdown; a source-reported `creditUsagePercent`, when present, wins over cap math.
- **Team / unified-billing accounts** report `onDemandCap: 0` on that surface (same conclusion CodexBar's Grok provider shipped) — those rows still render via a new optional `AgentQuota.percentUnknown`: the window's reset countdown is real, the percent degrades to "—" instead of a fabricated 0%. Old persisted snapshots decode as known. Personal/credits accounts get real numbers; if xAI ever exposes team usage here it starts working unchanged.
- Settings ▸ Agents ▸ Grok gains the usual "Show usage in sidebar" toggle (zh-Hans included); snapshot persistence follows the existing per-agent UserDefaults scheme.

## Verification / 验证

- Full suite green (350 tests, incl. new `GrokUsageReaderTests` — credits account decode, team zero-cap unknown-percent, legacy snapshot decode, clamping, malformed payloads, token loading).
- Live-verified against the real endpoint with a real login: HTTP 200, team account decodes to the unknown-percent row exactly as designed.