### PR TITLE
fix: close web remote snapshot and touch gesture gaps

### DIFF
--- a/Glint/Pane/GhosttySurfaceView.swift
+++ b/Glint/Pane/GhosttySurfaceView.swift
@@ -219,6 +219,7 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
     required init?(coder: NSCoder) { fatalError("not used") }
 
     deinit {
+        cancelPendingWebRemoteSnapshots()
         if let s = surface {
             ghostty_surface_set_pty_tee_v2_cb(s, nil, nil)
             ghostty_surface_free(s)
@@ -499,7 +500,14 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
     /// the prior session ended inside a full-screen TUI.
     private func restoreScrollback(into s: ghostty_surface_t, data: Data) {
         var text = String(decoding: data, as: UTF8.self)
-        guard !text.isEmpty else { return }
+        guard !text.isEmpty else {
+            // A waiter is allowed to outlive the restore attempt. Always
+            // complete it, even when an empty/corrupt archive gives us
+            // nothing to echo; otherwise the browser's first snapshot hangs
+            // forever waiting for a surface that can no longer change.
+            finishPendingWebRemoteSnapshots()
+            return
+        }
         // Remember the prior history verbatim so flushes re-attach it as a
         // stable prefix rather than re-deriving it (at a possibly different
         // width) from the grid every cycle. Trailing newlines stripped so the
@@ -539,6 +547,17 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
             let snapshot = self?.webRemoteSnapshot()
             waiters.forEach { $0(snapshot) }
         }
+    }
+
+    /// Complete browser snapshot requests that can no longer be fulfilled.
+    /// Surface teardown clears the pending restore data before the normal
+    /// restore callback can run, so leaving these closures queued would leave
+    /// the Web Remote request permanently pending.
+    private func cancelPendingWebRemoteSnapshots() {
+        guard !pendingWebRemoteSnapshotWaiters.isEmpty else { return }
+        let waiters = pendingWebRemoteSnapshotWaiters
+        pendingWebRemoteSnapshotWaiters.removeAll()
+        waiters.forEach { $0(nil) }
     }
 
     /// Snapshot the pane's current scrollback to disk as colored text (ANSI SGR).
@@ -1061,6 +1080,7 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
         }
 
         ghostty_surface_set_pty_tee_v2_cb(s, nil, nil)
+        cancelPendingWebRemoteSnapshots()
         surface = nil
         ghostty_surface_free(s)
         pendingVisibleRedraw = false

--- a/Glint/Resources/WebRemote/ime-input.mjs
+++ b/Glint/Resources/WebRemote/ime-input.mjs
@@ -19,13 +19,23 @@ export function installTwoFingerTerminalScrolling(
   WheelEventLike = WheelEvent
 ) {
   let touchScrollY = null;
+  let touchStartY = null;
+  let touchStartDistance = null;
+  let touchGesture = null;
   let touchScrollRemainder = 0;
 
   const reset = () => {
     touchScrollY = null;
+    touchStartY = null;
+    touchStartDistance = null;
+    touchGesture = null;
     touchScrollRemainder = 0;
   };
   const touchCenterY = touches => (touches[0].clientY + touches[1].clientY) / 2;
+  const touchDistance = touches => Math.hypot(
+    touches[0].clientX - touches[1].clientX,
+    touches[0].clientY - touches[1].clientY
+  );
   const terminalLineHeight = () => {
     const row = target.querySelector(".xterm-rows > div");
     const measured = row?.getBoundingClientRect().height;
@@ -64,8 +74,10 @@ export function installTwoFingerTerminalScrolling(
       reset();
       return;
     }
-    event.preventDefault();
     touchScrollY = touchCenterY(event.touches);
+    touchStartY = touchScrollY;
+    touchStartDistance = touchDistance(event.touches);
+    touchGesture = "undecided";
     touchScrollRemainder = 0;
   }, { passive: false });
 
@@ -74,8 +86,23 @@ export function installTwoFingerTerminalScrolling(
       reset();
       return;
     }
-    event.preventDefault();
     const nextY = touchCenterY(event.touches);
+    const verticalMovement = Math.abs(nextY - touchStartY);
+    const scaleMovement = Math.abs(touchDistance(event.touches) - touchStartDistance);
+    if (touchGesture === "undecided") {
+      // Leave pinch/zoom to the browser. Only claim the gesture once the
+      // fingers have clearly moved vertically together.
+      if (scaleMovement > 8 && scaleMovement > verticalMovement) {
+        touchGesture = "pinch";
+        reset();
+        return;
+      }
+      if (verticalMovement > 4 && verticalMovement > scaleMovement) {
+        touchGesture = "scroll";
+      }
+    }
+    if (touchGesture === "pinch") return;
+    if (touchGesture === "scroll") event.preventDefault();
     touchScrollRemainder += touchScrollY - nextY;
     touchScrollY = nextY;
 

--- a/Glint/Resources/WebRemote/web-remote.css
+++ b/Glint/Resources/WebRemote/web-remote.css
@@ -299,7 +299,9 @@ input:focus {
   min-height: 0;
   padding: 12px 10px 4px;
   display: none;
-  touch-action: none;
+  /* Keep pinch zoom available until the two-finger handler identifies a
+     vertical terminal scroll. The handler then cancels only that gesture. */
+  touch-action: manipulation;
 }
 #terminal.visible { display: block; }
 #terminal .xterm { height: 100%; }

--- a/GlintTests/WebRemoteProtocolTests.swift
+++ b/GlintTests/WebRemoteProtocolTests.swift
@@ -380,7 +380,7 @@ final class WebRemoteProtocolTests: XCTestCase {
         XCTAssertTrue(input.contains("new WheelEventLike(\"wheel\""))
         XCTAssertTrue(input.contains(".xterm-screen"))
         XCTAssertTrue(input.contains("passive: false"))
-        XCTAssertTrue(style.contains("touch-action: none"))
+        XCTAssertTrue(style.contains("touch-action: manipulation"))
     }
 
     func testBundledClientCanDisableTerminalAutoFocus() throws {

--- a/scripts/test-web-remote-ime.mjs
+++ b/scripts/test-web-remote-ime.mjs
@@ -15,6 +15,7 @@ function makeTouchScrollHarness(baseY, mouseTrackingMode = "none") {
   const listeners = new Map();
   const wheelEvents = [];
   const scrollCalls = [];
+  let preventDefaultCalls = 0;
   const row = { getBoundingClientRect: () => ({ height: 10 }) };
   const screen = { dispatchEvent: event => wheelEvents.push(event) };
   const target = {
@@ -44,10 +45,24 @@ function makeTouchScrollHarness(baseY, mouseTrackingMode = "none") {
       { clientX: 100, clientY: centerY },
       { clientX: 140, clientY: centerY },
     ],
-    preventDefault() {},
+    preventDefault() { preventDefaultCalls += 1; },
   });
-  return { dispatchTouch, scrollCalls, wheelEvents };
+  return {
+    dispatchTouch,
+    scrollCalls,
+    wheelEvents,
+    get preventDefaultCalls() { return preventDefaultCalls; },
+  };
 }
+
+test("only claims the default gesture after vertical scroll is identified", () => {
+  const harness = makeTouchScrollHarness(40);
+  harness.dispatchTouch("touchstart", 100);
+  harness.dispatchTouch("touchmove", 102);
+  assert.equal(harness.preventDefaultCalls, 0);
+  harness.dispatchTouch("touchmove", 110);
+  assert.equal(harness.preventDefaultCalls, 1);
+});
 
 test("keeps scrolling terminal history across consecutive two-finger moves", () => {
   const harness = makeTouchScrollHarness(40);


### PR DESCRIPTION
Complete pending Web Remote snapshot callbacks when restore or surface teardown cannot continue. Only claim two-finger gestures after detecting vertical scrolling, preserving pinch zoom, and update coverage.